### PR TITLE
Fix/companion cluster de compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ output/
 *.karospace
 *.genes.json
 *.genes/
+*.features.json
+*.features/
 *.bin
 *.loader.html
 *sidecar.html
@@ -58,6 +60,7 @@ tmp_hydrated_script_*.js
 # Overlay images extracted from h5ad by the example scripts — regenerable and
 # patient-derived, so they should never be committed.
 xenium_dapi_he*_images/
+*_images/
 # Keep unpublished local exports out of git
 BALO.html
 

--- a/examples/bench/PR10_review_draft.md
+++ b/examples/bench/PR10_review_draft.md
@@ -1,0 +1,97 @@
+# DRAFT review for PR #10 "KaroSpace for review" (Baboon61:main → main)
+
+## === SUMMARY COMMENT (top-level review body) ===
+
+Thanks for this — it's a big, genuinely valuable contribution. The pseudobulk DE,
+pathway enrichment, tutorial overlay, gene modules, and region groups are all
+features we want, and I've confirmed the image/H&E overlay layer is preserved.
+
+Before we can merge, a few things need attention. The main point up front: even
+though GitHub shows this as "mergeable / clean", that's only because it
+fast-forwards — it's effectively a fork-scale rewrite (+33k/−21k, 121 files,
+renamed public API, changed sidecar format, and the whole test suite removed).
+So rather than fast-forward `main`, I'd like to land this via an integration
+branch once the blockers below are resolved.
+
+**Blockers (should fix before merge):**
+1. **Test suite deleted with no replacement.** Commit `3651a53` removes
+   `tests/test_analytics.py`, `tests/test_gene_sidecar_export.py`, and
+   `tests/test_pseudobulk_interactions.py` (~3200 lines), leaving zero tests.
+   Much of that covered code that still exists. Please restore the still-valid
+   coverage (details inline) — at minimum the `test_analytics.py` helpers.
+2. **pseudobulk log2FC / p-value come from different models** (see inline on
+   `pseudobulk.py`). Reported fold-change is a mean-ratio while the p-value is
+   DESeq2's — a gene can be "significant" with a mismatched log2FC.
+3. **Pathway enrichment makes a network call at export time** (gseapy → Enrichr).
+   Offline/CI runs will fail unless `--pathway-gmt` is supplied. Needs a cached/
+   bundled fallback or clear documentation + graceful skip.
+
+**Needs a decision (not necessarily blocking):**
+4. **Public API rename** (`export_to_html`: `color→main_cell_annotation`,
+   `genes→features`, `additional_colors→cell_annotations`, plus removed params)
+   and the **sidecar binary format rename** (`gene→feature`). This breaks every
+   existing example script and any external caller, and packages may not be
+   cross-compatible between viewer versions. Let's treat it as an explicit
+   breaking release (changelog + a thin back-compat shim), not a silent change.
+5. **Removed features** — cluster-DE panel, dispersion insights, modal-blend
+   co-expression, html2canvas screenshots. Some look intentionally superseded
+   (modal-blend → OverviewSplit; html2canvas → native screenshots, fine). Please
+   confirm cluster-DE and dispersion are deliberately dropped.
+
+**Nits:**
+6. `compute_pseudobulk_complex_design_de` is dead code ("no supported caller").
+7. `pydeseq2` has no upper pin but relies on private internals (see inline).
+
+Happy to pair on the integration-branch plan and on porting the tests.
+
+---
+
+## === INLINE COMMENTS (file : line → text) ===
+
+### karospace/pseudobulk.py : 523  (inside _log2fc_from_pseudobulk_means / used by _fit_deseq2_pair ~599)
+> This computes log2FC as a raw mean-ratio and (in the pair path) overrides
+> DESeq2's model-based `log2FoldChange`, while the p-value/stat still come from
+> DESeq2. Reported effect size and significance then reflect *different* models,
+> which can produce genes flagged significant with a fold-change that disagrees
+> with the tested contrast (confusing volcano plots). Either use DESeq2's
+> (optionally shrunk) LFC consistently, or clearly label this as a display-only
+> "mean-based FC" and apply it uniformly across the shared-fit path too (which
+> currently doesn't re-inject it — so the two paths disagree).
+
+### karospace/pseudobulk.py : 151  (_subset_deseq2_dataset)
+> This reassigns `subset.__class__` and hand-restores ~15 private DeseqDataSet
+> attributes. That's reverse-engineered PyDESeq2 internals and will likely break
+> on a PyDESeq2 upgrade. Since `pydeseq2>=0.5.0` allows arbitrary newer versions,
+> please add an upper bound (e.g. `>=0.5.0,<0.6`) or use a supported public API.
+
+### karospace/pseudobulk.py : 857  (compute_pseudobulk_complex_design_de)
+> Flagged "no supported caller" at line 780 and unused. ~220 lines of dead code —
+> remove it, or gate behind an explicit experimental flag rather than shipping it.
+
+### karospace/pathways.py : 89  (_load_reactome_from_gseapy → gp.get_library)
+> `gp.get_library(...)` hits Enrichr over the network at export time. This makes
+> exports fail offline / in CI / air-gapped unless `--pathway-gmt` is passed.
+> Please cache or bundle a default Reactome GMT, and make the failure a graceful
+> skip (export still succeeds, pathways omitted with a warning).
+
+### karospace/exporter.py : 34475  (export_to_html signature — main_cell_annotation param)
+> Renamed/removed params here break existing callers and all example scripts
+> (`color→main_cell_annotation`, `genes→features`, `additional_colors→cell_annotations`,
+> plus removed `theme`, `vmin/vmax`, `gene_encoding`, `gene_sidecar_format`,
+> `marker_genes_*`, `cluster_de_*`). The sidecar/`.karospace` packaging itself is
+> retained (good) but the naming/manifest format migrated gene→feature
+> (`--gene-storage`→`--feature-storage`, `to_gene_sidecar_data`→`to_feature_sidecar_data`,
+> `_validate_feature_sidecar_manifest_payload`), so packages written by the current
+> `main` viewer may not validate/load in this one. Let's make this a deliberate
+> breaking release: add a back-compat shim mapping the old kwargs (with a
+> DeprecationWarning) + a manifest-version check, and note it in the changelog.
+
+### tests/  (deleted in commit 3651a53)
+> This commit removes the entire test suite (test_analytics.py,
+> test_gene_sidecar_export.py, test_pseudobulk_interactions.py) with no
+> replacement. Most of `test_analytics.py` covers helpers that still exist
+> unchanged (`_numeric_category_perm`, `_resolve_spatial_key`,
+> `_select_top_variable_genes`, `_compute_morans_i`) — please restore those
+> directly. For `test_gene_sidecar_export.py`, the `cluster_de` assertions are
+> obsolete but the binary sidecar / quantization / `.karospace` package contracts
+> are still live — please port those against the renamed `to_feature_sidecar_data`.

--- a/examples/bench/bench_delaunay.py
+++ b/examples/bench/bench_delaunay.py
@@ -1,0 +1,95 @@
+"""End-to-end Delaunay graph benchmark: KaroSpaceCompanion (Rust) vs scipy.
+
+Both paths do the same end-to-end work: read an h5ad, build a Delaunay spatial
+graph with 99th-percentile long-link trimming, write a new h5ad. Each is run as
+a fresh subprocess so the wall clock reflects the real "time to enriched file"
+(the Python side pays interpreter + import startup, which is part of that cost).
+
+After timing, both output graphs are compared by nnz for parity — if the edge
+counts diverge a lot, the two aren't doing the same work and the times aren't
+comparable.
+"""
+
+import os
+import subprocess
+import sys
+import time
+from statistics import median
+
+import anndata as ad
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+WORKER = os.path.join(HERE, "py_delaunay_worker.py")
+RUST_BIN = os.path.expanduser(
+    "~/work/karolinska_institutet/projects/KaroSpaceCompanion/target/release/karospace-companion"
+)
+PERCENTILE = 99.0
+REPEATS = 3
+TMPDIR = os.path.join(HERE, "_bench_tmp")
+
+DATASETS = [
+    ("VisiumHD_96k", os.path.expanduser("~/Downloads/Human_VisiumHD_compressed_v1.h5ad")),
+    ("MERFISH_401k", os.path.expanduser("~/Downloads/GSE284005_merfish_all.h5ad")),
+    (
+        "XeniumPup_1.36M",
+        os.path.expanduser(
+            "~/work/karolinska_institutet/projects/xenium_mouse_embryo/derived_scanpy/xenium_mouse_pup_gene_only.h5ad"
+        ),
+    ),
+]
+
+
+def time_cmd(cmd, repeats):
+    """Run cmd `repeats` times (after one warmup), return list of wall times."""
+    subprocess.run(cmd, check=True, capture_output=True)  # warmup
+    times = []
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        subprocess.run(cmd, check=True, capture_output=True)
+        times.append(time.perf_counter() - t0)
+    return times
+
+
+def graph_nnz(path):
+    a = ad.read_h5ad(path, backed="r")
+    conn = a.obsp["spatial_connectivities"]
+    return int(conn.nnz)
+
+
+def main():
+    os.makedirs(TMPDIR, exist_ok=True)
+    print(f"{'dataset':>16} | {'rust (s)':>9} | {'python (s)':>10} | "
+          f"{'speedup':>7} | {'rust edges':>11} | {'py edges':>10} | {'Δ%':>6}")
+    print("-" * 92)
+
+    for name, path in DATASETS:
+        if not os.path.exists(path):
+            print(f"{name:>16} | MISSING: {path}")
+            continue
+
+        rust_out = os.path.join(TMPDIR, f"{name}.rust.h5ad")
+        py_out = os.path.join(TMPDIR, f"{name}.py.h5ad")
+
+        rust_cmd = [
+            RUST_BIN, "prepare", path, "--output", rust_out,
+            "--delaunay", "--remove-long-links-percentile", str(PERCENTILE),
+            "--skip-normalized-layer", "--skip-aggregation",
+        ]
+        py_cmd = [sys.executable, WORKER, path, py_out, str(PERCENTILE)]
+
+        rust_t = time_cmd(rust_cmd, REPEATS)
+        py_t = time_cmd(py_cmd, REPEATS)
+
+        rn, pn = graph_nnz(rust_out), graph_nnz(py_out)
+        delta = 100.0 * (pn - rn) / rn if rn else float("nan")
+        rmed, pmed = median(rust_t), median(py_t)
+        speedup = pmed / rmed if rmed else float("nan")
+
+        print(f"{name:>16} | {rmed:9.2f} | {pmed:10.2f} | {speedup:6.2f}x | "
+              f"{rn:>11,} | {pn:>10,} | {delta:+5.1f}%")
+
+    print("\nnnz = 2 x undirected edges (symmetric). Δ% is python vs rust edge count.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/bench/py_delaunay_worker.py
+++ b/examples/bench/py_delaunay_worker.py
@@ -1,0 +1,67 @@
+"""Python scipy Delaunay baseline — mirrors KaroSpaceCompanion's graph.rs.
+
+Reads an h5ad, builds a Delaunay spatial graph with 99th-percentile long-link
+trimming, writes obsp["spatial_connectivities"] (1.0 weights) and
+obsp["spatial_distances"] (edge lengths), and saves a new h5ad.
+
+End-to-end: read + build + write, matching what the Rust CLI does.
+
+Usage: python py_delaunay_worker.py INPUT.h5ad OUTPUT.h5ad [PERCENTILE]
+"""
+
+import sys
+import numpy as np
+import scipy.sparse as sp
+from scipy.spatial import Delaunay
+import anndata as ad
+
+
+def build_delaunay_graph(coords: np.ndarray, percentile: float):
+    """Return (connectivities, distances) CSR matrices mirroring graph.rs."""
+    n = coords.shape[0]
+    tri = Delaunay(coords)
+    simp = tri.simplices  # (M, 3)
+
+    # Every triangle contributes its 3 undirected edges; sort endpoints so i<j.
+    e = np.vstack([simp[:, [0, 1]], simp[:, [1, 2]], simp[:, [0, 2]]])
+    e = np.sort(e, axis=1)
+    e = np.unique(e, axis=0)
+
+    d = np.linalg.norm(coords[e[:, 0]] - coords[e[:, 1]], axis=1)
+
+    # Trim long links: threshold = <percentile> of positive edge lengths.
+    # numpy's default linear interpolation matches graph.rs::percentile_value.
+    pos = d[d > 0.0]
+    if pos.size:
+        thr = np.percentile(pos, percentile)
+        keep = d <= thr
+        e, d = e[keep], d[keep]
+
+    # Symmetric CSR (both directions), like csr_from_neighbors.
+    rows = np.concatenate([e[:, 0], e[:, 1]])
+    cols = np.concatenate([e[:, 1], e[:, 0]])
+    conn = sp.csr_matrix(
+        (np.ones(rows.shape[0], dtype=np.float32), (rows, cols)), shape=(n, n)
+    )
+    dist = sp.csr_matrix(
+        (np.concatenate([d, d]).astype(np.float32), (rows, cols)), shape=(n, n)
+    )
+    return conn, dist
+
+
+def main():
+    inp, out = sys.argv[1], sys.argv[2]
+    percentile = float(sys.argv[3]) if len(sys.argv) > 3 else 99.0
+
+    adata = ad.read_h5ad(inp)
+    coords = np.asarray(adata.obsm["spatial"])[:, :2].astype(np.float64)
+
+    conn, dist = build_delaunay_graph(coords, percentile)
+    adata.obsp["spatial_connectivities"] = conn
+    adata.obsp["spatial_distances"] = dist
+
+    adata.write_h5ad(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gse284005_multisample_test.py
+++ b/examples/gse284005_multisample_test.py
@@ -1,0 +1,112 @@
+"""
+Example usage of KaroSpace with binary sidecar and .karospace export targets.
+
+This script is configured for the GSE284005 MERFISH All companion-ready h5ad and writes:
+1. an unpacked binary sidecar viewer bundle
+2. a packaged .karospace bundle with matching settings
+"""
+
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+os.environ.setdefault("KMP_WARNINGS", "0")
+os.environ.setdefault("NUMBA_CACHE_DIR", "/tmp/numba-cache")
+os.environ.setdefault("MPLCONFIGDIR", "/tmp/karospace-mpl-cache")
+
+from karospace import export_to_html, load_spatial_data
+
+H5AD_PATH = os.environ.get(
+    "GSE284005_MERFISH_ALL_H5AD_PATH",
+    "/Users/chrislangseth/Downloads/GSE284005_merfish_all.companion.ready.h5ad",
+)
+
+PRIMARY_ANNOTATION = "majorCluster_final"
+ADDITIONAL_ANNOTATIONS = [
+    "Region_banksy_major",
+    "Region_banksy",
+]
+SIDECAR_OUTPUT = "gse284005_multisample-sidecar.html"
+PACKAGE_OUTPUT = "gse284005_multisample.karospace"
+FEATURE_MANIFEST_PATH = "gse284005_multisample.features.json"
+
+if not Path(H5AD_PATH).exists():
+    raise SystemExit(
+        "GSE284005 MERFISH All h5ad not found. Set GSE284005_MERFISH_ALL_H5AD_PATH before running "
+        "examples/gse284005-merfish-all-binary-sidecar-package.py."
+    )
+
+dataset = load_spatial_data(
+    H5AD_PATH,
+    section_key="sample",
+    spatial_key="spatial",
+    section_metadata=[
+        "sample",
+    ],
+)
+
+print(f"Loaded {dataset.n_sections} sections with {dataset.n_cells:,} total cells")
+print(f"Available annotation columns: {dataset.obs_columns[:10]}...")
+
+common_kwargs = dict(
+    main_cell_annotation=PRIMARY_ANNOTATION,
+    title="GSE284005 MERFISH All",
+    min_panel_size=120,
+    spot_size="auto",
+    downsample=10_000_000,
+    outline_by=None,
+    cell_annotations=ADDITIONAL_ANNOTATIONS,
+    features=[],
+    use_hvgs=False,
+    hvg_limit=50,
+    feature_storage="sidecar",
+    feature_encoding="auto",
+    feature_value_encoding="uint16",
+    feature_manifest_path=FEATURE_MANIFEST_PATH,
+    feature_sidecar_shard_size=16,
+    neighbor_stats_annotations=[
+        "majorCluster_final",
+        "Region_banksy_major",
+        "Region_banksy",
+    ],
+    neighbor_stats_permutations=0,
+    neighbor_stats_seed=42,
+    # New-API pseudobulk DE, explicitly pointed at the 17-sample replicate column
+    # so DESeq2 actually runs. pseudobulk defaults to 'auto' (enabled); it takes
+    # 'auto'/None, not a bool.
+    pseudobulk="auto",
+    pseudobulk_replicate_annotation="sample",
+    pseudobulk_additional_annotations=[
+        "majorCluster_final",
+        "Region_banksy_major",
+    ],
+    interaction_markers=None,
+)
+
+export_to_html(
+    dataset,
+    output_path=SIDECAR_OUTPUT,
+    **common_kwargs,
+)
+
+export_to_html(
+    dataset,
+    output_path=PACKAGE_OUTPUT,
+    **common_kwargs,
+)
+
+print(f"\nDone! Wrote unpacked binary sidecar viewer: {SIDECAR_OUTPUT}")
+print(f"  - feature manifest: {FEATURE_MANIFEST_PATH}")
+print(f"  - shard directory: {Path(FEATURE_MANIFEST_PATH).with_suffix('')}")
+print(f"Wrote packaged binary viewer: {PACKAGE_OUTPUT}")
+print(f"  - local opener: {Path(PACKAGE_OUTPUT).with_suffix('.loader.html')}")
+print("Share either route:")
+print(f"  - local web server flow: {SIDECAR_OUTPUT} + {FEATURE_MANIFEST_PATH} + shard directory")
+print(
+    "  - no-install local package flow: "
+    f"{PACKAGE_OUTPUT} + {Path(PACKAGE_OUTPUT).with_suffix('.loader.html')}"
+)

--- a/examples/mouse_kidney.py
+++ b/examples/mouse_kidney.py
@@ -1,0 +1,244 @@
+"""
+KaroSpace viewer for the mouse_kidney Illumina NovaSeq X spatial dataset
+(companion-ready) — a single section, 276,925 cells × 56,748 genes.
+
+Carries an RGB H&E `he_hires` image (uns/spatial/mouse_kidney) attached as an
+overlay (open the sample → H&E Overlay controls or ✨ Auto-align). Gene
+expression is shown from the `lognorm` layer; analytics / DE are enabled for the
+two columns the companion precomputed stats for: `leiden` and
+`cellcharter_domains`. The remaining cellcharter_k* columns are exposed as plain
+categorical overlays (no precomputed analytics).
+
+Analytics (marker genes, cluster-vs-cluster DE, neighbor composition stats) are
+read straight from uns/karospace_companion — requesting the two analytics
+columns reuses those precomputed results instead of recomputing them.
+
+Usage:
+    python examples/mouse_kidney.py
+    MOUSE_KIDNEY_H5AD=/path/to/file.h5ad python examples/mouse_kidney.py
+"""
+
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+os.environ.setdefault("KMP_WARNINGS", "0")
+os.environ.setdefault("NUMBA_CACHE_DIR", "/tmp/numba-cache")
+os.environ.setdefault("MPLCONFIGDIR", "/tmp/karospace-mpl-cache")
+
+import h5py
+import numpy as np
+from PIL import Image
+
+from karospace import export_to_html, load_spatial_data
+
+H5AD_PATH = os.environ.get(
+    "MOUSE_KIDNEY_H5AD",
+    "/Users/chrislangseth/work/karolinska_institutet/projects/KaroSpaceDataWrangling/"
+    "data/processed/illumina-novaseqx-spatial/mouse_kidney.companion.ready.h5ad",
+)
+
+OUTPUT_DIR = REPO_ROOT
+IMAGE_DIR = OUTPUT_DIR / "mouse_kidney_images"
+SIDECAR_OUTPUT = str(OUTPUT_DIR / "mouse_kidney.html")
+PACKAGE_OUTPUT = str(OUTPUT_DIR / "mouse_kidney.karospace")
+# Sidecar accepts a full path; the .karospace packager needs a bare filename
+# (it lives inside the archive), so pass Path(...).name there.
+GENE_AUX_PATH = str(OUTPUT_DIR / "mouse_kidney.genes.json")
+
+GROUPBY = "sample_id"
+PRIMARY_COLOR = "leiden"
+
+# Only leiden + cellcharter_domains have precomputed companion analytics; these
+# get DE / marker / neighbor-stats panels.
+ANALYTICS_COLUMNS = ["leiden", "cellcharter_domains"]
+
+# Extra cellcharter resolutions: plain categorical overlays, NOT analytics.
+PLAIN_CATEGORICAL = [
+    "cellcharter_k8",
+    "cellcharter_k10",
+    "cellcharter_k12",
+    "cellcharter_k15",
+    "cellcharter_k18",
+    "cellcharter_k22",
+]
+
+# Continuous QC / morphology metrics available as colourings.
+CONTINUOUS_METRICS = [
+    "total_counts",
+    "n_genes",
+    "area_um2",
+    "nuc_area_um2",
+    "nuc_cyto_ratio",
+]
+
+ADDITIONAL_COLORS = ANALYTICS_COLUMNS + PLAIN_CATEGORICAL + CONTINUOUS_METRICS
+
+
+def _read_sample_ids(f: "h5py.File") -> np.ndarray:
+    """Return obs/sample_id as a string array, handling categorical encoding."""
+    node = f["obs/sample_id"]
+    if isinstance(node, h5py.Group):  # categorical: codes + categories
+        cats = np.asarray(node["categories"][()])
+        cats = np.array([c.decode() if isinstance(c, bytes) else str(c) for c in cats])
+        codes = np.asarray(node["codes"][()])
+        out = np.where(codes >= 0, cats[codes.clip(min=0)], "")
+        return out.astype(str)
+    arr = np.asarray(node[()])
+    return np.array([c.decode() if isinstance(c, bytes) else str(c) for c in arr])
+
+
+def extract_he_image(h5ad_path: str, out_dir: Path) -> dict:
+    """Pull each sample's RGB `he_hires` H&E image, cropped to its cells.
+
+    The embedded `he_hires` bitmap carries gray margins around the tissue, but
+    the viewer auto-fits the WHOLE image to the cell bounding box — so the tissue
+    ends up uniformly shrunk. We crop the image to the exact cell bounding box
+    (converted from microns to hires pixels via the squidpy scalefactors) so the
+    auto-fit lands 1:1. Conversion: hires_px = micron * he_hires_scalef /
+    pixel_size_um (obsm/spatial is in microns; he_hires = full-res * scalef).
+
+    Returns {sample_key: {"H&E": path}} for samples carrying an image.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    per_sample: dict[str, dict] = {}
+    with h5py.File(h5ad_path, "r") as f:
+        if "spatial" not in f.get("uns", {}):
+            return per_sample
+        spatial = f["uns/spatial"]
+        coords = np.asarray(f["obsm/spatial"][()])[:, :2]
+        sample_ids = _read_sample_ids(f)
+        for sample_key in spatial.keys():
+            node = spatial[sample_key]
+            images = node.get("images") if isinstance(node, h5py.Group) else None
+            if images is None or "he_hires" not in images:
+                continue
+            arr = np.asarray(images["he_hires"][()])
+            if arr.dtype != np.uint8:
+                a = arr.astype(np.float32)
+                lo, hi = np.percentile(a, (2.0, 99.5))
+                hi = hi if hi > lo else lo + 1.0
+                arr = (np.clip((a - lo) / (hi - lo), 0.0, 1.0) * 255.0 + 0.5).astype(np.uint8)
+            mode = "RGB" if arr.ndim == 3 else "L"
+            img = Image.fromarray(arr, mode=mode)
+
+            # Crop to this sample's cell bounding box, in hires-image pixels.
+            sf = node.get("scalefactors") if isinstance(node, h5py.Group) else None
+            mask = sample_ids == str(sample_key)
+            if sf is not None and "he_hires_scalef" in sf and "pixel_size_um" in sf and mask.any():
+                scalef = float(sf["he_hires_scalef"][()])
+                pixel_um = float(sf["pixel_size_um"][()])
+                m2px = scalef / pixel_um  # microns -> hires pixels
+                cc = coords[mask]
+                W, H = img.size
+                left = max(0, int(np.floor(cc[:, 0].min() * m2px)))
+                right = min(W, int(np.ceil(cc[:, 0].max() * m2px)))
+                upper = max(0, int(np.floor(cc[:, 1].min() * m2px)))
+                lower = min(H, int(np.ceil(cc[:, 1].max() * m2px)))
+                if right > left and lower > upper:
+                    img = img.crop((left, upper, right, lower))
+                    print(
+                        f"  Cropped '{sample_key}' H&E to cell bbox "
+                        f"({right - left}×{lower - upper}px from {W}×{H}px, "
+                        f"{1.0 / m2px:.3f} µm/px)"
+                    )
+                else:
+                    print(f"  Warning: degenerate crop box for '{sample_key}' — using full image")
+            else:
+                print(f"  Warning: no scalefactors for '{sample_key}' — using full (uncropped) image")
+
+            path = out_dir / f"{sample_key}_he_hires.png"
+            img.save(path)
+            per_sample[str(sample_key)] = {"H&E": str(path)}
+    return per_sample
+
+
+def main() -> None:
+    if not Path(H5AD_PATH).exists():
+        raise SystemExit(
+            f"H5AD not found: {H5AD_PATH}\nSet MOUSE_KIDNEY_H5AD or edit the path above."
+        )
+
+    print("Extracting H&E image(s)...")
+    images_by_sample = extract_he_image(H5AD_PATH, IMAGE_DIR)
+    print(f"  extracted {len(images_by_sample)} image(s)")
+
+    print("Loading spatial data (276k cells × 56.7k genes — this can take a while)...")
+    dataset = load_spatial_data(
+        H5AD_PATH,
+        groupby=GROUPBY,
+        spatial_key="spatial",
+        metadata_columns=[GROUPBY],
+    )
+    print(f"  {dataset.n_sections} section(s), {dataset.n_cells:,} cells")
+
+    # The viewer's gene-expression path reads a layer literally named
+    # "normalized"; this file stores normalized counts under "lognorm". Alias it
+    # so both gene display and cluster DE use the lognorm values.
+    if "normalized" not in dataset.adata.layers and "lognorm" in dataset.adata.layers:
+        dataset.adata.layers["normalized"] = dataset.adata.layers["lognorm"]
+        print("  Aliased layers['lognorm'] -> layers['normalized'] for gene display/DE")
+
+    # Attach the H&E overlay to its matching section.
+    section_images = {
+        s.section_id: images_by_sample[str(s.section_id)]
+        for s in dataset.sections
+        if str(s.section_id) in images_by_sample
+    } or None
+
+    common_kwargs = dict(
+        color=PRIMARY_COLOR,
+        title="Mouse Kidney — NovaSeq X Spatial",
+        min_panel_size=140,
+        spot_size="auto",
+        theme="light",
+        outline_by=None,
+        additional_colors=ADDITIONAL_COLORS,
+        genes=[],
+        use_hvgs=False,
+        gene_storage="sidecar",
+        gene_sidecar_format="binary-v1",
+        gene_encoding="auto",
+        gene_value_encoding="uint8",
+        gene_sidecar_shard_size=128,
+        # Analytics enabled ONLY for the two companion-precomputed columns;
+        # requesting them reuses uns/karospace_companion instead of recomputing.
+        marker_genes_groupby=ANALYTICS_COLUMNS,
+        marker_genes_top_n=30,
+        neighbor_stats_groupby=ANALYTICS_COLUMNS,
+        neighbor_stats_permutations=0,
+        cluster_de_groupby=ANALYTICS_COLUMNS,
+        cluster_de_top_n=20,
+        cluster_de_method="t-test",
+        cluster_de_layer="normalized",
+        interaction_markers_groupby=None,
+        section_images=section_images,
+        section_images_max_px=4096,
+    )
+
+    print("Exporting sidecar HTML...")
+    export_to_html(
+        dataset, output_path=SIDECAR_OUTPUT, gene_aux_path=GENE_AUX_PATH, **common_kwargs
+    )
+
+    print("Packaging .karospace archive...")
+    export_to_html(
+        dataset,
+        output_path=PACKAGE_OUTPUT,
+        gene_aux_path=Path(GENE_AUX_PATH).name,
+        **common_kwargs,
+    )
+
+    print(f"\nDone!\n  sidecar: {SIDECAR_OUTPUT}\n  package: {PACKAGE_OUTPUT}")
+    print(
+        "Coloured by leiden; DE/analytics enabled for leiden & cellcharter_domains. "
+        "cellcharter_k* are plain categorical overlays. Open the sample for the H&E overlay."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mouse_kidney_v2_test.py
+++ b/examples/mouse_kidney_v2_test.py
@@ -1,0 +1,244 @@
+"""
+KaroSpace viewer for the mouse_kidney Illumina NovaSeq X spatial dataset
+(companion-ready) — a single section, 276,925 cells × 56,748 genes.
+
+Carries an RGB H&E `he_hires` image (uns/spatial/mouse_kidney) attached as an
+overlay (open the sample → H&E Overlay controls or ✨ Auto-align). Gene
+expression is shown from the `lognorm` layer; analytics / DE are enabled for the
+two columns the companion precomputed stats for: `leiden` and
+`cellcharter_domains`. The remaining cellcharter_k* columns are exposed as plain
+categorical overlays (no precomputed analytics).
+
+Analytics (marker genes, cluster-vs-cluster DE, neighbor composition stats) are
+read straight from uns/karospace_companion — requesting the two analytics
+columns reuses those precomputed results instead of recomputing them.
+
+Usage:
+    python examples/mouse_kidney.py
+    MOUSE_KIDNEY_H5AD=/path/to/file.h5ad python examples/mouse_kidney.py
+"""
+
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+os.environ.setdefault("KMP_WARNINGS", "0")
+os.environ.setdefault("NUMBA_CACHE_DIR", "/tmp/numba-cache")
+os.environ.setdefault("MPLCONFIGDIR", "/tmp/karospace-mpl-cache")
+
+import h5py
+import numpy as np
+from PIL import Image
+
+from karospace import export_to_html, load_spatial_data
+
+H5AD_PATH = os.environ.get(
+    "MOUSE_KIDNEY_H5AD",
+    "/Users/chrislangseth/work/karolinska_institutet/projects/KaroSpaceDataWrangling/"
+    "data/processed/illumina-novaseqx-spatial/mouse_kidney.companion.ready.h5ad",
+)
+
+OUTPUT_DIR = REPO_ROOT
+IMAGE_DIR = OUTPUT_DIR / "mouse_kidney_images"
+SIDECAR_OUTPUT = str(OUTPUT_DIR / "mouse_kidney_v2.html")
+PACKAGE_OUTPUT = str(OUTPUT_DIR / "mouse_kidney_v2.karospace")
+# Sidecar accepts a full path; the .karospace packager needs a bare filename
+# (it lives inside the archive), so pass Path(...).name there.
+GENE_AUX_PATH = str(OUTPUT_DIR / "mouse_kidney_v2.genes.json")
+
+GROUPBY = "sample_id"
+PRIMARY_COLOR = "leiden"
+
+# Only leiden + cellcharter_domains have precomputed companion analytics; these
+# get DE / marker / neighbor-stats panels.
+ANALYTICS_COLUMNS = ["leiden", "cellcharter_domains"]
+
+# Extra cellcharter resolutions: plain categorical overlays, NOT analytics.
+PLAIN_CATEGORICAL = [
+    "cellcharter_k8",
+    "cellcharter_k10",
+    "cellcharter_k12",
+    "cellcharter_k15",
+    "cellcharter_k18",
+    "cellcharter_k22",
+]
+
+# Continuous QC / morphology metrics available as colourings.
+CONTINUOUS_METRICS = [
+    "total_counts",
+    "n_genes",
+    "area_um2",
+    "nuc_area_um2",
+    "nuc_cyto_ratio",
+]
+
+ADDITIONAL_COLORS = ANALYTICS_COLUMNS + PLAIN_CATEGORICAL + CONTINUOUS_METRICS
+
+
+def _read_sample_ids(f: "h5py.File") -> np.ndarray:
+    """Return obs/sample_id as a string array, handling categorical encoding."""
+    node = f["obs/sample_id"]
+    if isinstance(node, h5py.Group):  # categorical: codes + categories
+        cats = np.asarray(node["categories"][()])
+        cats = np.array([c.decode() if isinstance(c, bytes) else str(c) for c in cats])
+        codes = np.asarray(node["codes"][()])
+        out = np.where(codes >= 0, cats[codes.clip(min=0)], "")
+        return out.astype(str)
+    arr = np.asarray(node[()])
+    return np.array([c.decode() if isinstance(c, bytes) else str(c) for c in arr])
+
+
+def extract_he_image(h5ad_path: str, out_dir: Path) -> dict:
+    """Pull each sample's RGB `he_hires` H&E image, cropped to its cells.
+
+    The embedded `he_hires` bitmap carries gray margins around the tissue, but
+    the viewer auto-fits the WHOLE image to the cell bounding box — so the tissue
+    ends up uniformly shrunk. We crop the image to the exact cell bounding box
+    (converted from microns to hires pixels via the squidpy scalefactors) so the
+    auto-fit lands 1:1. Conversion: hires_px = micron * he_hires_scalef /
+    pixel_size_um (obsm/spatial is in microns; he_hires = full-res * scalef).
+
+    Returns {sample_key: {"H&E": path}} for samples carrying an image.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    per_sample: dict[str, dict] = {}
+    with h5py.File(h5ad_path, "r") as f:
+        if "spatial" not in f.get("uns", {}):
+            return per_sample
+        spatial = f["uns/spatial"]
+        coords = np.asarray(f["obsm/spatial"][()])[:, :2]
+        sample_ids = _read_sample_ids(f)
+        for sample_key in spatial.keys():
+            node = spatial[sample_key]
+            images = node.get("images") if isinstance(node, h5py.Group) else None
+            if images is None or "he_hires" not in images:
+                continue
+            arr = np.asarray(images["he_hires"][()])
+            if arr.dtype != np.uint8:
+                a = arr.astype(np.float32)
+                lo, hi = np.percentile(a, (2.0, 99.5))
+                hi = hi if hi > lo else lo + 1.0
+                arr = (np.clip((a - lo) / (hi - lo), 0.0, 1.0) * 255.0 + 0.5).astype(np.uint8)
+            mode = "RGB" if arr.ndim == 3 else "L"
+            img = Image.fromarray(arr, mode=mode)
+
+            # Crop to this sample's cell bounding box, in hires-image pixels.
+            sf = node.get("scalefactors") if isinstance(node, h5py.Group) else None
+            mask = sample_ids == str(sample_key)
+            if sf is not None and "he_hires_scalef" in sf and "pixel_size_um" in sf and mask.any():
+                scalef = float(sf["he_hires_scalef"][()])
+                pixel_um = float(sf["pixel_size_um"][()])
+                m2px = scalef / pixel_um  # microns -> hires pixels
+                cc = coords[mask]
+                W, H = img.size
+                left = max(0, int(np.floor(cc[:, 0].min() * m2px)))
+                right = min(W, int(np.ceil(cc[:, 0].max() * m2px)))
+                upper = max(0, int(np.floor(cc[:, 1].min() * m2px)))
+                lower = min(H, int(np.ceil(cc[:, 1].max() * m2px)))
+                if right > left and lower > upper:
+                    img = img.crop((left, upper, right, lower))
+                    print(
+                        f"  Cropped '{sample_key}' H&E to cell bbox "
+                        f"({right - left}×{lower - upper}px from {W}×{H}px, "
+                        f"{1.0 / m2px:.3f} µm/px)"
+                    )
+                else:
+                    print(f"  Warning: degenerate crop box for '{sample_key}' — using full image")
+            else:
+                print(f"  Warning: no scalefactors for '{sample_key}' — using full (uncropped) image")
+
+            path = out_dir / f"{sample_key}_he_hires.png"
+            img.save(path)
+            per_sample[str(sample_key)] = {"H&E": str(path)}
+    return per_sample
+
+
+def main() -> None:
+    if not Path(H5AD_PATH).exists():
+        raise SystemExit(
+            f"H5AD not found: {H5AD_PATH}\nSet MOUSE_KIDNEY_H5AD or edit the path above."
+        )
+
+    print("Extracting H&E image(s)...")
+    images_by_sample = extract_he_image(H5AD_PATH, IMAGE_DIR)
+    print(f"  extracted {len(images_by_sample)} image(s)")
+
+    print("Loading spatial data (276k cells × 56.7k genes — this can take a while)...")
+    dataset = load_spatial_data(
+        H5AD_PATH,
+        section_key=GROUPBY,          # was: groupby (renamed in the merge)
+        spatial_key="spatial",
+        section_metadata=[GROUPBY],   # was: metadata_columns
+    )
+    print(f"  {dataset.n_sections} section(s), {dataset.n_cells:,} cells")
+
+    # The viewer's gene-expression path reads a layer literally named
+    # "normalized"; this file stores normalized counts under "lognorm". Alias it
+    # so both gene display and cluster DE use the lognorm values.
+    if "normalized" not in dataset.adata.layers and "lognorm" in dataset.adata.layers:
+        dataset.adata.layers["normalized"] = dataset.adata.layers["lognorm"]
+        print("  Aliased layers['lognorm'] -> layers['normalized'] for gene display/DE")
+
+    # Attach the H&E overlay to its matching section.
+    section_images = {
+        s.section_id: images_by_sample[str(s.section_id)]
+        for s in dataset.sections
+        if str(s.section_id) in images_by_sample
+    } or None
+
+    common_kwargs = dict(
+        color=PRIMARY_COLOR,
+        title="Mouse Kidney — NovaSeq X Spatial",
+        min_panel_size=140,
+        spot_size="auto",
+        theme="light",
+        outline_by=None,
+        additional_colors=ADDITIONAL_COLORS,
+        genes=[],
+        use_hvgs=False,
+        gene_storage="sidecar",
+        gene_sidecar_format="binary-v1",
+        gene_encoding="auto",
+        gene_value_encoding="uint8",
+        gene_sidecar_shard_size=128,
+        # Analytics enabled ONLY for the two companion-precomputed columns;
+        # requesting them reuses uns/karospace_companion instead of recomputing.
+        marker_genes_groupby=ANALYTICS_COLUMNS,
+        marker_genes_top_n=30,
+        neighbor_stats_groupby=ANALYTICS_COLUMNS,
+        neighbor_stats_permutations=0,
+        cluster_de_groupby=ANALYTICS_COLUMNS,
+        cluster_de_top_n=20,
+        cluster_de_method="t-test",
+        cluster_de_layer="normalized",
+        interaction_markers_groupby=None,
+        section_images=section_images,
+        section_images_max_px=4096,
+    )
+
+    print("Exporting sidecar HTML...")
+    export_to_html(
+        dataset, output_path=SIDECAR_OUTPUT, gene_aux_path=GENE_AUX_PATH, **common_kwargs
+    )
+
+    print("Packaging .karospace archive...")
+    export_to_html(
+        dataset,
+        output_path=PACKAGE_OUTPUT,
+        gene_aux_path=Path(GENE_AUX_PATH).name,
+        **common_kwargs,
+    )
+
+    print(f"\nDone!\n  sidecar: {SIDECAR_OUTPUT}\n  package: {PACKAGE_OUTPUT}")
+    print(
+        "Coloured by leiden; DE/analytics enabled for leiden & cellcharter_domains. "
+        "cellcharter_k* are plain categorical overlays. Open the sample for the H&E overlay."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/stroke_all.py
+++ b/examples/stroke_all.py
@@ -1,0 +1,159 @@
+"""
+KaroSpace export for the full stroke (dMCAO) dataset stroke_all (companion-ready)
+— 49 samples, ~3.66M cells, one section per sample.
+
+Each sample carries a grayscale `hires` morphology image (uns/spatial), attached
+PER SECTION as an overlay (open a sample → use the H&E Overlay controls or
+✨ Auto-align). Coloured by the coarse `cluster` annotation, with cell
+morphology / QC metrics available as continuous colourings.
+
+~3.66M cells / 500 genes — writes a binary-sidecar viewer bundle and a matching
+packaged .karospace.
+
+Usage:
+    python examples/stroke_all.py
+    STROKE_ALL_H5AD=/path/to/file.h5ad python examples/stroke_all.py
+"""
+
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+os.environ.setdefault("KMP_WARNINGS", "0")
+os.environ.setdefault("NUMBA_CACHE_DIR", "/tmp/numba-cache")
+os.environ.setdefault("MPLCONFIGDIR", "/tmp/karospace-mpl-cache")
+
+import h5py
+import numpy as np
+from PIL import Image
+
+from karospace import export_to_html, load_spatial_data
+
+H5AD_PATH = os.environ.get(
+    "STROKE_ALL_H5AD",
+    "/Users/chrislangseth/Downloads/stroke_all.companion.ready.h5ad",
+)
+
+OUTPUT_DIR = REPO_ROOT
+IMAGE_DIR = OUTPUT_DIR / "stroke_all_images"
+SIDECAR_OUTPUT = "stroke_all.html"
+PACKAGE_OUTPUT = "stroke_all.karospace"
+# Must be a BARE filename: it's written next to the sidecar HTML and packaged by
+# name inside the .karospace archive (a full path is rejected for the package).
+GENE_AUX_PATH = "stroke_all.genes.json"
+
+PRIMARY_COLOR = "cluster"
+ADDITIONAL_COLORS = [
+    "cluster",
+    "density",
+    "area",
+    "elongation",
+    "n_transcripts",
+    "avg_confidence",
+    "max_cluster_frac",
+    "lifespan",
+]
+CLUSTER_COLUMNS = ["cluster"]
+
+
+def extract_images_per_sample(h5ad_path: str, out_dir: Path) -> dict:
+    """Pull the grayscale 'hires' morphology image for every sample in uns/spatial.
+
+    Returns {sample_key: {"Morphology": path}} for samples that have an image.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    per_sample: dict[str, dict] = {}
+    with h5py.File(h5ad_path, "r") as f:
+        spatial = f["uns/spatial"]
+        for sample_key in spatial.keys():
+            node = spatial[sample_key]
+            images = node.get("images") if isinstance(node, h5py.Group) else None
+            if images is None or "hires" not in images:
+                continue
+            arr = np.asarray(images["hires"][()])
+            if arr.dtype != np.uint8:
+                a = arr.astype(np.float32)
+                lo, hi = np.percentile(a, (2.0, 99.5))
+                hi = hi if hi > lo else lo + 1.0
+                arr = (np.clip((a - lo) / (hi - lo), 0.0, 1.0) * 255.0 + 0.5).astype(np.uint8)
+            mode = "RGB" if arr.ndim == 3 else "L"
+            path = out_dir / f"{sample_key}_hires.png"
+            Image.fromarray(arr, mode=mode).save(path)
+            per_sample[str(sample_key)] = {"Morphology": str(path)}
+    return per_sample
+
+
+def main() -> None:
+    if not Path(H5AD_PATH).exists():
+        raise SystemExit(
+            f"H5AD not found: {H5AD_PATH}\nSet STROKE_ALL_H5AD or edit the path above."
+        )
+
+    print("Extracting per-sample morphology images...")
+    images_by_sample = extract_images_per_sample(H5AD_PATH, IMAGE_DIR)
+    print(f"  extracted {len(images_by_sample)} images")
+
+    print("Loading spatial data (16 GB / ~3.66M cells — this can take a while)...")
+    dataset = load_spatial_data(
+        H5AD_PATH,
+        groupby="sample",
+        spatial_key="spatial",
+        metadata_columns=["sample"],
+    )
+    print(f"  {dataset.n_sections} section(s), {dataset.n_cells:,} cells")
+
+    # Attach each section's own morphology image (matched by sample key).
+    section_images = {}
+    for s in dataset.sections:
+        layers = images_by_sample.get(str(s.section_id))
+        if layers:
+            section_images[s.section_id] = layers
+    if not section_images:
+        section_images = None
+
+    common_kwargs = dict(
+        color=PRIMARY_COLOR,
+        title="Stroke (dMCAO) — all samples",
+        min_panel_size=120,
+        spot_size="auto",
+        downsample=10_000_000,
+        theme="light",
+        outline_by=None,
+        additional_colors=ADDITIONAL_COLORS,
+        genes=[],
+        use_hvgs=False,
+        gene_storage="sidecar",
+        gene_sidecar_format="binary-v1",
+        gene_encoding="auto",
+        gene_value_encoding="uint8",
+        gene_aux_path=GENE_AUX_PATH,
+        gene_sidecar_shard_size=128,
+        marker_genes_groupby=CLUSTER_COLUMNS,
+        marker_genes_top_n=30,
+        neighbor_stats_groupby=CLUSTER_COLUMNS,
+        neighbor_stats_permutations=0,
+        cluster_de_groupby=CLUSTER_COLUMNS,
+        cluster_de_top_n=20,
+        cluster_de_method="t-test",
+        cluster_de_layer=None,
+        interaction_markers_groupby=None,
+        section_images=section_images,
+        section_images_max_px=4096,
+    )
+
+    print("Exporting binary-sidecar viewer...")
+    export_to_html(dataset, output_path=SIDECAR_OUTPUT, **common_kwargs)
+
+    print("Packaging .karospace archive...")
+    export_to_html(dataset, output_path=PACKAGE_OUTPUT, **common_kwargs)
+
+    print(f"\nDone!\n  sidecar: {SIDECAR_OUTPUT}\n  package: {PACKAGE_OUTPUT}")
+    print("Coloured by cluster; switch to morphology/QC metrics via the colour selector. Per-section morphology images attach as overlays.")
+
+
+if __name__ == "__main__":
+    main()

--- a/karospace/data_loader.py
+++ b/karospace/data_loader.py
@@ -951,6 +951,13 @@ def _load_companion_analytics(adata) -> Dict[str, Any]:
     analytics: Dict[str, Any] = {}
     if "analytics_columns" in companion:
         analytics["analytics_columns"] = _normalize_uns_text_list(companion.get("analytics_columns"))
+    # Plain string scalar (not JSON): the cell-level DE method Companion used
+    # ("ttest" / "wilcoxon"). Used to tag reused cluster DE so the viewer badge
+    # labels it as cell-level markers rather than a DESeq2 pseudobulk result.
+    if "analytics_cluster_de_method" in companion:
+        analytics["cluster_de_method"] = _normalize_uns_text(
+            companion.get("analytics_cluster_de_method")
+        )
 
     for uns_key, analytics_key in COMPANION_ANALYTICS_JSON_FIELDS.items():
         if uns_key not in companion:
@@ -967,6 +974,79 @@ def _load_companion_analytics(adata) -> Dict[str, Any]:
             )
 
     return analytics
+
+
+def _companion_de_source_tag(method: Optional[str]) -> str:
+    """Map Companion's DE-method scalar to a viewer badge source tag."""
+    normalized = str(method or "").strip().lower().replace("-", "").replace("_", "")
+    if normalized == "wilcoxon":
+        return "companion_wilcoxon"
+    # Companion's default (and TTest enum) is a cell-level Welch t-test.
+    return "companion_ttest"
+
+
+def _backfill_companion_pseudobulk_summary(
+    payload: Any,
+    annotation_key: str,
+    companion_gene_means: Any,
+    method: Optional[str],
+) -> Any:
+    """Give a reused Companion cluster-DE payload the _summary the viewer expects.
+
+    Companion emits cell-level t-test / Wilcoxon DE (no ``_summary``, no method
+    tag) and stores per-cluster means in a separate ``cluster_gene_means_json``
+    field. Stitch the two together so (a) the DE-method badge labels these as
+    cell-level markers instead of defaulting to the DESeq2 label, and (b) the
+    category-means / category-vs-rest panels render. Idempotent: a future
+    Companion that already writes ``_summary.category_gene_means`` is left alone
+    apart from ensuring a source tag.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    source_tag = _companion_de_source_tag(method)
+
+    existing_summary = payload.get("_summary")
+    if isinstance(existing_summary, dict) and isinstance(
+        existing_summary.get("category_gene_means"), dict
+    ):
+        existing_summary["category_gene_means"].setdefault("source", source_tag)
+        existing_summary.setdefault("source", source_tag)
+        return payload
+
+    # Per-category cell counts aren't in cluster_gene_means_json; recover them
+    # from any contrast leaf's n_source (source category == that leaf's source).
+    n_cells: Dict[str, int] = {}
+    for source_cat, refs in payload.items():
+        if str(source_cat).startswith("_") or not isinstance(refs, dict):
+            continue
+        for ref_result in refs.values():
+            if isinstance(ref_result, dict) and ref_result.get("n_source") is not None:
+                try:
+                    n_cells[str(source_cat)] = int(ref_result["n_source"])
+                except (TypeError, ValueError):
+                    pass
+                break
+
+    category_gene_means = None
+    if isinstance(companion_gene_means, dict):
+        columns = companion_gene_means.get("columns")
+        column = columns.get(annotation_key) if isinstance(columns, dict) else None
+        if isinstance(column, dict):
+            category_gene_means = {
+                "genes": list(companion_gene_means.get("genes") or []),
+                "categories": list(column.get("categories") or []),
+                "means": dict(column.get("means") or {}),
+                "background": list(column.get("background") or []),
+                "n_cells": n_cells,
+                "source": source_tag,
+            }
+
+    summary = dict(existing_summary) if isinstance(existing_summary, dict) else {}
+    if category_gene_means is not None:
+        summary["category_gene_means"] = category_gene_means
+    summary.setdefault("source", source_tag)
+    payload["_summary"] = summary
+    return payload
 
 
 def _strip_category_pseudobulk_sample_diagnostics(payload: Any) -> Any:
@@ -2395,6 +2475,8 @@ class SpatialDataset:
         )
         pending_pseudobulk_de_annotations = list(requested_pseudobulk_de_annotations)
         companion_pseudobulk_de = companion_analytics.get("pseudobulk_de")
+        companion_gene_means = companion_analytics.get("category_gene_means")
+        companion_de_method = companion_analytics.get("cluster_de_method")
         if (
             not replicate_override
             and pending_pseudobulk_de_annotations
@@ -2412,9 +2494,19 @@ class SpatialDataset:
                     f"{'s' if len(reused_pseudobulk_de_annotations) != 1 else ''}."
                 )
                 for annotation_key in reused_pseudobulk_de_annotations:
-                    pseudobulk_de[annotation_key] = _strip_category_pseudobulk_sample_diagnostics(
+                    reused_payload = _strip_category_pseudobulk_sample_diagnostics(
                         companion_pseudobulk_de[annotation_key]
                     )
+                    # Companion cluster DE lacks _summary and a method tag;
+                    # stitch in per-cluster means + a cell-level source tag so
+                    # the badge/category panels render correctly.
+                    reused_payload = _backfill_companion_pseudobulk_summary(
+                        reused_payload,
+                        annotation_key,
+                        companion_gene_means,
+                        companion_de_method,
+                    )
+                    pseudobulk_de[annotation_key] = reused_payload
             pending_pseudobulk_de_annotations = [
                 annotation_key
                 for annotation_key in pending_pseudobulk_de_annotations

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -27017,7 +27017,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const isSpotlit = linkedSpotlightEnabled && spotlightPinnedCategory === key;
             return `
                 <div class="marker-group">
-                    <div class="marker-group-title${{isSpotlit ? ' is-spotlit' : ''}}" data-marker-category="${{escapeHtml(key)}}" title="Click to highlight this annotation in the viewer">${{renderAggCategoryChip(markerColorCol, key, catIdx)}}</div>
+                    <div class="marker-group-title${{isSpotlit ? ' is-spotlit' : ''}}" data-marker-category="${{escapeHtml(key)}}" title="Click to color the map by this annotation and highlight this cluster">${{renderAggCategoryChip(markerColorCol, key, catIdx)}}</div>
                     <div class="gene-token-grid">${{geneButtons}}</div>
                 </div>
             `;
@@ -27038,9 +27038,23 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             title.addEventListener('click', (event) => {{
                 const cat = title.getAttribute('data-marker-category');
                 if (!cat) return;
+                // The spotlight is validated against getColorConfig().categories,
+                // which follows the map's active coloring (currentAnnotation, or a
+                // continuous gene scale when currentGene is set). If the map is
+                // showing a gene or a different annotation than this markers panel,
+                // a pinned category from here would be silently rejected. So bring
+                // the map onto this marker annotation (dropping any active gene)
+                // first, then toggle the category spotlight.
+                const onThisAnnotation = !currentGene && currentAnnotation === markerColorCol;
+                const alreadySpotlit = linkedSpotlightEnabled
+                    && spotlightPinnedCategory === cat
+                    && onThisAnnotation;
+                if (!alreadySpotlit && !onThisAnnotation) {{
+                    setViewerColorColumn(markerColorCol);
+                }}
                 linkedSpotlightEnabled = true;
                 neighborNetworkFocusCategories = null;
-                spotlightPinnedCategory = spotlightPinnedCategory === cat ? null : cat;
+                spotlightPinnedCategory = alreadySpotlit ? null : cat;
                 spotlightHoverCategory = null;
                 updateAllLegendSpotlightClasses();
                 rerenderForSpotlightChange();

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -19298,6 +19298,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (source.indexOf('cell_welch') === 0) {{
             return '<span class="de-method-badge de-method-welch" title="Single-sample data (fewer than 2 biological replicates): per-cluster markers were computed with a Welch t-test, treating each cell as a replicate and testing each category vs the rest. This is a descriptive marker ranking, NOT a DESeq2 pseudobulk result — p-values are anti-conservative (pseudoreplication). Use for marker discovery, not formal inference.">Cluster markers &middot; Welch <span class="de-method-badge-note">(single-sample, descriptive)</span></span>';
         }}
+        if (source.indexOf('companion') === 0) {{
+            const isWilcoxon = source.indexOf('wilcoxon') !== -1;
+            const methodLabel = isWilcoxon ? 'Wilcoxon' : 't-test';
+            return '<span class="de-method-badge de-method-welch" title="Precomputed by KaroSpaceCompanion: per-cluster markers from a cell-level ' + methodLabel + ' (each cell treated as a replicate, category vs category). This is a descriptive marker ranking, NOT a DESeq2 pseudobulk result — use for marker discovery, not formal inference.">Cluster markers &middot; ' + methodLabel + ' <span class="de-method-badge-note">(cell-level, descriptive)</span></span>';
+        }}
         return '<span class="de-method-badge de-method-deseq2" title="Pseudobulk differential expression: cells summed into per-replicate pseudobulk samples and fit with DESeq2 (~ replicate + annotation), then evaluated as a category-vs-category contrast.">Pseudobulk DE &middot; DESeq2</span>';
     }}
 


### PR DESCRIPTION
Make marker cluster/cell-type labels switch the map to that annotation and spotlight the cluster — fixing the case where clicking a cluster did nothing after a marker gene was loaded.