### PR TITLE
Per-cluster cell-level fallback markers + multimodal viewer UX

### DIFF
--- a/examples/comet-xenium-multimodal-sidecar-package.py
+++ b/examples/comet-xenium-multimodal-sidecar-package.py
@@ -1,0 +1,278 @@
+"""
+Export a KaroSpace viewer for the COMET multimodal Xenium dataset.
+
+This is a 4-core tissue microarray (hepatocellular carcinoma / non-tumour HCC
+liver / tonsil / hepatocellular adenoma) profiled with BOTH:
+  * RNA   — 5,001-gene Xenium panel (adata.X)
+  * Protein — 16-channel COMET immunofluorescence (adata.obsm['protein'],
+    channel names in adata.uns['protein_var'], e.g. DAPI, CK8, CD45, HepPar1)
+
+Each core also carries a post-stain H&E image. The H&E PNGs are NOT embedded in
+the h5ad — `uns/section_images` holds a relative PATH per section and the actual
+files live in `he_images/` next to the h5ad. We resolve those paths and attach
+each core's own H&E as an overlay, so in the viewer you can open a core and
+toggle / auto-align the H&E under the cells.
+
+Because this carries an extra (protein) modality, the exporter requires
+feature_storage="sidecar" (a single embedded HTML can't carry a 2nd modality).
+
+Usage:
+    python examples/comet-xenium-multimodal-sidecar-package.py
+    COMET_XENIUM_H5AD=/path/to/comet_xenium_multimodal.h5ad \
+        python examples/comet-xenium-multimodal-sidecar-package.py
+"""
+
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+os.environ.setdefault("KMP_WARNINGS", "0")
+os.environ.setdefault("NUMBA_CACHE_DIR", "/tmp/numba-cache")
+os.environ.setdefault("MPLCONFIGDIR", "/tmp/karospace-mpl-cache")
+
+import h5py
+import numpy as np
+import scipy.sparse as sp
+from scipy.spatial import cKDTree
+
+from karospace import export_to_html, load_spatial_data
+
+# k for the spatial kNN graph. Typical Xenium neighbourhoods use ~6 neighbours.
+SPATIAL_GRAPH_K = 6
+
+H5AD_PATH = os.environ.get(
+    "COMET_XENIUM_H5AD",
+    "/Users/chrislangseth/work/karolinska_institutet/projects/KaroSpaceDataWrangling/"
+    "notebooks/data/comet_xenium_multimodal/comet_xenium_multimodal.h5ad",
+)
+
+OUTPUT_DIR = REPO_ROOT
+BASE_NAME = "comet-xenium-multimodal"
+SIDECAR_OUTPUT = str(OUTPUT_DIR / f"{BASE_NAME}-sidecar.html")
+PACKAGE_OUTPUT = str(OUTPUT_DIR / f"{BASE_NAME}.karospace")
+FEATURE_MANIFEST_PATH = str(OUTPUT_DIR / f"{BASE_NAME}.features.json")
+
+# leiden_rna is the most familiar default; keep the protein-based clustering and
+# the tissue label available too.
+PRIMARY_ANNOTATION = "leiden_rna"
+ADDITIONAL_ANNOTATIONS = [
+    "leiden_rna",
+    "leiden_protein",
+    "tissue",
+    "area_px",
+]
+# Run cluster analytics (markers / DE / neighbor stats) on both clusterings so
+# either can be explored in the Insights panel.
+CLUSTER_COLUMNS = ["leiden_rna", "leiden_protein"]
+
+
+def resolve_section_images(h5ad_path: str) -> dict:
+    """Map each section to its H&E overlay by resolving the paths in
+    uns/section_images. Paths are stored relative to the data repo root; fall
+    back to the he_images/ dir sitting next to the h5ad if that fails.
+
+    Returns {section_id: {"H&E": absolute_png_path}} for images found on disk.
+    """
+    h5ad = Path(h5ad_path).resolve()
+    h5ad_dir = h5ad.parent
+    # .../<repo>/notebooks/data/<dataset>/file.h5ad -> repo root is parents[3]
+    repo_root = h5ad.parents[3] if len(h5ad.parents) > 3 else h5ad_dir
+
+    per_section: dict[str, dict] = {}
+    with h5py.File(h5ad_path, "r") as f:
+        if "section_images" not in f["uns"]:
+            return per_section
+        for section_key in f["uns/section_images"].keys():
+            raw = f["uns/section_images"][section_key][()]
+            rel = raw.decode() if isinstance(raw, bytes) else str(raw)
+            candidates = [
+                repo_root / rel,
+                h5ad_dir / rel,
+                h5ad_dir / "he_images" / Path(rel).name,
+            ]
+            png = next((c for c in candidates if c.exists()), None)
+            if png is None:
+                print(f"  Warning: H&E for '{section_key}' not found (tried: {rel})")
+                continue
+            per_section[str(section_key)] = {"H&E": str(png.resolve())}
+            print(f"  [{section_key}] H&E -> {png.name}")
+    return per_section
+
+
+def build_spatial_graph(adata, section_col: str, spatial_key: str = "spatial",
+                        k: int = SPATIAL_GRAPH_K) -> None:
+    """Build a per-section symmetric kNN spatial graph into
+    adata.obsp['spatial_connectivities'].
+
+    The exporter's spatially-variable-genes step (Moran's I) only *reads* a graph
+    from obsp — unlike neighbor stats, it never builds one from coordinates. This
+    plain h5ad ships no graph, so we build one here. Edges are added within each
+    section only, so Moran's I never draws spurious links between the 4 cores.
+    """
+    coords = np.asarray(adata.obsm[spatial_key])[:, :2].astype(float)
+    n = coords.shape[0]
+    sections = np.asarray(adata.obs[section_col].astype(str))
+
+    rows: list[np.ndarray] = []
+    cols: list[np.ndarray] = []
+    for sec in np.unique(sections):
+        idx = np.flatnonzero(sections == sec)
+        if idx.size < 2:
+            continue
+        kk = int(min(k, idx.size - 1))
+        tree = cKDTree(coords[idx])
+        # k+1 because the first neighbour is the point itself.
+        _, nbr = tree.query(coords[idx], k=kk + 1)
+        nbr = np.atleast_2d(nbr)[:, 1:]  # drop self column
+        src = np.repeat(idx, nbr.shape[1])
+        dst = idx[nbr.ravel()]
+        rows.append(src)
+        cols.append(dst)
+
+    if not rows:
+        print("  Warning: could not build a spatial graph (too few cells).")
+        return
+
+    r = np.concatenate(rows)
+    c = np.concatenate(cols)
+    data = np.ones(r.shape[0], dtype=np.float32)
+    W = sp.coo_matrix((data, (r, c)), shape=(n, n)).tocsr()
+    W = W.maximum(W.T)  # symmetrize (mutual + one-directional kNN edges)
+    # Self-neighbours were already dropped, so the diagonal is zero by construction.
+    adata.obsp["spatial_connectivities"] = W
+    print(f"  Built spatial graph: {n:,} cells, {W.nnz:,} edges "
+          f"(k={k}, per-section, symmetric).")
+
+
+def clean_protein_channel_names(dataset) -> None:
+    """Strip the fluorophore suffix from protein channel names so they're
+    addressable by antibody target alone.
+
+    The COMET channels ship as 'CD45 - TRITC', 'CD66 - FITC', etc. In the viewer
+    that means colouring requires typing the full 'CD45 - TRITC'; bare 'CD45'
+    matches nothing. The suffix is the detection channel, not the target, so we
+    drop it — but only if every stripped name stays unique (no collisions).
+    """
+    mod = dataset.modalities.get("protein")
+    if mod is None:
+        return
+    orig = list(mod.var.index)
+    cleaned = [str(n).split(" - ")[0].strip() for n in orig]
+    if len(set(cleaned)) != len(cleaned):
+        print("  Skipping protein channel rename — stripping suffixes would collide.")
+        return
+    mod.var.index = cleaned
+    renamed = [f"{o} -> {c}" for o, c in zip(orig, cleaned) if o != c]
+    print(f"  Cleaned {len(renamed)} protein channel name(s), e.g. {renamed[:3]}")
+
+
+def main() -> None:
+    if not Path(H5AD_PATH).exists():
+        raise SystemExit(
+            f"H5AD not found: {H5AD_PATH}\nSet COMET_XENIUM_H5AD or edit the path above."
+        )
+
+    print("Resolving per-core H&E overlays...")
+    images_by_section = resolve_section_images(H5AD_PATH)
+    if not images_by_section:
+        print("  Warning: no H&E overlays resolved — exporting without images.")
+
+    print("Loading spatial data...")
+    dataset = load_spatial_data(
+        H5AD_PATH,
+        section_key="sample_id",
+        spatial_key="spatial",
+        section_metadata=["sample_id", "tissue"],
+    )
+    print(f"  {dataset.n_sections} section(s), {dataset.n_cells:,} cells")
+    print(f"  section IDs: {[s.section_id for s in dataset.sections]}")
+    print(f"  detected modalities: {list(dataset.modalities.keys())}")
+
+    # Make protein channels addressable by antibody target (CD45, not CD45 - TRITC).
+    print("Cleaning protein channel names...")
+    clean_protein_channel_names(dataset)
+
+    # The exporter's Moran's I step needs a spatial graph in obsp (it won't build
+    # one). Add a per-section kNN graph so spatially variable genes populate.
+    if "spatial_connectivities" not in dataset.adata.obsp:
+        print("Building spatial neighbour graph for Moran's I...")
+        build_spatial_graph(dataset.adata, section_col="sample_id", spatial_key="spatial")
+
+    # Attach each core's OWN H&E (section_id from section_key='sample_id' matches
+    # the uns/section_images keys).
+    section_images = {}
+    for s in dataset.sections:
+        layers = images_by_section.get(str(s.section_id))
+        if layers:
+            section_images[s.section_id] = layers
+        else:
+            print(f"  Warning: no H&E for section '{s.section_id}' — no overlay.")
+    section_images = section_images or None
+
+    common_kwargs = dict(
+        main_cell_annotation=PRIMARY_ANNOTATION,
+        title="COMET Multimodal Xenium (RNA + 16-plex Protein) — H&E",
+        min_panel_size=100,
+        spot_size="auto",
+        outline_by=None,
+        cell_annotations=ADDITIONAL_ANNOTATIONS,
+        features=[],
+        use_hvgs=False,
+        # Extra (protein) modality requires sidecar storage.
+        feature_storage="sidecar",
+        feature_encoding="auto",
+        feature_value_encoding="uint8",
+        feature_sidecar_shard_size=128,
+        # Cluster analytics (computed here — this is a plain, non-companion h5ad).
+        marker_gene_annotations=CLUSTER_COLUMNS,
+        marker_genes_top_n=30,
+        neighbor_stats_annotations=CLUSTER_COLUMNS,
+        neighbor_stats_permutations=0,
+        pseudobulk_de_annotations=CLUSTER_COLUMNS,
+        pseudobulk_de_top_n=20,
+        pseudobulk_de_method="t-test",
+        pseudobulk_de_layer=None,
+        interaction_marker_annotations=None,
+        # RNA panel + 16-channel COMET protein.
+        modalities=["rna", "protein"],
+        # H&E overlays.
+        section_images=section_images,
+        section_images_max_px=4096,
+    )
+
+    # Sidecar manifest is written next to the HTML (full path OK); the .karospace
+    # packager needs a bare filename (the manifest lives inside the archive).
+    print("\nExporting sidecar HTML...")
+    export_to_html(
+        dataset,
+        output_path=SIDECAR_OUTPUT,
+        feature_manifest_path=FEATURE_MANIFEST_PATH,
+        **common_kwargs,
+    )
+
+    print(f"Packaging {PACKAGE_OUTPUT}...")
+    export_to_html(
+        dataset,
+        output_path=PACKAGE_OUTPUT,
+        feature_manifest_path=Path(FEATURE_MANIFEST_PATH).name,
+        **common_kwargs,
+    )
+
+    print("\nDone! Wrote multimodal viewer:")
+    print(f"  1. Sidecar Viewer:  {SIDECAR_OUTPUT}")
+    print(f"  2. Feature Manifest:{FEATURE_MANIFEST_PATH}")
+    print(f"  3. Shard Directory: {Path(FEATURE_MANIFEST_PATH).with_suffix('')}/")
+    print(f"  4. KaroSpace Package:{PACKAGE_OUTPUT}")
+    print(f"  5. Local Loader:    {Path(PACKAGE_OUTPUT).with_suffix('.loader.html')}")
+    print(
+        "\nOpen a core, switch the modality (RNA <-> Protein) to color by any of the "
+        "16 antibodies, and use the H&E overlay controls to toggle / auto-align the stain."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/karospace/data_loader.py
+++ b/karospace/data_loader.py
@@ -3054,6 +3054,150 @@ class SpatialDataset:
             float(pseudobulk_padj_cutoff),
             float(pseudobulk_log2fc_cutoff),
         )
+
+        def _cell_level_fallback_markers(
+            pseudobulk_markers,
+            annotation_cols,
+            *,
+            replicate_col,
+            min_cells,
+            top_n=25,
+            padj_cutoff=0.05,
+            method="wilcoxon",
+        ):
+            """One-vs-rest CELL-LEVEL markers, computed ONLY for categories that
+            pseudobulk DE could not test because they sit in a single replicate.
+
+            No biological replication underlies these numbers — every cell is
+            treated as an independent replicate (statistical double-dipping), so
+            they are exploratory only and the viewer labels them very explicitly.
+            Returns {annotation_col: {category: [gene, ...]}} for eligible
+            categories only (missing from pseudobulk AND present in < 2 replicates
+            with >= min_cells cells, so pseudobulk genuinely could not run).
+            """
+            from scipy.stats import rankdata, norm
+
+            obs = self.adata.obs
+            if replicate_col not in obs.columns:
+                return {}
+            sections = obs[replicate_col].astype(str).to_numpy()
+            var_names = list(self.adata.var_names)
+            n_genes = len(var_names)
+            n_cells = int(self.adata.n_obs)
+            X = self.adata.X
+            is_sparse = sp.issparse(X)
+
+            groups = []  # (col, category_label, cell_mask)
+            for col in annotation_cols:
+                meta = annotation_data.get(col)
+                if not meta or meta.get("is_continuous"):
+                    continue
+                vals = meta["values"]
+                cats = meta["categories"]
+                existing = pseudobulk_markers.get(col, {}) or {}
+                for code, cat in enumerate(cats):
+                    cat_key = str(cat)
+                    if existing.get(cat_key):
+                        continue  # pseudobulk already produced markers here
+                    mask = np.isfinite(vals) & (vals == code)
+                    n_in = int(mask.sum())
+                    if n_in < int(min_cells) or n_in >= n_cells:
+                        continue
+                    _, counts = np.unique(sections[mask], return_counts=True)
+                    if int((counts >= int(min_cells)).sum()) >= 2:
+                        continue  # >= 2 replicates: pseudobulk could run; empty is a real negative
+                    groups.append((col, cat_key, mask))
+            if not groups:
+                return {}
+
+            n_groups = len(groups)
+            z_stat = np.zeros((n_groups, n_genes))
+            mean_in = np.zeros((n_groups, n_genes))
+            mean_out = np.zeros((n_groups, n_genes))
+            n_in_arr = np.array([int(m.sum()) for (_, _, m) in groups])
+
+            chunk = 512
+            for start in range(0, n_genes, chunk):
+                stop = min(start + chunk, n_genes)
+                block = X[:, start:stop]
+                dense = np.asarray(
+                    block.toarray() if is_sparse else block, dtype=np.float64
+                )
+                width = dense.shape[1]
+                ranks = np.empty_like(dense)
+                tie_term = np.zeros(width)
+                for j in range(width):
+                    ranks[:, j] = rankdata(dense[:, j])
+                    _, cnt = np.unique(dense[:, j], return_counts=True)
+                    cnt = cnt.astype(np.float64)
+                    tie_term[j] = float(np.sum(cnt ** 3 - cnt))
+                for gi, (_, _, mask) in enumerate(groups):
+                    n1 = int(n_in_arr[gi])
+                    n2 = n_cells - n1
+                    mean_in[gi, start:stop] = dense[mask].mean(axis=0)
+                    mean_out[gi, start:stop] = dense[~mask].mean(axis=0)
+                    if n1 <= 0 or n2 <= 0:
+                        continue
+                    r1 = ranks[mask].sum(axis=0)
+                    u_stat = r1 - n1 * (n1 + 1) / 2.0
+                    mu = n1 * n2 / 2.0
+                    var = (n1 * n2 / 12.0) * (
+                        (n_cells + 1) - tie_term / (n_cells * (n_cells - 1))
+                    )
+                    sigma = np.sqrt(np.maximum(var, 1e-12))
+                    z_stat[gi, start:stop] = (u_stat - mu) / sigma
+
+            def _bh(pvals):
+                p = np.asarray(pvals, dtype=np.float64)
+                n = p.size
+                if n == 0:
+                    return p
+                order = np.argsort(p)
+                ranked = p[order] * n / (np.arange(n) + 1)
+                ranked = np.minimum.accumulate(ranked[::-1])[::-1]
+                out = np.empty(n)
+                out[order] = np.clip(ranked, 0.0, 1.0)
+                return out
+
+            results = {}
+            for gi, (col, cat_key, _) in enumerate(groups):
+                z = z_stat[gi]
+                pvals = norm.sf(z)  # one-sided: up-regulated in this category
+                padj = _bh(pvals)
+                keep = (
+                    (mean_in[gi] > mean_out[gi])
+                    & (padj < float(padj_cutoff))
+                    & np.isfinite(z)
+                )
+                idx = np.flatnonzero(keep)
+                if idx.size == 0:
+                    continue
+                idx = idx[np.argsort(z[idx])[::-1]][: int(top_n)]
+                results.setdefault(col, {})[cat_key] = [var_names[i] for i in idx]
+            return results
+
+        cell_level_marker_method = "wilcoxon"
+        marker_genes_cell_level = {}
+        try:
+            marker_genes_cell_level = _cell_level_fallback_markers(
+                marker_genes,
+                requested_pseudobulk_de_annotations,
+                replicate_col=pseudobulk_replicate_name,
+                min_cells=int(pseudobulk_min_cells_per_pseudobulk),
+                padj_cutoff=float(pseudobulk_padj_cutoff),
+                method=cell_level_marker_method,
+            )
+        except Exception as exc:  # never let the fallback break an export
+            log_warning(f"Cell-level fallback markers skipped: {exc}", level=1)
+        if marker_genes_cell_level:
+            total = sum(len(v) for v in marker_genes_cell_level.values())
+            log_detail(
+                f"Cell-level fallback markers computed for {total} single-replicate "
+                f"categor{'ies' if total != 1 else 'y'} "
+                f"(exploratory; no biological replication).",
+                level=1,
+            )
+
         pseudobulk_de = _drop_legacy_logfoldchanges(pseudobulk_de)
         interaction_markers = _drop_legacy_logfoldchanges(interaction_markers)
 
@@ -3254,6 +3398,8 @@ class SpatialDataset:
             "available_deconvolutions": list(decon_data.keys()),
             "available_features": list(feature_data.keys()),
             "marker_genes": marker_genes,
+            "marker_genes_cell_level": marker_genes_cell_level,
+            "marker_genes_cell_level_method": cell_level_marker_method,
             "pseudobulk_de": pseudobulk_de,
             "pseudobulk_de_by_modality": pseudobulk_de_by_modality,
             "has_umap": umap_coords is not None,

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -4775,6 +4775,18 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             line-height: 1.35;
         }}
         .genes-warning + .genes-warning {{ margin-top: -2px; }}
+        .marker-fallback-warning {{
+            margin: 4px 0 6px;
+            padding: 7px 9px;
+            border: 1px solid color-mix(in srgb, var(--warning-border) 80%, #b45309);
+            border-left: 3px solid #b45309;
+            border-radius: 6px;
+            background: var(--warning-bg);
+            color: var(--warning-text);
+            font-size: 10px;
+            line-height: 1.4;
+        }}
+        .marker-fallback-warning strong {{ display: block; margin-bottom: 2px; }}
         .genes-warning .agg-chip {{
             margin-left: 4px;
             color: var(--chip-text);
@@ -7744,6 +7756,20 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function getActiveModalityDescriptor() {{
         return MODALITY_DESCRIPTORS.find(d => d && d.name === CURRENT_MODALITY) || null;
     }}
+    function updateGeneInputPlaceholder() {{
+        const input = document.getElementById('gene-input');
+        if (!input) return;
+        // Default (RNA) modality keeps the familiar gene example placeholder.
+        if (CURRENT_MODALITY === DEFAULT_MODALITY_NAME) {{
+            input.placeholder = 'e.g. Cd4, Gfap...';
+            return;
+        }}
+        const feats = Array.isArray(FEATURES_BY_MODALITY[CURRENT_MODALITY])
+            ? FEATURES_BY_MODALITY[CURRENT_MODALITY]
+            : [];
+        const examples = feats.slice(0, 2).join(', ');
+        input.placeholder = examples ? `e.g. ${{examples}}...` : 'Type a feature name...';
+    }}
     function getLoadedFeaturesForModality(modality = CURRENT_MODALITY) {{
         const meta = (modality === CURRENT_MODALITY || (modality === 'gene' && CURRENT_MODALITY === 'rna'))
             ? DATA.features_meta
@@ -7955,15 +7981,40 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             console.warn('Unknown modality:', name);
             return;
         }}
+        // Remember whether the user was viewing a feature. Switching modality
+        // clears the specific gene (it may not exist in the new modality), but
+        // it should NOT drop the user back to annotation coloring — they picked
+        // a modality precisely to browse its features.
+        const wasFeatureMode = document.getElementById('default-source-gene')
+            ?.classList.contains('active') || false;
         _snapshotModalityGeneState(CURRENT_MODALITY);
         CURRENT_MODALITY = name;
         _restoreModalityGeneState(CURRENT_MODALITY);
         rebuildActiveFeatureIndex();
         populateGeneInputDatalist();
+        updateGeneInputPlaceholder();
         // Clear any active gene selection so cells don't render with a feature
         // that doesn't exist in the new modality.
         if (typeof activateViewerGene === 'function') {{
             try {{ await activateViewerGene(''); }} catch (e) {{ console.warn(e); }}
+        }}
+        // activateViewerGene('') forces the visual source back to annotation. If
+        // the user was in feature mode, restore it so they land ready to pick a
+        // channel in the new modality instead of collapsing to annotation.
+        if (wasFeatureMode) {{
+            const controls = document.getElementById('visual-default-controls');
+            controls?.classList.remove('annotation-mode');
+            controls?.classList.add('gene-mode');
+            document.getElementById('default-source-annotation')?.classList.remove('active');
+            document.getElementById('default-source-gene')?.classList.add('active');
+            const geneInput = document.getElementById('gene-input');
+            if (geneInput) {{
+                geneInput.value = '';
+                try {{ geneInput.focus(); }} catch (e) {{}}
+            }}
+            if (typeof setGeneDiscoveryOpen === 'function') {{
+                try {{ setGeneDiscoveryOpen(true); }} catch (e) {{}}
+            }}
         }}
         if (typeof renderGeneDiscoveryPanel === 'function') {{
             try {{ renderGeneDiscoveryPanel(); }} catch (e) {{}}
@@ -14558,6 +14609,33 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
         }}
 
+        // For a non-default modality with a small, enumerable feature set (e.g.
+        // a 16-plex protein panel), list every channel so the user can see what
+        // is available and click to load it — DE/marker suggestions don't cover
+        // non-RNA modalities, so this is the primary way to browse them.
+        const activeModalityFeatures = Array.isArray(FEATURES_BY_MODALITY[CURRENT_MODALITY])
+            ? FEATURES_BY_MODALITY[CURRENT_MODALITY]
+            : [];
+        if (
+            CURRENT_MODALITY !== DEFAULT_MODALITY_NAME &&
+            activeModalityFeatures.length &&
+            activeModalityFeatures.length <= 200
+        ) {{
+            const modLabel = getActiveModalityDescriptor()?.label || CURRENT_MODALITY;
+            const channelRows = `<div class="gene-token-grid">${{activeModalityFeatures.map((feat) =>
+                renderGeneTokenButton(feat, {{
+                    isActive: feat === currentGene,
+                    title: `Load ${{escapeHtml(modLabel)}} channel into the viewer`,
+                }})
+            ).join('')}}</div>`;
+            sections.push(`
+                <div class="gene-discovery-section">
+                    <div class="gene-discovery-label">${{escapeHtml(modLabel)}} channels (${{activeModalityFeatures.length}})</div>
+                    ${{channelRows}}
+                </div>
+            `);
+        }}
+
         const recentRows = recentGenes.length
             ? `<div class="gene-token-grid">${{recentGenes.map((gene) => renderGeneTokenButton(gene, {{
                 isActive: gene === currentGene,
@@ -19363,6 +19441,55 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const matchedRawKey = Object.keys(byColor).find(k => String(k).toLowerCase() === rawKey.toLowerCase());
         if (matchedRawKey && Array.isArray(byColor[matchedRawKey])) return byColor[matchedRawKey];
         return [];
+    }}
+
+    // Exploratory cell-level markers, computed only for clusters that pseudobulk
+    // DE could not test (confined to a single replicate/section). These carry NO
+    // biological replication, so they are surfaced separately with an explicit
+    // warning and never mixed into the pseudobulk DE token list.
+    function getCellLevelFallbackMarkers(annotationCol, category) {{
+        if (!annotationCol || category === null || category === undefined || category === BLEND_ALL_CATEGORIES) return [];
+        const byColor = (DATA.marker_genes_cell_level || {{}})[annotationCol];
+        if (!byColor || typeof byColor !== 'object') return [];
+        const rawCategory = resolveRawCategoryValue(annotationCol, category);
+        for (const key of [category, rawCategory, String(category), String(rawCategory)]) {{
+            if (Array.isArray(byColor[key])) return byColor[key];
+        }}
+        const catKey = String(category).toLowerCase();
+        const matched = Object.keys(byColor).find(k => String(k).toLowerCase() === catKey);
+        return (matched && Array.isArray(byColor[matched])) ? byColor[matched] : [];
+    }}
+
+    function renderCellLevelFallbackMarkers(annotationCol, category) {{
+        const genes = getCellLevelFallbackMarkers(annotationCol, category);
+        if (!genes.length) {{
+            return '<div class="marker-empty">No pseudobulk DE genes found.</div>';
+        }}
+        const method = String(DATA.marker_genes_cell_level_method || 'cell-level');
+        const methodLabel = method === 'wilcoxon' ? 'Wilcoxon rank-sum' : method;
+        const tokens = genes.map((gene) => {{
+            const loadable = isViewerGeneLoadable(gene);
+            const canonical = resolveCanonicalGeneName(gene);
+            return renderGeneTokenButton(gene, {{
+                allowUnknown: true,
+                disableActivation: !loadable,
+                isActive: loadable && !!canonical && canonical === currentGene,
+                showMeta: false,
+                title: loadable
+                    ? 'Exploratory cell-level marker (NOT replicated DE) — click to view expression'
+                    : 'Exploratory cell-level marker (NOT replicated DE)',
+            }});
+        }}).join('');
+        return `
+            <div class="marker-fallback-warning">
+                <strong>&#9888; Cell-level markers &mdash; NOT differential expression.</strong>
+                This cluster sits in a single section, so replicated pseudobulk DE could not run.
+                The genes below come from a cell-level ${{escapeHtml(methodLabel)}} one-vs-rest test that
+                treats individual cells as replicates (statistical double-dipping). Treat them as
+                exploratory hints only &mdash; do not report them as differentially expressed.
+            </div>
+            <div class="gene-token-grid">${{tokens}}</div>
+        `;
     }}
 
     function getAvailableComparisonColors() {{
@@ -26999,8 +27126,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 }});
                 if (!hasMatch) return '';
             }}
-            const geneButtons = genes.length
-                ? genes.map((entry) => {{
+            const bodyHtml = genes.length
+                ? `<div class="gene-token-grid">${{genes.map((entry) => {{
                     const loadable = isViewerGeneLoadable(entry.raw);
                     return renderGeneTokenButton(entry.raw, {{
                         allowUnknown: true,
@@ -27012,13 +27139,13 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                             ? 'Load pseudobulk DE gene into the viewer'
                             : 'This category-vs-balanced-rest gene is not available for expression viewing',
                     }});
-                }}).join('')
-                : '<div class="marker-empty">No pseudobulk DE genes found.</div>';
+                }}).join('')}}</div>`
+                : renderCellLevelFallbackMarkers(markerColorCol, key);
             const isSpotlit = linkedSpotlightEnabled && spotlightPinnedCategory === key;
             return `
                 <div class="marker-group">
                     <div class="marker-group-title${{isSpotlit ? ' is-spotlit' : ''}}" data-marker-category="${{escapeHtml(key)}}" title="Click to color the map by this annotation and highlight this cluster">${{renderAggCategoryChip(markerColorCol, key, catIdx)}}</div>
-                    <div class="gene-token-grid">${{geneButtons}}</div>
+                    ${{bodyHtml}}
                 </div>
             `;
         }}).filter(Boolean);
@@ -33749,6 +33876,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 modalitySelect.appendChild(opt);
             }}
             modalityControl.style.display = '';
+            // With >1 modality the color-source toggle's "Gene" wording is
+            // misleading (a protein channel isn't a gene). Use the neutral
+            // "Feature" label; the Modality dropdown disambiguates RNA vs protein.
+            const featureSourceBtn = document.getElementById('default-source-gene');
+            if (featureSourceBtn) featureSourceBtn.textContent = 'Feature';
+            const geneSrLabel = document.querySelector('label.sr-only[for="gene-input"]');
+            if (geneSrLabel) geneSrLabel.textContent = 'Feature';
+            updateGeneInputPlaceholder();
             modalitySelect.addEventListener('change', async (e) => {{
                 const target = e.target.value;
                 await setActiveModality(target);


### PR DESCRIPTION
## Summary

Fills a gap in cluster marker coverage and polishes the multimodal viewer UX. Builds on top of #14 (per-modality pseudobulk).

### Per-cluster cell-level fallback markers
The existing whole-annotation Welch fallback (`compute_cell_level_group_markers`) only fires when pseudobulk DE fails for an **entire** annotation (a fully single-sample dataset). It does **not** rescue an individual cluster that is confined to one replicate/section while the *rest* of the annotation runs pseudobulk DE normally — that cluster just shows "No pseudobulk DE genes found."

This adds a **per-category** rescue: for each such single-replicate cluster we compute one-vs-rest Wilcoxon markers and surface them in a **prominent, explicit warning box** stating they are cell-level, not replicated DE (statistical double-dipping — exploratory only).

- Stored under a separate `marker_genes_cell_level` key, so it never mixes with real pseudobulk DE tokens.
- Defers to any existing pseudobulk/Welch markers for the same category (no double-firing — verified).
- Eligibility is strict: a category is rescued only if it is missing from pseudobulk output **and** present in < 2 replicates with ≥ `min_cells` cells (i.e. pseudobulk genuinely could not run). Clusters that pseudobulk *tested and found nothing* keep the honest empty state.

### Multimodal viewer UX
- **Keep Feature view when switching modality** — selecting RNA/Protein was collapsing the viewer back to annotation coloring; it now stays in Feature mode so you can pick a channel in the new modality.
- **Gene Discovery panel lists non-RNA modality channels** (e.g. the 16 protein antibodies) plus a modality-aware input placeholder, since DE/marker suggestions don't cover non-RNA modalities.
- **Relabel color-source toggle** "Gene" → "Feature" when more than one modality is exported.
- Add the COMET multimodal Xenium sidecar **example script**.

## Testing
Regenerated the COMET multimodal Xenium viewer (46,003 cells, RNA + 16-plex protein, 4 cores). Fallback fires for the 12 single-replicate categories across `leiden_rna`/`leiden_protein`; cluster 0 now shows biologically sensible hepatocyte/HCC markers (EPCAM, DLK1, IGF2, PEG10…) under the explicit warning. Coexists with the existing Welch path with no double-firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)