### PR TITLE
Bastien/dev/multimodal viewer

### DIFF
--- a/FEATURES_SUMMARY.md
+++ b/FEATURES_SUMMARY.md
@@ -7,8 +7,8 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 - Python API for inspecting input metadata, loading `.h5ad`, `AnnData`, or SpatialData input, and exporting an HTML viewer.
 - Command-line interface (`karospace`) for scriptable exports and inspect-only metadata checks.
 - Desktop GUI (`karospace.gui`) for non-code export configuration.
-- Standalone HTML output that can be opened in a browser without a Python server when all required gene data is embedded.
-- Optional sidecar and `.karospace` package outputs for large gene payloads.
+- Standalone HTML output that can be opened in a browser without a Python server when all required feature data is embedded.
+- Optional sidecar and `.karospace` package outputs for large feature payloads.
 
 ## 2. Input and Export Payload
 
@@ -19,14 +19,14 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 - Section grouping uses `section_key` to group metadata by section.
 - Section metadata is split into `section_metadata` for visual filter chips and `section_metadata_extra` for stored section metadata that is not displayed as filter chips.
 - Cell annotation dropdowns use `main_cell_annotation` plus `cell_annotations`.
-- Optional payloads include UMAP coordinates, neighborhood graphs, image overlays, deconvolution keys, modules, sidecar genes, pseudobulk DE, pathways, spatial genes, category means, and gene correlations.
+- Optional payloads include UMAP coordinates, neighborhood graphs, image overlays, deconvolution keys, modules, sidecar feature catalogs, pseudobulk DE by modality, pathways, spatial features, category means, and feature correlations.
 
 ## 3. Introduction
 
 - The central grid is the primary spatial browsing surface.
 - Each visible section appears as a card with metadata, rotation controls, scalebar, outline color, and a canvas-rendered cell layer.
 - The section filter bar displays exported section-level metadata chips and can reduce the grid to specific stages, samples, conditions, regions, or batches.
-- The status area reports visible sections, exported cells, and exported genes.
+- The status area reports visible sections, exported cells, and exported features.
 - Downsampling status is displayed when the export contains fewer cells than the original input.
 
 ## 4. Helpers
@@ -49,21 +49,21 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 - The visual parameters button opens cell display controls such as size and opacity.
 - Default mode displays one layer across the grid.
 - Split mode compares two aligned visual layers in the same spatial panels.
-- Default source can be a cell annotation layer or a gene/expression layer.
+- Default source can be a cell annotation layer or a feature layer from the selected namespace.
 - The annotation selector chooses which cell-level annotation colors the grid.
-- Split layer A and split layer B can represent annotations, genes, or exported modalities.
+- Split layer A and split layer B can independently represent annotations, exported modalities, or module scores.
 - The split boundary slider controls where layer A ends and layer B begins within each spatial panel.
 
-## 7. Gene Expression
+## 7. Feature Values
 
-- Gene source changes the grid from annotation colors to gene or feature expression.
-- The gene discovery panel supports fuzzy search, keyboard navigation, recent genes, marker suggestions, spatial genes, correlated-gene suggestions, and module-related suggestions when those payloads exist.
-- The gene input accepts embedded genes and sidecar-loadable genes.
-- Gene expression scale controls adjust the visible color range and can be propagated across split gene comparison.
-- Sidecar mode keeps all gene expression vectors outside the HTML and fetches them from nearby sidecar files.
-- Multiple modalities can be selected when exported, for example RNA genes and protein features.
+- Feature source changes the grid from annotation colors to feature values.
+- The feature discovery panel supports fuzzy search, keyboard navigation, recent features, marker suggestions, spatial features, correlated-feature suggestions, and module-related suggestions when those payloads exist.
+- The feature input is scoped by the active namespace dropdown and accepts embedded or sidecar-loadable features.
+- Feature scale controls adjust the visible color range and can be propagated across split feature comparison.
+- Sidecar mode keeps feature vectors outside the HTML and fetches them from nearby sidecar files.
+- Multiple modalities can be selected when exported, for example RNA genes and protein features, and modules are exposed as their own feature namespace when present.
 - Requested `features` / `features-list` names are resolved against all exported modalities, and duplicate names are retained in every selected modality where they exist.
-- Genes not embedded in the HTML can still appear in DE tables or marker lists; sidecar-loadable genes can be fetched on demand.
+- Features not embedded in the HTML can still appear in DE tables or marker lists; sidecar-loadable features can be fetched on demand.
 
 ## 8. Spatial Selection
 
@@ -73,7 +73,7 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 - Regions can be cleared with the cross-format compare button.
 - Selected cells can be saved as a region annotation.
 - Selected cells can be cleared from the lasso/cross control or from the selection chip.
-- The cell search tool can select cells from annotation values, genes, or section metadata.
+- The cell search tool can select cells from annotation values, feature values, or section metadata.
 
 ## 9. Modal View
 
@@ -104,7 +104,7 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 
 ## 12. Insights Modes
 
-- Insights is the workspace for selected cells, regions, gene modules, and built-in analysis panels.
+- Insights is the workspace for selected cells, regions, modules, and built-in analysis panels.
 - Selection mode shows compact summaries for active lasso, UMAP, or cell search selections.
 - Region mode stores, selects, groups, imports, exports, recolors, and deletes user-created spatial regions or cell sets.
 - Module mode creates gene modules and displays module scores like expression layers.
@@ -114,9 +114,9 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 
 - The Selection summary reports active selected cells by section and main annotation.
 - Find More opens the full `Compare > Per cell > Selections` workflow.
-- Selection marker genes are calculated from selected cells using a two-sided Welch test.
+- Selection marker features are calculated from selected cells using a two-sided Welch test.
 - The selection comparison panel displays composition and expression summaries.
-- Expression summaries show mean expression and percent expressed for displayed genes.
+- Expression summaries show mean value and percent detected for displayed features.
 
 ## 14. Region Workflow
 
@@ -133,14 +133,14 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 
 - The module panel has a gene picker.
 - Creating a module scales each gene and computes an average module score.
-- Module scores can be loaded into the spatial viewer like gene expression.
+- Module scores can be loaded into the spatial viewer like feature layers.
 - Module definitions can be imported or exported as JSON.
 
 ## 16. Exploration Menu
 
-- The Visualization menu tree opens Overview, Genes, Compare, and Neighbors panels.
+- The Visualization menu tree opens Overview, Features, Compare, and Neighbors panels.
 - Overview summarizes section composition and metadata trends.
-- Genes focuses marker genes, spatial genes, per-cell distributions, and per-sample/category mean expression.
+- Features focuses marker features, spatial features, per-cell distributions, and per-sample/category means in the selected feature namespace.
 - Compare contains selection, region, annotation, pseudobulk, pathway, and relationship comparisons.
 - Neighbors contains spatial adjacency enrichment, interaction markers, and dispersion analysis.
 
@@ -152,17 +152,18 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 - `Overview > Sections` compares section-level composition.
 - Section composition can be shown as stacked bars or a heatmap.
 
-## 18. Exploration > Genes
+## 18. Exploration > Features
 
-- `Genes > Markers` lists pseudobulk-derived marker genes by category when available.
-- Marker genes can be displayed as compact lists or heatmaps.
-- `Genes > Spatial` shows Moran Index rankings computed at export on the full input cell set.
-- Spatial genes can be displayed as a ranked list or graph.
-- `Genes > Distribution > Per cell` summarizes expression distributions across categories for a selected gene.
+- `Features > Markers` lists pseudobulk-derived marker features by category when available.
+- Marker features can be displayed as compact lists or heatmaps.
+- `Features > Spatial` shows Moran Index rankings computed at export for each selected modality.
+- Spatial features can be displayed as a ranked list or graph.
+- `Features > Distribution > Per cell` summarizes value distributions across categories for a selected feature.
 - Per-cell distribution calculations use cells embedded in the HTML.
 - Per-cell distributions can be shown as a table or violin/boxplot.
-- `Genes > Distribution > Per sample` uses pseudobulk/category mean summaries for selected genes.
+- `Features > Distribution > Per sample` uses pseudobulk/category mean summaries for selected features.
 - Per-sample/category means can be shown as a table or barplot.
+- The feature namespace selector scopes marker, spatial, distribution, mean, and correlation panels to one modality or module namespace.
 
 ## 19. Exploration > Compare
 
@@ -171,13 +172,14 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 - `Compare > Per cell > Annotations` compares categories within the selected annotation using per-cell summaries.
 - `Compare > Per sample > Simple design` displays category-versus-category pseudobulk DE when exported.
 - Simple design includes raw tables, markers, MA plots, volcano plots, PCA, distance matrix diagnostics, and pathway enrichment.
-- Simple design metrics can be shown as Raw table, Genes, and Samples views.
+- Simple design metrics can be shown as Raw table, Features, and Samples views.
 - Pseudobulk DE can be exported for selected modalities with `pseudobulk_modalities` / `--pseudobulk-modalities`; the default is the dataset default modality.
-- DE genes are filtered with `padj < cutoff` and `abs(log2FC) >= cutoff`.
-- Genes below the minimum percent-expressed threshold in both compared groups are removed before `DeseqStats`, so they do not enter contrast-level multiple-testing correction.
+- The Simple design modality selector switches between available modality-scoped pseudobulk results.
+- DE features are filtered with `padj < cutoff` and `abs(log2FC) >= cutoff`.
+- Features below the minimum percent-detected threshold in both compared groups are removed before `DeseqStats`, so they do not enter contrast-level multiple-testing correction.
 - The pseudobulk marker lists are ordered by adjusted p-value then log2FC and can expand from the first displayed rows.
-- MA and volcano plots show non-significant genes, minimum-percent-expression filtered genes, and significant genes with updated legends.
-- Pathway Enrichment displays ORA pathways and GSEA enrichment in a separate panel.
+- MA and volcano plots show non-significant features, minimum-percent-detected filtered features, and significant features with updated legends.
+- Pathway Enrichment displays ORA pathways and GSEA enrichment in a separate panel for gene-compatible modalities.
 - ORA uses significant DE genes favoring the selected annotation.
 - ORA is shown as a dot plot with GeneRatio on x, pathway labels on y, dot size as gene count, fill color as `-log10(adjusted p-value)`, and border color indicating adjusted p-value threshold.
 - GSEA uses the retained ranked gene list after model and expression-percent filtering.
@@ -188,6 +190,7 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 ## 20. Exploration > Neighbors
 
 - `Neighbors > Enrichment` summarizes which annotation categories are spatially adjacent more or less often than expected.
+- `Neighbors > Interactions` has a modality selector for contact-conditioned marker features when multiple interaction marker payloads were exported.
 - Enrichment can be displayed as a table, network, or chord view.
 - Optional neighbor permutations add enrichment z-scores; with zero permutations, observed counts, shares, cell counts, and mean degree still remain available.
 - `Neighbors > Interactions` compares source cells based on which target categories they touch.
@@ -200,21 +203,22 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 
 - Pseudobulk DE uses raw counts grouped by replicate and annotation.
 - Pseudobulk DE and contact-conditioned interaction markers can run on selected modalities rather than always using the default RNA matrix.
+- Pathway enrichment is shown for gene-compatible modalities only; non-gene modalities report an unavailable state instead of an empty pathway panel.
 - Pseudobulk samples require at least `pseudobulk_min_cells_per_pseudobulk` cells before entering the shared DESeq2 fit.
 - Category-versus-category contrasts are extracted from a shared fit per annotation column.
 - Balanced-rest contrasts compare one category against the equally weighted mean of retained other categories.
 - Pairwise PCA and distance diagnostics are generated for selected pseudobulk comparisons.
 - ORA and GSEA are computed after Simple design pseudobulk DE and feed the Pathway Enrichment panel.
-- Spatially variable genes are computed with Moran's I for up to `spatial_variable_genes_n` variable genes on the full input cell set.
-- Category gene means are derived from embedded pseudobulk DE genes and feed per-sample/category distribution panels.
-- Gene correlations are computed from category means and feed related-gene suggestions.
+- Spatially variable features are computed with Moran's I per selected modality for up to `spatial_variable_genes_n` variable features on the full input cell set.
+- Category feature means are derived from pseudobulk DE feature summaries and feed per-sample/category distribution panels.
+- Feature correlations are computed from category means and feed related-feature suggestions.
 - Full-cell spatial dispersion is computed before HTML downsampling for the main cell annotation and requested `cell_annotations`.
 
 ## 22. Sharing and Storage
 
 - Embedded HTML stores viewer data directly in the HTML file.
 - Export reproducibility metadata is embedded by default so a shared HTML file can describe the arguments and resolved settings used to generate it; disable with `embed_reproducibility_info=False` or `--no-reproducibility-info`.
-- Sidecar mode writes all gene expression vectors to a manifest and binary shard directory for lazy loading over HTTP(S).
+- Sidecar mode writes feature vectors to a manifest and binary shard directory for lazy loading over HTTP(S).
 - `.karospace` packages wrap sidecar exports into one shareable ZIP-based package with a local or hosted loader.
 - Generated HTML is static; re-export is required to pick up new viewer code or new analytics.
 

--- a/FEATURES_SUMMARY.md
+++ b/FEATURES_SUMMARY.md
@@ -107,7 +107,7 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 - Insights is the workspace for selected cells, regions, modules, and built-in analysis panels.
 - Selection mode shows compact summaries for active lasso, UMAP, or cell search selections.
 - Region mode stores, selects, groups, imports, exports, recolors, and deletes user-created spatial regions or cell sets.
-- Module mode creates gene modules and displays module scores like expression layers.
+- Module mode creates feature modules and displays module scores like feature layers.
 - Exploration mode contains the Visualization menu tree and the built-in analysis panels.
 
 ## 13. Selection Workflow
@@ -115,8 +115,8 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 - The Selection summary reports active selected cells by section and main annotation.
 - Find More opens the full `Compare > Per cell > Selections` workflow.
 - Selection marker features are calculated from selected cells using a two-sided Welch test.
-- The selection comparison panel displays composition and expression summaries.
-- Expression summaries show mean value and percent detected for displayed features.
+- The selection comparison panel displays composition and feature-value summaries.
+- Feature-value summaries show mean value and percent detected for displayed features.
 
 ## 14. Region Workflow
 
@@ -131,8 +131,8 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 
 ## 15. Module Workflow
 
-- The module panel has a gene picker.
-- Creating a module scales each gene and computes an average module score.
+- The module panel has a feature picker.
+- Creating a module scales each feature and computes an average module score.
 - Module scores can be loaded into the spatial viewer like feature layers.
 - Module definitions can be imported or exported as JSON.
 
@@ -182,7 +182,7 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 - Pathway Enrichment displays ORA pathways and GSEA enrichment in a separate panel for gene-compatible modalities.
 - ORA uses significant DE genes favoring the selected annotation.
 - ORA is shown as a dot plot with GeneRatio on x, pathway labels on y, dot size as gene count, fill color as `-log10(adjusted p-value)`, and border color indicating adjusted p-value threshold.
-- GSEA uses the retained ranked gene list after model and expression-percent filtering.
+- GSEA uses the retained ranked gene list after model and percent-detected filtering.
 - GSEA profiles can be selected from a pathway dropdown and are displayed as enrichment-profile plots with hits and ranked-metric context.
 - ORA and GSEA sections can switch between plot and raw table and include download buttons.
 - `Compare > Relationships` shows how categories from two annotations map to each other, with controls to select the second annotation, swap direction, and export the correspondence table.
@@ -209,7 +209,7 @@ This document summarizes what the generated KaroSpace HTML viewer currently disp
 - Balanced-rest contrasts compare one category against the equally weighted mean of retained other categories.
 - Pairwise PCA and distance diagnostics are generated for selected pseudobulk comparisons.
 - ORA and GSEA are computed after Simple design pseudobulk DE and feed the Pathway Enrichment panel.
-- Spatially variable features are computed with Moran's I per selected modality for up to `spatial_variable_genes_n` variable features on the full input cell set.
+- Spatially variable features are computed with Moran's I per selected modality for up to `spatial_variable_features_n` variable features on the full input cell set.
 - Category feature means are derived from pseudobulk DE feature summaries and feed per-sample/category distribution panels.
 - Feature correlations are computed from category means and feed related-feature suggestions.
 - Full-cell spatial dispersion is computed before HTML downsampling for the main cell annotation and requested `cell_annotations`.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,19 @@
+# KaroSpace Terminology
+
+## Feature
+
+Use **feature** as the generic label for a displayable per-cell or per-spot value in a
+modality. A feature can be an RNA gene, protein, peak, genomic range, bin, module,
+or another modality-specific measurement.
+
+Use feature in generic UI labels, CLI help, export summaries, logs, and docs when
+the current modality may be anything other than RNA/gene expression.
+
+## Gene
+
+Use **gene** only when the context is specifically gene expression, RNA/rna data,
+pathway gene sets, ORA/GSEA gene universes, or compatibility fields whose persisted
+schema name is already gene-based.
+
+Legacy public option names and payload keys that include `gene` may remain as
+compatibility aliases, but new user-facing names should prefer `feature`.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Visit [KaroSpace Website](https://karospace.se/).
 - [x] **Region-to-region comparison** — Compare saved regions directly in the viewer, export JSON/CSV reports, and search top hits
 - [x] **Cell search** — Select cells with query syntax based on annotations, features, or section metadata, then reuse the selection in summaries and comparisons
 - [x] **Split screen** — Compare two variables side-by-side in the modal (`Annotation`, a selected feature modality, or `Module`)
-- [x] **Gene modules** — Build custom gene sets, compute averaged module scores, display them like expression layers, and import/export module definitions
+- [x] **Feature modules** — Build custom feature sets, compute averaged module scores, display them like feature layers, and import/export module definitions
 - [x] **Legend controls** — Toggle/hide categories and spotlight one class across grid and UMAP
 - [x] **Feature exploration** — Search within a selected modality, inspect value distributions, review marker features, spatial features, category means, and related-feature suggestions
-- [x] **Per cell comparison** — Live comparison of cell selections or regions with table and graphs visualization (Welch test scores, log2FC, mean, expression percentage)
+- [x] **Per cell comparison** — Live comparison of cell selections or regions with table and graph visualization (Welch test scores, log2FC, mean, percent detected)
 - [x] **Per sample comparison** — Precomputed pseudobulk differential feature analysis using DESeq2 (PCA, distance matrices, volcano plots) with pathway enrichment for gene-compatible modalities.
 - [x] **Neighbor graph tools** — Graph overlay, hover rings (1–3 hops), enrichment, interactions, and dispersion summaries when `adata.obsp` contains a spatial graph
 - [x] **Quality-of-life controls** — Hideable toolbar, screenshots, light/dark theme toggle, buttons explanation, keyboard shortcuts, and adjustable spot size
@@ -135,12 +135,12 @@ export_to_html(
         "leiden",
         "niche",
     ],
-    features=[                      # Pre-load features for expression view; matched across selected modalities
+    features=[                      # Pre-load features for visualization; matched across selected modalities
         "Cd4",
         "Cd8a",
         "Gfap",
     ],
-    features_list=None,             # Optional text file with one feature/gene per line
+    features_list=None,             # Optional text file with one feature per line
     feature_encoding="auto",        # "auto" | "dense" | "sparse"
     feature_storage="embedded",     # "embedded" | "sidecar"
     feature_manifest_path=None,          # Optional manifest path; defaults to viewer.features.json
@@ -266,8 +266,8 @@ karospace your_data.h5ad \
 | `--inspect-input` | Read input metadata and exit without building sections, downsampling, exporting HTML, or running analytics | off |
 | `--main-cell-annotation` | Main cell-annotation column shown first in the viewer | `leiden` |
 | `--cell-annotations` | Comma-separated extra cell obs annotation columns to embed as selectable cell annotations | empty |
-| `--features` | Comma-separated features or genes to preload. Requested names are matched against every exported `--modalities` namespace, so the same feature name is included in each selected modality where it exists. Significant pseudobulk DE features are embedded automatically up to the per-comparison cap | empty |
-| `--features-list` | Text file with one feature/gene per line; combined with `--features`, deduplicated, and resolved across selected modalities | empty |
+| `--features` | Comma-separated features to preload. Requested names are matched against every exported `--modalities` namespace, so the same feature name is included in each selected modality where it exists. Significant pseudobulk DE features are embedded automatically up to the per-comparison cap | empty |
+| `--features-list` | Text file with one feature per line; combined with `--features`, deduplicated, and resolved across selected modalities | empty |
 | `--section-metadata` | Comma-separated obs columns to use as section metadata shown in the visual params bar/filter chips | empty |
 | `--section-metadata-extra` | Comma-separated obs columns to store as section metadata without visual params bar/filter chips | empty |
 | `--metadata-value-order` | JSON object mapping metadata columns to ordered value lists | empty |
@@ -300,7 +300,7 @@ karospace your_data.h5ad \
 | `--neighbor-stats-seed` | Random seed for neighbor enrichment permutations | `0` |
 | `--interaction-markers` | Contact-conditioned pseudobulk marker mode (`auto`, `None`) | `auto` |
 | `--interaction-markers-top-targets` | Target categories evaluated per source for contact-conditioned markers | `5` |
-| `--interaction-markers-top-genes` | Top DE features kept per source-target interaction | `20` |
+| `--interaction-markers-top-features` | Top DE features kept per source-target interaction | `20` |
 | `--interaction-markers-min-cells` | Minimum cells per replicate contact+ and contact- pseudobulk sample | `30` |
 | `--interaction-markers-min-neighbors` | Minimum target neighbors to classify contact+ source cells | `1` |
 | `--pseudobulk` | Category pseudobulk DE mode (`auto`, `None`) | `auto` |
@@ -310,7 +310,7 @@ karospace your_data.h5ad \
 | `--pseudobulk-modalities` | Comma-separated modalities to run category pseudobulk DE and contact-conditioned interaction markers on. Use `all` for all detected modalities. This is independent of `--modalities`, which controls feature export for the viewer | dataset default modality |
 | `--pseudobulk-simple-constrast-categories` | Categories to report in category-versus-category contrasts. With `--pseudobulk-additional-annotations`, use annotation-specific JSON wrapped in single quotes, such as `'{"cell_type":["Astrocyte","B cell"],"region":["Cortex"]}'`, or a nested list matching `[main-cell-annotation, additional...]` | empty |
 | `--pseudobulk-min-cell-counts` | Exclude cells with fewer than this many total raw counts before pseudobulk aggregation; use `0` to disable | `0` |
-| `--pseudobulk-min-gene-counts` | Exclude features with fewer than this many total raw pseudobulk counts in the shared DESeq2 fit; use `0` to disable | `0` |
+| `--pseudobulk-min-feature-counts` | Exclude features with fewer than this many total raw pseudobulk counts in the shared DESeq2 fit; use `0` to disable | `0` |
 | `--pseudobulk-min-cells-per-pseudobulk` | Minimum cells required in each replicate × annotation pseudobulk sample before it can enter the shared DESeq2 fit | `20` |
 | `--pseudobulk-min-replicates` | Minimum paired replicates required for each reported contrast | `2` |
 | `--pseudobulk-min-pct-expressed` | Minimum fraction of cells with nonzero feature values required in at least one compared group before DE results are reported; values >1 are interpreted as percentages | `0` |
@@ -326,13 +326,15 @@ karospace your_data.h5ad \
 | `--pathway-min-overlap` | Minimum pathway/query gene overlap for ORA/GSEA reporting | `3` |
 | `--pathway-gsea-permutations` | Permutations for compact preranked GSEA p-values | `100` |
 | `--section-rotations` | Comma-separated `section_id:angle` pairs | empty |
-| `--gene-correlation-top-n` | Correlated features shown per embedded feature in discovery panel | `5` |
-| `--category-means-n-genes` | Maximum embedded pseudobulk-DE features used for category mean summaries; use `0` to disable | `500` |
-| `--spatial-variable-genes-n` | Top variable features scored with Moran's I; use `0` to disable | `20` |
+| `--feature-correlation-top-n` | Correlated features shown per embedded feature in discovery panel | `5` |
+| `--category-means-n-features` | Maximum embedded pseudobulk-DE features used for category mean summaries; use `0` to disable | `500` |
+| `--spatial-variable-features-n` | Top variable features scored with Moran's I; use `0` to disable | `20` |
 | `--deconvolutions` | JSON object mapping deconvolution labels to obs/obsm keys | empty |
 | `--section-images` | JSON object mapping section IDs to image paths/specs | empty |
 | `--section-images-max-px` | Maximum image dimension when embedding section images | `4096` |
 | `--scalebar-unit` | Unit label for the scalebar | `μm` |
+
+Legacy gene-named aliases for feature-count options are still accepted for existing scripts, but new commands should use the feature-named options above.
 
 > [!NOTE]
 > See [FEATURES_SUMMARY.md](FEATURES_SUMMARY.md) for a guided overview of the main HTML viewer features.

--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ Visit [KaroSpace Website](https://karospace.se/).
 - [x] **Cells selection composition** — Selected-cell totals and per-type counts with expandable scrollable lists
 - [x] **Polygon regions** — Save lasso selections as persistent regions, reorder labels, and export JSON for downstream integration
 - [x] **Region-to-region comparison** — Compare saved regions directly in the viewer, export JSON/CSV reports, and search top hits
-- [x] **Cell search** — Select cells with query syntax based on annotations, genes, or section metadata, then reuse the selection in summaries and comparisons
-- [x] **Split screen** — Compare two variables side-by-side in the modal (`Annotation`, `Modality` or `Module`)
+- [x] **Cell search** — Select cells with query syntax based on annotations, features, or section metadata, then reuse the selection in summaries and comparisons
+- [x] **Split screen** — Compare two variables side-by-side in the modal (`Annotation`, a selected feature modality, or `Module`)
 - [x] **Gene modules** — Build custom gene sets, compute averaged module scores, display them like expression layers, and import/export module definitions
 - [x] **Legend controls** — Toggle/hide categories and spotlight one class across grid and UMAP
-- [x] **Gene exploration** — Search genes, inspect expression distributions, review marker genes, spatial genes, category means, and related-gene suggestions
+- [x] **Feature exploration** — Search within a selected modality, inspect value distributions, review marker features, spatial features, category means, and related-feature suggestions
 - [x] **Per cell comparison** — Live comparison of cell selections or regions with table and graphs visualization (Welch test scores, log2FC, mean, expression percentage)
-- [x] **Per sample comparison** — Precomputed pseudobulk differential gene expression using DESeq2 (PCA, distance matrices, volcano plots) and pathway enrichments.
+- [x] **Per sample comparison** — Precomputed pseudobulk differential feature analysis using DESeq2 (PCA, distance matrices, volcano plots) with pathway enrichment for gene-compatible modalities.
 - [x] **Neighbor graph tools** — Graph overlay, hover rings (1–3 hops), enrichment, interactions, and dispersion summaries when `adata.obsp` contains a spatial graph
 - [x] **Quality-of-life controls** — Hideable toolbar, screenshots, light/dark theme toggle, buttons explanation, keyboard shortcuts, and adjustable spot size
 - [x] **Standalone export** — One self-contained HTML file, no backend required
-- [x] **Compact sidecar** — Keep large gene matrices outside the HTML with lazy-loaded sidecar manifests and binary shards for lighter initial viewer files
+- [x] **Compact sidecar** — Keep large feature matrices outside the HTML with lazy-loaded sidecar manifests and binary shards for lighter initial viewer files
 - [x] **Shareable packages** — Export as `.karospace` bundles (ZIP + viewer HTML)
 
 ## Quick Start
@@ -140,11 +140,12 @@ export_to_html(
         "Cd8a",
         "Gfap",
     ],
-    features_list=None,             # Optional text file with one gene per line
+    features_list=None,             # Optional text file with one feature/gene per line
     feature_encoding="auto",        # "auto" | "dense" | "sparse"
     feature_storage="embedded",     # "embedded" | "sidecar"
     feature_manifest_path=None,          # Optional manifest path; defaults to viewer.features.json
     feature_sparse_zero_threshold=0.8,
+    modalities=["rna", "protein"],  # Feature namespaces to export into the viewer
     neighbor_stats_annotations=["cell_type"],
     neighbor_stats_permutations=20,
     pseudobulk="auto",           # Use None to disable category pseudobulk DE
@@ -230,10 +231,11 @@ karospace your_data.h5ad \
   --downsample 30000 \
   --cell-annotations leiden, niche \
   --features Cd4,Cd8a,Gfap \
-  --features-list genes.txt \
+  --features-list features.txt \
   --feature-encoding auto \
   --feature-storage embedded \
   --feature-sparse-zero-threshold 0.8 \
+  --modalities rna,protein \
   --neighbor-stats-annotations cell_type \
   --neighbor-permutations 20 \
   --pseudobulk auto \
@@ -264,7 +266,7 @@ karospace your_data.h5ad \
 | `--inspect-input` | Read input metadata and exit without building sections, downsampling, exporting HTML, or running analytics | off |
 | `--main-cell-annotation` | Main cell-annotation column shown first in the viewer | `leiden` |
 | `--cell-annotations` | Comma-separated extra cell obs annotation columns to embed as selectable cell annotations | empty |
-| `--features` | Comma-separated features or genes to preload. Requested names are matched against every exported `--modalities` namespace, so the same feature name is included in each selected modality where it exists. Significant pseudobulk DE genes are embedded automatically up to the per-comparison cap | empty |
+| `--features` | Comma-separated features or genes to preload. Requested names are matched against every exported `--modalities` namespace, so the same feature name is included in each selected modality where it exists. Significant pseudobulk DE features are embedded automatically up to the per-comparison cap | empty |
 | `--features-list` | Text file with one feature/gene per line; combined with `--features`, deduplicated, and resolved across selected modalities | empty |
 | `--section-metadata` | Comma-separated obs columns to use as section metadata shown in the visual params bar/filter chips | loader defaults |
 | `--section-metadata-extra` | Comma-separated obs columns to store as section metadata without visual params bar/filter chips | empty |
@@ -286,11 +288,11 @@ karospace your_data.h5ad \
 | `--viewer-info-html-file` | Path to an HTML fragment shown in the viewer Info tab | empty |
 | `--tutorial` | (in development) Embed the static Story Mode HTML tutorial; users start it from the graduation-cap control and move through prepared viewer states with Next/Back | off |
 | `--no-reproducibility-info` | Do not embed export arguments, thresholds, cutoffs, inputs, and resolved settings in the HTML reproducibility popover | off |
-| `--feature-encoding` | Gene vector encoding (`auto`, `dense`, `sparse`) | `auto` |
-| `--feature-value-encoding` | Sidecar/package gene value encoding for binary shards (`uint16`, `uint8`) | `uint16` |
-| `--feature-storage` | Feature storage mode: `embedded` stores requested/top DE expression vectors in the HTML; `sidecar` stores all gene expression vectors outside the HTML | `embedded` |
+| `--feature-encoding` | Feature vector encoding (`auto`, `dense`, `sparse`) | `auto` |
+| `--feature-value-encoding` | Sidecar/package feature value encoding for binary shards (`uint16`, `uint8`) | `uint16` |
+| `--feature-storage` | Feature storage mode: `embedded` stores requested/top DE feature vectors in the HTML; `sidecar` stores all feature vectors outside the HTML | `embedded` |
 | `--feature-manifest-path` | Path for the feature sidecar manifest JSON | auto |
-| `--feature-sidecar-shard-size` | Genes/features per sidecar shard | `256` |
+| `--feature-sidecar-shard-size` | Features per sidecar shard | `256` |
 | `--feature-sparse-zero-threshold` | Zero fraction threshold for `auto` sparse encoding | `0.8` |
 | `--modalities` | Comma-separated modalities to export | all detected |
 | `--neighbor-permutations` | Permutations for neighbor enrichment z-scores | `auto` |
@@ -298,7 +300,7 @@ karospace your_data.h5ad \
 | `--neighbor-stats-seed` | Random seed for neighbor enrichment permutations | `0` |
 | `--interaction-markers` | Contact-conditioned pseudobulk marker mode (`auto`, `None`) | `auto` |
 | `--interaction-markers-top-targets` | Target categories evaluated per source for contact-conditioned markers | `5` |
-| `--interaction-markers-top-genes` | Top DE genes kept per source-target interaction | `20` |
+| `--interaction-markers-top-genes` | Top DE features kept per source-target interaction | `20` |
 | `--interaction-markers-min-cells` | Minimum cells per replicate contact+ and contact- pseudobulk sample | `30` |
 | `--interaction-markers-min-neighbors` | Minimum target neighbors to classify contact+ source cells | `1` |
 | `--pseudobulk` | Category pseudobulk DE mode (`auto`, `None`) | `auto` |
@@ -308,25 +310,25 @@ karospace your_data.h5ad \
 | `--pseudobulk-modalities` | Comma-separated modalities to run category pseudobulk DE and contact-conditioned interaction markers on. Use `all` for all detected modalities. This is independent of `--modalities`, which controls feature export for the viewer | dataset default modality |
 | `--pseudobulk-simple-constrast-categories` | Categories to report in category-versus-category contrasts. With `--pseudobulk-additional-annotations`, use annotation-specific JSON wrapped in single quotes, such as `'{"cell_type":["Astrocyte","B cell"],"region":["Cortex"]}'`, or a nested list matching `[main-cell-annotation, additional...]` | empty |
 | `--pseudobulk-min-cell-counts` | Exclude cells with fewer than this many total raw counts before pseudobulk aggregation; use `0` to disable | `0` |
-| `--pseudobulk-min-gene-counts` | Exclude genes with fewer than this many total raw pseudobulk counts in the shared DESeq2 fit; use `0` to disable | `0` |
+| `--pseudobulk-min-gene-counts` | Exclude features with fewer than this many total raw pseudobulk counts in the shared DESeq2 fit; use `0` to disable | `0` |
 | `--pseudobulk-min-cells-per-pseudobulk` | Minimum cells required in each replicate × annotation pseudobulk sample before it can enter the shared DESeq2 fit | `20` |
 | `--pseudobulk-min-replicates` | Minimum paired replicates required for each reported contrast | `2` |
-| `--pseudobulk-min-pct-expressed` | Minimum fraction of cells expressing a gene required in at least one compared group before DE results are reported; values >1 are interpreted as percentages | `0` |
+| `--pseudobulk-min-pct-expressed` | Minimum fraction of cells with nonzero feature values required in at least one compared group before DE results are reported; values >1 are interpreted as percentages | `0` |
 | `--pseudobulk-p-adjust-method` | Multiple-testing correction method (`fdr_bh`, `bonferroni`, `holm`, `none`) | `fdr_bh` |
-| `--pseudobulk-padj-cutoff` | Adjusted p-value threshold for DE calls and plot coloring; DE genes must pass `padj < cutoff` | `0.05` |
+| `--pseudobulk-padj-cutoff` | Adjusted p-value threshold for DE calls and plot coloring; DE features must pass `padj < cutoff` | `0.05` |
 | `--pseudobulk-log2fc-cutoff` | Absolute log2FC cutoff for volcano highlighting and DE table inclusion | `1` |
 | `--pseudobulk-deseq2-fit-type` | PyDESeq2 dispersion trend fit type; use `mean` to avoid parametric trend fallback warnings | `parametric` |
 | `--pseudobulk-n-cpus` | CPU workers for the shared DESeq2 fit and maximum parallel shared-fit contrasts | `1` |
-| `--pseudobulk-embed-top-n-per-comparison` | Significant DE genes to auto-embed per category/contact comparison in embedded mode; ignored by sidecar mode because all gene expression vectors are sidecar-loaded | `2` |
+| `--pseudobulk-embed-top-n-per-comparison` | Significant DE features to auto-embed per category/contact comparison in embedded mode; ignored by sidecar mode because feature vectors are sidecar-loaded | `2` |
 | `--pathway-gmt` | GMT pathway file(s) for ORA/GSEA after Simple design DE; omitted uses cached/default Reactome when available, then falls back to GSEApy/Enrichr | Reactome |
 | `--pathway-organism` | Organism used for default Reactome loading, e.g. `Human` or `Mouse` | `Mouse` |
 | `--pathway-top-n` | Maximum ORA/GSEA pathways stored per direction and comparison | `10` |
 | `--pathway-min-overlap` | Minimum pathway/query gene overlap for ORA/GSEA reporting | `3` |
 | `--pathway-gsea-permutations` | Permutations for compact preranked GSEA p-values | `100` |
 | `--section-rotations` | Comma-separated `section_id:angle` pairs | empty |
-| `--gene-correlation-top-n` | Correlated genes shown per embedded gene in discovery panel | `5` |
-| `--category-means-n-genes` | Maximum embedded pseudobulk-DE genes used for category mean summaries; use `0` to disable | `500` |
-| `--spatial-variable-genes-n` | Top variable genes scored with Moran's I; use `0` to disable | `20` |
+| `--gene-correlation-top-n` | Correlated features shown per embedded feature in discovery panel | `5` |
+| `--category-means-n-genes` | Maximum embedded pseudobulk-DE features used for category mean summaries; use `0` to disable | `500` |
+| `--spatial-variable-genes-n` | Top variable features scored with Moran's I; use `0` to disable | `20` |
 | `--deconvolutions` | JSON object mapping deconvolution labels to obs/obsm keys | empty |
 | `--section-images` | JSON object mapping section IDs to image paths/specs | empty |
 | `--section-images-max-px` | Maximum image dimension when embedding section images | `4096` |
@@ -403,11 +405,21 @@ If the export is downsampled, the visible graph overlay and neighbor-hover contr
 
 `Insights → Neighbors → Enrichment` and `Interactions` use neighbor composition statistics for the selected Exploration annotation. If no graph or no stats exist for that annotation, the viewer shows a yellow warning and lists the annotations that do have neighbor stats. `Insights → Neighbors → Dispersion` is computed from all cells before HTML downsampling for the main cells annotation and any requested `cell_annotations`, then summarizes whether each category is clustered, random, or dispersed relative to the observed all-cell layout.
 
+### Multimodal feature viewer
+
+When multiple modalities are exported with `modalities=["rna", "protein"]` or `--modalities rna,protein`, the viewer treats each modality as its own feature namespace. In Default mode, switch from `Annotation` to `Feature`, then use the feature-namespace dropdown beside the source switch to choose RNA, protein, or `Module` when modules exist. The search box is scoped to that namespace, so a feature name shared by RNA and protein is loaded from the active namespace rather than shown with modality badges.
+
+Split view keeps an independent source and feature namespace for layer A and layer B. This allows comparisons such as RNA feature versus protein feature, annotation versus protein, or module score versus RNA without changing the main visual namespace.
+
+`Insights → Features` has its own feature-namespace selector for marker features, spatial features, per-cell distributions, per-sample/category means, and related-feature suggestions. `Insights → Compare → Per sample → Simple design` has a pseudobulk modality selector, and `Insights → Neighbors → Interactions` has an interaction-marker modality selector. Exported CSV/SVG filenames include the selected modality where a result is modality-specific.
+
+Pathway enrichment is gene-compatible only. It is computed for RNA/gene-like modalities and reported as unavailable for unsupported modalities unless a future export provides an explicit feature-to-gene mapping.
+
 ### Optional pseudobulk category selection
 
-Pseudobulk category DE is precomputed automatically for the initial `main cells annotation` column unless `pseudobulk=None` / `--pseudobulk None` is used, and shown in `Insights → Compare → Per sample → Simple design`. KaroSpace aggregates raw counts by replicate and annotation, keeps replicate × annotation pseudobulk samples with at least `pseudobulk_min_cells_per_pseudobulk` / `--pseudobulk-min-cells-per-pseudobulk` cells, fits one shared `~ replicate + annotation` DESeq2 model per annotation column, then extracts category-versus-category contrasts. It also extracts a balanced-rest contrast for every category: the category minus the equally weighted mean of all other retained annotation categories. Genes that do not reach `pseudobulk_min_pct_expressed` / `--pseudobulk-min-pct-expressed` in at least one compared group are removed from reported DE results, so they do not enter the contrast-level multiple-testing correction applied by KaroSpace. Pairwise PCA/distance diagnostics are generated automatically for selected category pairs.
+Pseudobulk category DE is precomputed automatically for the initial `main cells annotation` column unless `pseudobulk=None` / `--pseudobulk None` is used, and shown in `Insights → Compare → Per sample → Simple design`. KaroSpace aggregates raw counts by replicate and annotation, keeps replicate × annotation pseudobulk samples with at least `pseudobulk_min_cells_per_pseudobulk` / `--pseudobulk-min-cells-per-pseudobulk` cells, fits one shared `~ replicate + annotation` DESeq2 model per annotation column, then extracts category-versus-category contrasts. It also extracts a balanced-rest contrast for every category: the category minus the equally weighted mean of all other retained annotation categories. Features that do not reach `pseudobulk_min_pct_expressed` / `--pseudobulk-min-pct-expressed` in at least one compared group are removed from reported DE results, so they do not enter the contrast-level multiple-testing correction applied by KaroSpace. Pairwise PCA/distance diagnostics are generated automatically for selected category pairs.
 
-By default, pseudobulk DE and contact-conditioned interaction markers run on the dataset default modality, usually `rna`. Use `pseudobulk_modalities=["rna", "protein"]` in Python or `--pseudobulk-modalities rna,protein` on the CLI to run those analyses on selected modalities, or use `all` for every detected modality. When multiple pseudobulk modalities are selected, the first selected modality remains available through the legacy `pseudobulk_de` / `interaction_markers` payloads, and all selected results are stored in modality-keyed payloads.
+By default, pseudobulk DE and contact-conditioned interaction markers run on the dataset default modality, usually `rna`. Use `pseudobulk_modalities=["rna", "protein"]` in Python or `--pseudobulk-modalities rna,protein` on the CLI to run those analyses on selected modalities, or use `all` for every detected modality. Results are stored only in modality-keyed payloads such as `pseudobulk_de_by_modality`, `interaction_markers_by_modality`, `category_feature_means_by_modality`, `feature_correlations_by_modality`, `spatial_variable_features_by_modality`, and `pathway_settings_by_modality`.
 
 When selecting specific pairwise categories from the command line, wrap listed values in single quotes:
 
@@ -423,11 +435,11 @@ KaroSpace has three practical export modes:
 
 | Mode | Output | Best for | How to open |
 | --- | --- | --- | --- |
-| Embedded HTML | `viewer.html` | Small to medium gene payloads, easiest sharing | Double-click or open the file in a browser |
-| Sidecar viewer | `viewer.html` + `viewer.features.json` + `viewer.features/` | Large gene payloads with lazy gene loading | Serve the directory over HTTP(S), then open the HTML URL |
+| Embedded HTML | `viewer.html` | Small to medium feature payloads, easiest sharing | Double-click or open the file in a browser |
+| Sidecar viewer | `viewer.html` + `viewer.features.json` + `viewer.features/` | Large feature payloads with lazy loading | Serve the directory over HTTP(S), then open the HTML URL |
 | `.karospace` package | `viewer.karospace` + optional `viewer.loader.html` | One-file sharing of a sidecar viewer | Drop the package into the hosted loader or the generated local loader |
 
-Sidecar mode keeps the initial HTML smaller by moving all gene expression vectors into a manifest and binary shard files. The viewer fetches those shards only when a gene is needed. This is useful when many genes or modalities would make a single HTML file too large.
+Sidecar mode keeps the initial HTML smaller by moving feature vectors into a manifest and binary shard files. The viewer fetches those shards only when a feature is needed. This is useful when many features or modalities would make a single HTML file too large.
 
 ### Create a sidecar viewer
 
@@ -454,7 +466,7 @@ export_to_html(
     output_path="viewer.html",
     main_cell_annotation="cell_type",
     features=["Cd4", "Cd8a", "Gfap"],
-    features_list="genes.txt",
+    features_list="features.txt",
     feature_storage="sidecar",
     feature_manifest_path="viewer.features.json"
 )
@@ -472,7 +484,7 @@ viewer.features/
 ```
 
 > [!IMPORTANT]
-> Keep all three elements together. The HTML contains the viewer and embedded summary data, but no gene expression vectors in sidecar mode; `viewer.features.json` is the sidecar manifest; `viewer.features/` contains the binary feature shards.
+> Keep all three elements together. The HTML contains the viewer and embedded summary data, but no feature vectors in sidecar mode; `viewer.features.json` is the sidecar manifest; `viewer.features/` contains the binary feature shards.
 
 ### Open a sidecar viewer
 
@@ -551,7 +563,7 @@ karospace package-sidecar viewer.html \
 ### Sidecar troubleshooting
 
 > [!TIP]
-> - **The viewer opens but genes do not load**: check that the HTML is served over HTTP(S), not opened with `file://`.
+> - **The viewer opens but features do not load**: check that the HTML is served over HTTP(S), not opened with `file://`.
 > - **404 for `viewer.features.json` or `.bin` shards**: keep `viewer.html`, `viewer.features.json`, and `viewer.features/` in the same relative layout used at export time.
 > - **Custom `--feature-manifest-path`**: for normal sidecar HTML it may be a path; for direct `.karospace` export it must be a filename inside the package.
 > - **Large packages**: increase `--feature-sidecar-shard-size` for fewer shard files, decrease it for smaller individual requests.

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ karospace your_data.h5ad \
 | `--cell-annotations` | Comma-separated extra cell obs annotation columns to embed as selectable cell annotations | empty |
 | `--features` | Comma-separated features or genes to preload. Requested names are matched against every exported `--modalities` namespace, so the same feature name is included in each selected modality where it exists. Significant pseudobulk DE features are embedded automatically up to the per-comparison cap | empty |
 | `--features-list` | Text file with one feature/gene per line; combined with `--features`, deduplicated, and resolved across selected modalities | empty |
-| `--section-metadata` | Comma-separated obs columns to use as section metadata shown in the visual params bar/filter chips | loader defaults |
+| `--section-metadata` | Comma-separated obs columns to use as section metadata shown in the visual params bar/filter chips | empty |
 | `--section-metadata-extra` | Comma-separated obs columns to store as section metadata without visual params bar/filter chips | empty |
 | `--metadata-value-order` | JSON object mapping metadata columns to ordered value lists | empty |
 | `--metadata-max-columns` | Limit metadata columns used, preserving order | empty |
@@ -373,7 +373,7 @@ a different target key.
 
 ### Optional metadata
 
-Use `section_metadata=[...]` / `--section-metadata ...` for section-level obs columns that should appear in the visual params bar and filter chips. Use `section_metadata_extra=[...]` / `--section-metadata-extra ...` for section-level metadata that should be stored in the viewer payload but not shown as filter chips.
+Use `section_metadata=[...]` / `--section-metadata ...` for section-level obs columns that should appear in the visual params bar and filter chips. If omitted, no section metadata columns are added by default. Use `section_metadata_extra=[...]` / `--section-metadata-extra ...` for section-level metadata that should be stored in the viewer payload but not shown as filter chips.
 
 - `course` — Experimental phase (e.g., `"naive"`, `"peak_I"`); sections are outlined by this column when `outlineby="course"` / `--outlineby course` is used
 - `region`, `condition`, `timepoint` — Typical section metadata shown as filter chips

--- a/docs/research/features-spatial-calculation.md
+++ b/docs/research/features-spatial-calculation.md
@@ -1,0 +1,59 @@
+# Features Spatial Calculation
+
+## Short Answer
+
+The concept named approximately "Features Spatial" is the HTML viewer's `Features > Spatial` panel. It is not calculated in the browser; it is precomputed during export as `spatial_variable_features_by_modality` and rendered later as Moran Index rankings. The generated UI has a `Features` branch with a `Spatial` leaf, and the tutorial calls this the "Features Spatial panel" that shows Moran Index rankings computed at export. Citations: `karospace/exporter.py:25615-25627`, `karospace/exporter.py:9664-9672`, `karospace/data_loader.py:3342-3349`, `karospace/data_loader.py:3411-3417`.
+
+## Calculation Site
+
+The actual calculation is in `karospace/data_loader.py` inside `_compute_morans_i_for_features`. The function looks for the first available graph in `adata.obsp` under `spatial_connectivities`, `connectivities`, `neighbors`, or `neighbor_graph`; if no graph is found, it returns an empty list. Citations: `karospace/data_loader.py:853-861`.
+
+The function converts the graph to CSR, row-normalizes it, rejects an all-zero graph, selects the top variable features from `adata.X`, centers the selected expression matrix, computes Moran's I as `n_obs * (Z * WZ).sum(axis=0) / (s0 * (Z * Z).sum(axis=0))`, clips results to `[-1, 1]`, rounds to four decimals, and sorts descending by `I`. Citations: `karospace/data_loader.py:863-899`.
+
+The feature candidate list comes from `_select_top_variable_features`, which ranks features by variance across cells using sparse or dense matrix handling. Citations: `karospace/data_loader.py:840-850`.
+
+## Export-Time Call Path
+
+`export_to_html` currently keeps the legacy `spatial_variable_genes_n` parameter with default `20` for compatibility; its docstring describes the value as the number of top variable features scored with Moran's I, requires a spatial weight matrix in `adata.obsp`, and can be disabled with `0`. Citations: `karospace/exporter.py:34709-34765`, `karospace/exporter.py:34830-34838`.
+
+During export, `export_to_html` calls `dataset.to_json_data(...)` while building the viewer payload and passes `analytics_modalities=selected_modalities` plus `spatial_variable_genes_n=int(spatial_variable_genes_n)`. Citations: `karospace/exporter.py:35199-35205`, `karospace/exporter.py:35257-35295`.
+
+Inside `SpatialDataset.to_json_data`, all available features are recorded per modality in `features_by_modality`; requested/embedded features are handled separately, but the spatial calculation is passed `list(features_by_modality.get(modality_name) or [])`, so the spatial ranking uses the modality's available feature universe, not only the manually requested features. Citations: `karospace/data_loader.py:2422-2459`, `karospace/data_loader.py:3342-3349`.
+
+For each selected analytics modality, `to_json_data` obtains a modality-specific AnnData object via `_adata_for_pseudobulk_modality`. For non-default modalities, that object is built from the modality matrix and var table while copying compatible `.obsm` and `.obsp` entries from the base AnnData, preserving the spatial graph used by Moran's I. Citations: `karospace/data_loader.py:2390-2412`, `karospace/data_loader.py:3342-3349`.
+
+The computed lists are stored in the JSON payload under `spatial_variable_features_by_modality`; every modality is initialized with an empty list, then selected analytics modalities are filled when `spatial_variable_genes_n > 0`. Citations: `karospace/data_loader.py:3311-3313`, `karospace/data_loader.py:3342-3349`, `karospace/data_loader.py:3411-3417`.
+
+## User-Facing Entry Points
+
+CLI users control the calculation with `--spatial-variable-features-n`, whose help text says it scores top variable features with Moran's I, requires a spatial graph in `obsp`, and can be disabled with `0`. The legacy `--spatial-variable-genes-n` alias remains accepted and both forms are passed to `export_to_html` as `spatial_variable_genes_n=args.spatial_variable_genes_n`. Citations: `karospace/cli.py:550-555`, `karospace/cli.py:810-820`, `karospace/cli.py:830-868`.
+
+GUI users control the same value through the "Moran features N" field, initialized to `20`, parsed as a non-negative integer, and added to `export_kwargs` as `spatial_variable_genes_n`; the GUI worker then calls `load_spatial_data(...)` followed by `export_to_html(dataset, **export_kwargs)`. Citations: `karospace/gui.py:277-292`, `karospace/gui.py:641-646`, `karospace/gui.py:1256-1283`, `karospace/gui.py:1328-1335`.
+
+Python API users reach the same code through `karospace.export_to_html`; the package exposes `export_to_html`, `load_spatial_data`, and `SpatialDataset` from `karospace.__init__`, and `export_to_html` carries the same `spatial_variable_genes_n` parameter. Citations: `karospace/__init__.py:40-57`, `karospace/exporter.py:34709-34765`.
+
+## Viewer Consumption
+
+The generated JavaScript reads `DATA.spatial_variable_features_by_modality` via `getModalityPayload(...)`, and `getExplorationSpatialVariableFeaturesPayload(...)` returns the modality-specific list or `[]`. Citations: `karospace/exporter.py:7761-7770`, `karospace/exporter.py:7838-7841`.
+
+When the active Insights tab is `features` and its subtab is `spatial`, the viewer calls `renderSpatialVariableGenes()`. Citations: `karospace/exporter.py:24765-24773`.
+
+`renderSpatialVariableGenes()` renders an empty message when no spatial rankings were precomputed, otherwise it reads each row's `gene` and `I` value, presents list rows with rank and `I=...`, and can switch to a graph view. Citations: `karospace/exporter.py:28013-28024`, `karospace/exporter.py:28028-28049`, `karospace/exporter.py:28055-28073`.
+
+The graph view plots the top entries on a "Moran Index" axis, and the calculation-info popover describes spatial features as ranked by Moran index, measuring whether nearby cells have similar feature values. Citations: `karospace/exporter.py:27137-27165`, `karospace/exporter.py:8433-8437`.
+
+The feature discovery sidebar also surfaces the top 12 entries from `getExplorationSpatialVariableFeaturesPayload(...)` under "Spatially variable features" with `I` metadata. Citations: `karospace/exporter.py:14649-14666`.
+
+## Documentation and Tests
+
+The README documents `--spatial-variable-features-n` as "Top variable features scored with Moran's I" with default `20`, and documents that `Insights -> Features` includes spatial features scoped by the feature namespace selector. Citations: `README.md:329-331`, `README.md:408-414`.
+
+`FEATURES_SUMMARY.md` documents that `Features > Spatial` shows Moran Index rankings computed at export for each selected modality and that spatially variable features are computed with Moran's I per selected modality for up to `spatial_variable_features_n` variable features on the full input cell set. Citations: `FEATURES_SUMMARY.md:155-166`, `FEATURES_SUMMARY.md:202-215`.
+
+The multimodal export schema test builds an AnnData object with `obsm["spatial"]` and `obsp["spatial_connectivities"]`, calls `to_json_data(..., spatial_variable_genes_n=2, ...)`, and asserts that `spatial_variable_features_by_modality` has both `rna` and `protein` keys with expected features in each modality's spatial list. Citations: `tests/test_multimodal_export_schema.py:38-55`, `tests/test_multimodal_export_schema.py:182-224`.
+
+The HTML runtime test checks that generated copy includes "Spatial features", confirming the browser output retains the user-facing feature label. Citations: `tests/test_multimodal_html_runtime.py:235-243`.
+
+## Practical Interpretation
+
+If "Features Spatial" is missing or empty in a generated viewer, the primary causes visible in the code are: `spatial_variable_genes_n` was set to `0`; the selected analytics modality did not run; or the AnnData object lacked one of the accepted `.obsp` graph keys. Citations: `karospace/data_loader.py:853-861`, `karospace/data_loader.py:3342-3349`, `karospace/exporter.py:35032-35039`, `karospace/exporter.py:35288-35292`.

--- a/karospace/cli.py
+++ b/karospace/cli.py
@@ -40,13 +40,13 @@ def _parse_section_rotations_arg(raw: str) -> Optional[Dict[str, float]]:
 
 def _run_export_cli(argv=None):
     parser = argparse.ArgumentParser(
-        description="Generate HTML viewer for Xenium spatial transcriptomics data"
+        description="Generate HTML viewer for multimodal spatial data"
     )
     io_args = parser.add_argument_group("Input/output")
     dataset_args = parser.add_argument_group("Dataset loading and coordinates")
     metadata_args = parser.add_argument_group("Metadata and labels")
     viewer_args = parser.add_argument_group("Viewer layout")
-    gene_args = parser.add_argument_group("Gene content and storage")
+    feature_args = parser.add_argument_group("Feature content and storage")
     pseudobulk_args = parser.add_argument_group("Pseudobulk DE")
     neighborhood_args = parser.add_argument_group("Neighborhoods and interactions")
     overlay_args = parser.add_argument_group("Images, deconvolution, and utilities")
@@ -74,7 +74,7 @@ def _run_export_cli(argv=None):
         type=str,
         default="leiden",
         dest="main_cell_annotation",
-        help="Main cell annotation column or gene shown first in the viewer (default: leiden)"
+        help="Main cell annotation column or feature shown first in the viewer (default: leiden)"
     )
     viewer_args.add_argument(
         "--cell-annotations",
@@ -84,18 +84,18 @@ def _run_export_cli(argv=None):
         help="Comma-separated extra cell obs annotation columns to embed as selectable annotations "
              "(e.g. a second clustering). Needed to compare annotations in the River plot."
     )
-    gene_args.add_argument(
+    feature_args.add_argument(
         "--features",
         type=str,
         default="",
-        help="Comma-separated features to preload for expression visualization. In embedded mode, significant DE genes are embedded automatically up to the configured cap."
+        help="Comma-separated features to preload for visualization. In embedded mode, significant DE features are embedded automatically up to the configured cap."
     )
-    gene_args.add_argument(
+    feature_args.add_argument(
         "--features-list",
         type=str,
         default=None,
         dest="features_list",
-        help="Path to a text file with one feature/gene per line. Values are combined with --features and deduplicated."
+        help="Path to a text file with one feature per line. Values are combined with --features and deduplicated."
     )
     dataset_args.add_argument(
         "--section-key",
@@ -254,46 +254,47 @@ def _run_export_cli(argv=None):
         ),
     )
     viewer_args.set_defaults(embed_reproducibility_info=True)
-    gene_args.add_argument(
+    feature_args.add_argument(
         "--feature-encoding",
         choices=["auto", "dense", "sparse"],
         default="auto",
         help="Feature vector encoding. 'sparse' stores only non-zero indices/values (smaller HTML for zero-inflated data). (default: auto)"
     )
-    gene_args.add_argument(
+    feature_args.add_argument(
         "--feature-value-encoding",
         choices=["uint16", "uint8"],
         default="uint16",
         help="Sidecar/package feature value encoding for binary shards. (default: uint16)"
     )
-    gene_args.add_argument(
+    feature_args.add_argument(
         "--feature-storage",
         choices=["embedded", "sidecar"],
         default="embedded",
         help="Store requested/top DE feature vectors in the HTML (`embedded`) or write all feature vectors to a sidecar (`sidecar`). (default: embedded)"
     )
-    gene_args.add_argument(
+    feature_args.add_argument(
         "--feature-manifest-path",
         type=str,
         default=None,
         help="Optional output path for the feature sidecar JSON when --feature-storage sidecar."
     )
-    gene_args.add_argument(
+    feature_args.add_argument(
         "--feature-sidecar-shard-size",
         type=int,
         default=256,
         help="Number of features per sidecar shard. (default: 256)"
     )
-    gene_args.add_argument(
+    feature_args.add_argument(
         "--modalities",
         type=str,
         default=None,
         help=(
             "Comma-separated list of modalities to export (e.g. 'rna,protein'). "
-            "Defaults to all detected. Non-default modalities require --feature-storage sidecar."
+            "Defaults to the default modality with --feature-storage embedded, "
+            "or all detected modalities with --feature-storage sidecar."
         ),
     )
-    gene_args.add_argument(
+    feature_args.add_argument(
         "--feature-sparse-zero-threshold",
         type=float,
         default=0.8,
@@ -309,7 +310,11 @@ def _run_export_cli(argv=None):
         "--neighbor-stats-annotations",
         type=str,
         default="auto",
-        help="Comma-separated obs columns to compute neighbor composition stats for. Use 'auto' (default) to match --main-cell-annotation; empty disables."
+        help=(
+            "Comma-separated obs columns to compute neighbor composition stats for. "
+            "Use 'auto' (default) to include --main-cell-annotation and --cell-annotations; "
+            "empty disables standalone neighbor enrichment unless interaction markers need it."
+        )
     )
     pseudobulk_args.add_argument(
         "--pseudobulk",
@@ -325,8 +330,8 @@ def _run_export_cli(argv=None):
         type=str,
         default="",
         help=(
-            "Comma-separated additional annotation columns to analyze when pseudobulk or "
-            "interaction markers are enabled. --main-cell-annotation is included automatically."
+            "Comma-separated additional annotation columns to analyze when pseudobulk is "
+            "enabled. --main-cell-annotation is included automatically."
         )
     )
     pseudobulk_args.add_argument(
@@ -379,13 +384,21 @@ def _run_export_cli(argv=None):
         ),
     )
     pseudobulk_args.add_argument(
-        "--pseudobulk-min-gene-counts",
+        "--pseudobulk-min-feature-counts",
         type=int,
         default=0,
+        dest="pseudobulk_min_gene_counts",
+        metavar="N",
         help=(
-            "Exclude genes with fewer than this many total raw pseudobulk counts in the shared DESeq2 fit. "
+            "Exclude features with fewer than this many total raw pseudobulk counts in the shared DESeq2 fit. "
             "Use 0 to disable. (default: 0)"
         ),
+    )
+    pseudobulk_args.add_argument(
+        "--pseudobulk-min-gene-counts",
+        type=int,
+        dest="pseudobulk_min_gene_counts",
+        help=argparse.SUPPRESS,
     )
     pseudobulk_args.add_argument(
         "--pseudobulk-min-cells-per-pseudobulk",
@@ -411,8 +424,8 @@ def _run_export_cli(argv=None):
         type=int,
         default=2,
         help=(
-            "Maximum significant DE genes to auto-embed per category/contact comparison in embedded mode. "
-            "Ignored by --feature-storage sidecar, where all gene expression vectors are written to the sidecar. (default: 2)"
+            "Maximum significant DE features to auto-embed per category/contact comparison in embedded mode. "
+            "Ignored by --feature-storage sidecar, where all feature vectors are written to the sidecar. (default: 2)"
         ),
     )
     pseudobulk_args.add_argument(
@@ -425,7 +438,7 @@ def _run_export_cli(argv=None):
         "--pseudobulk-min-pct-expressed",
         type=float,
         default=0.0,
-        help="Minimum fraction of cells expressing a gene in at least one compared group before reporting DE results. Values >1 are interpreted as percentages. (default: 0)"
+        help="Minimum fraction of cells with a positive feature value in at least one compared group before reporting DE results. Values >1 are interpreted as percentages. (default: 0)"
     )
     pseudobulk_args.add_argument(
         "--pseudobulk-p-adjust-method",
@@ -507,10 +520,18 @@ def _run_export_cli(argv=None):
         help="Number of target categories to evaluate per source for contact-conditioned markers. (default: 5)"
     )
     neighborhood_args.add_argument(
-        "--interaction-markers-top-genes",
+        "--interaction-markers-top-features",
         type=int,
         default=20,
-        help="Number of top DE genes to keep per source-target interaction. (default: 20)"
+        dest="interaction_markers_top_genes",
+        metavar="N",
+        help="Number of top DE features to keep per source-target interaction. (default: 20)"
+    )
+    neighborhood_args.add_argument(
+        "--interaction-markers-top-genes",
+        type=int,
+        dest="interaction_markers_top_genes",
+        help=argparse.SUPPRESS,
     )
     neighborhood_args.add_argument(
         "--interaction-markers-min-cells",
@@ -530,23 +551,47 @@ def _run_export_cli(argv=None):
         default="",
         help="Comma-separated section_id:angle pairs for initial per-section rotations with exact degree values (example: S1:37.5,S2:-90)."
     )
-    gene_args.add_argument(
-        "--gene-correlation-top-n",
+    feature_args.add_argument(
+        "--feature-correlation-top-n",
         type=int,
         default=5,
-        help="Number of top correlated genes to show per embedded gene in the discovery panel. Use 0 to disable. (default: 5)"
+        dest="gene_correlation_top_n",
+        metavar="N",
+        help="Number of top correlated features to show per embedded feature in the discovery panel. Use 0 to disable. (default: 5)"
     )
-    gene_args.add_argument(
-        "--category-means-n-genes",
+    feature_args.add_argument(
+        "--gene-correlation-top-n",
+        type=int,
+        dest="gene_correlation_top_n",
+        help=argparse.SUPPRESS,
+    )
+    feature_args.add_argument(
+        "--category-means-n-features",
         type=int,
         default=500,
-        help="Maximum embedded pseudobulk-DE genes to expose in category mean summaries. Use 0 to disable. (default: 500)"
+        dest="category_means_n_genes",
+        metavar="N",
+        help="Maximum embedded pseudobulk-DE features to expose in category mean summaries. Use 0 to disable. (default: 500)"
     )
-    gene_args.add_argument(
-        "--spatial-variable-genes-n",
+    feature_args.add_argument(
+        "--category-means-n-genes",
+        type=int,
+        dest="category_means_n_genes",
+        help=argparse.SUPPRESS,
+    )
+    feature_args.add_argument(
+        "--spatial-variable-features-n",
         type=int,
         default=20,
-        help="Number of top variable genes to score with Moran's I spatial autocorrelation. Requires spatial graph in obsp. Use 0 to disable. (default: 20)"
+        dest="spatial_variable_genes_n",
+        metavar="N",
+        help="Number of top variable features to score with Moran's I spatial autocorrelation. Requires spatial graph in obsp. Use 0 to disable. (default: 20)"
+    )
+    feature_args.add_argument(
+        "--spatial-variable-genes-n",
+        type=int,
+        dest="spatial_variable_genes_n",
+        help=argparse.SUPPRESS,
     )
     viewer_args.add_argument(
         "--scalebar-unit",
@@ -578,7 +623,7 @@ def _run_export_cli(argv=None):
     if args.pseudobulk_min_cell_counts < 0:
         parser.error("--pseudobulk-min-cell-counts must be >= 0")
     if args.pseudobulk_min_gene_counts < 0:
-        parser.error("--pseudobulk-min-gene-counts must be >= 0")
+        parser.error("--pseudobulk-min-feature-counts must be >= 0")
     if args.pseudobulk_n_cpus < 1:
         parser.error("--pseudobulk-n-cpus must be >= 1")
     if args.pseudobulk_embed_top_n_per_comparison < 0:
@@ -615,7 +660,21 @@ def _run_export_cli(argv=None):
         print(f"Input: {report['path']}")
         if report.get("spatialdata_table"):
             print(f"SpatialData table: {report['spatialdata_table']}")
-        print(f"Cells: {report['n_cells']:,} | Genes: {report['n_genes']:,}")
+        print(f"Cells: {report['n_cells']:,}")
+        feature_modalities = report.get("feature_modalities") or []
+        if feature_modalities:
+            print("Features by modality:")
+            for entry in feature_modalities:
+                name = str(entry.get("name") or "")
+                label = str(entry.get("label") or name)
+                display = name
+                if label and label != name:
+                    display = f"{name} [{label}]"
+                if entry.get("is_default"):
+                    display += " (default)"
+                print(f"  - {display}: {int(entry.get('n_features') or 0):,} features")
+        else:
+            print(f"Features: {report['n_genes']:,}")
         print("Available cell metadata (adata.obs):")
         for entry in report["metadata"]:
             examples = ", ".join(json.dumps(value, ensure_ascii=False) for value in entry["examples"])
@@ -683,10 +742,6 @@ def _run_export_cli(argv=None):
         print(f"Error: {option_name} must be 'auto' or 'None'", file=sys.stderr)
         sys.exit(2)
 
-    if str(args.neighbor_stats_annotations).lower() == "auto":
-        neighbor_stats_annotations = [args.main_cell_annotation]
-    else:
-        neighbor_stats_annotations = _parse_csv(args.neighbor_stats_annotations)
     pseudobulk_mode = _parse_auto_or_none(args.pseudobulk, "--pseudobulk")
     interaction_markers_mode = _parse_auto_or_none(args.interaction_markers, "--interaction-markers")
     pseudobulk_additional_annotations = _parse_csv(args.pseudobulk_additional_annotations)
@@ -707,6 +762,13 @@ def _run_export_cli(argv=None):
     pathway_gmt = _parse_csv(args.pathway_gmt) or None
     pathway_organism = str(args.pathway_organism or "Mouse").strip() or "Mouse"
     cell_annotations = _parse_csv(args.cell_annotations)
+    if str(args.neighbor_stats_annotations).lower() == "auto":
+        neighbor_stats_annotations = []
+        for col in [args.main_cell_annotation, *(cell_annotations or [])]:
+            if col and col not in neighbor_stats_annotations:
+                neighbor_stats_annotations.append(col)
+    else:
+        neighbor_stats_annotations = _parse_csv(args.neighbor_stats_annotations)
     features = _parse_csv(args.features)
     if args.features_list:
         features_list_path = Path(args.features_list).expanduser()
@@ -852,7 +914,7 @@ def _run_export_cli(argv=None):
     if args.feature_storage == "sidecar":
         output_obj = Path(output_path).expanduser()
         print(
-            "Done! Sidecar gene loading requires HTTP(S). "
+            "Done! Sidecar feature loading requires HTTP(S). "
             f"Serve the output directory with: python -m http.server --directory {output_obj.parent}"
         )
         print(f"Then open http://localhost:8000/{output_obj.name}")

--- a/karospace/cli.py
+++ b/karospace/cli.py
@@ -158,7 +158,7 @@ def _run_export_cli(argv=None):
         dest="section_metadata",
         help=(
             "Comma-separated obs columns to use as section metadata and visual filter chips "
-            "(e.g. strain,region,Batch,Slide). Empty uses loader defaults."
+            "(e.g. strain,region,Batch,Slide). Empty disables section metadata."
         ),
     )
     metadata_args.add_argument(

--- a/karospace/data_loader.py
+++ b/karospace/data_loader.py
@@ -3700,7 +3700,8 @@ def load_spatial_data(
     section_order : list, optional
         Custom order for sections
     section_metadata : list, optional
-        Obs columns to use for section metadata and visual filter chips.
+        Obs columns to use for section metadata and visual filter chips. If not
+        provided, no section metadata columns are requested.
     section_metadata_extra : list, optional
         Additional obs columns to store as section metadata without visual filter chips.
     metadata_value_order : dict, optional
@@ -3778,16 +3779,25 @@ def load_spatial_data(
         return list(dict.fromkeys(cleaned))
 
     # Determine section metadata columns.
-    if section_metadata is None:
-        section_metadata = ["course", "region", "condition", "timepoint", "last_score", "last_day"]
-    else:
-        section_metadata = _clean_column_list(section_metadata)
-    section_metadata_extra = _clean_column_list(section_metadata_extra)
+    requested_section_metadata = _clean_column_list(section_metadata)
+    requested_section_metadata_extra = _clean_column_list(section_metadata_extra)
+    section_metadata = [
+        col for col in requested_section_metadata
+        if col in adata.obs.columns
+    ]
+    section_metadata_extra = [
+        col for col in requested_section_metadata_extra
+        if col in adata.obs.columns
+    ]
     if metadata_max_columns is not None:
         if metadata_max_columns < 0:
             raise ValueError("metadata_max_columns must be >= 0")
         section_metadata = section_metadata[:metadata_max_columns]
     section_metadata_columns = list(dict.fromkeys([*section_metadata, *section_metadata_extra]))
+    missing_section_metadata_columns = [
+        col for col in dict.fromkeys([*requested_section_metadata, *requested_section_metadata_extra])
+        if col not in adata.obs.columns
+    ]
     if section_metadata_columns:
         log_detail(
             "Section metadata columns: "
@@ -3796,6 +3806,18 @@ def load_spatial_data(
                 f" ({len(section_metadata)} shown in the visual params bar; "
                 f"{len(section_metadata_extra)} stored as section-only metadata)."
             )
+        )
+        if missing_section_metadata_columns:
+            log_warning(
+                "Section metadata columns not found in obs and skipped: "
+                + ", ".join(missing_section_metadata_columns),
+                level=1,
+            )
+    elif missing_section_metadata_columns:
+        log_warning(
+            "No requested section metadata columns were found in obs; skipped: "
+            + ", ".join(missing_section_metadata_columns),
+            level=1,
         )
     else:
         log_detail("No section metadata columns were requested.")

--- a/karospace/data_loader.py
+++ b/karospace/data_loader.py
@@ -1110,6 +1110,168 @@ def _drop_legacy_logfoldchanges(payload: Any) -> Any:
     return payload
 
 
+def _select_top_variable_features(adata: Any, n: int) -> List[str]:
+    """Return up to n feature names ranked by expression variance across cells."""
+    X = adata.X
+    if hasattr(X, "toarray"):
+        mean_sq = np.asarray(X.power(2).mean(axis=0)).ravel()
+        sq_mean = np.asarray(X.mean(axis=0)).ravel() ** 2
+        variances = mean_sq - sq_mean
+    else:
+        variances = np.var(np.asarray(X, dtype=float), axis=0)
+    top_idx = np.argsort(variances)[::-1][: int(n)]
+    return [str(adata.var_names[i]) for i in top_idx]
+
+
+def _compute_morans_i_for_features(adata: Any, features: List[str], n_features: int = 200) -> list:
+    """Compute Moran's I spatial autocorrelation for the top variable features."""
+    W = None
+    for key in ("spatial_connectivities", "connectivities", "neighbors", "neighbor_graph"):
+        if key in adata.obsp:
+            W = adata.obsp[key]
+            break
+    if W is None:
+        return []
+
+    if not sp.issparse(W):
+        W = sp.csr_matrix(W)
+    else:
+        W = W.tocsr().astype(float)
+
+    n_obs = W.shape[0]
+    row_sums = np.asarray(W.sum(axis=1)).ravel()
+    row_sums[row_sums == 0] = 1.0
+    W = sp.diags(1.0 / row_sums) @ W
+    s0 = float(W.sum())
+    if s0 == 0:
+        return []
+
+    selected = _select_top_variable_features(adata, int(n_features))
+    selected = [feature for feature in selected if feature in set(features)]
+    if not selected:
+        return []
+
+    X = adata[:, selected].X
+    if hasattr(X, "toarray"):
+        X = X.toarray()
+    X = np.asarray(X, dtype=float)
+    Z = X - X.mean(axis=0)
+    WZ = W.dot(Z)
+
+    num = n_obs * (Z * WZ).sum(axis=0)
+    denom = s0 * (Z * Z).sum(axis=0)
+    valid = denom > 0
+    i_values = np.where(valid, num / np.where(valid, denom, 1.0), 0.0)
+    i_values = np.clip(i_values, -1.0, 1.0)
+
+    results = [
+        {"gene": feature, "I": round(float(i_values[idx]), 4)}
+        for idx, feature in enumerate(selected)
+        if valid[idx]
+    ]
+    results.sort(key=lambda row: row["I"], reverse=True)
+    return results
+
+
+def _compute_feature_correlations_from_category_means(
+    category_feature_means: Optional[dict],
+    features: List[str],
+    top_n: int = 10,
+) -> dict:
+    """Compute feature correlations across pseudobulk/category mean profiles."""
+    if not features or int(top_n) < 1:
+        return {feature: [] for feature in features} if features else {}
+    if not category_feature_means or not isinstance(category_feature_means, dict):
+        return {feature: [] for feature in features}
+    mean_features = [str(g) for g in (category_feature_means.get("genes") or [])]
+    if len(mean_features) < 2:
+        return {feature: [] for feature in features}
+    feature_positions = {feature: idx for idx, feature in enumerate(mean_features)}
+    selected = [str(g) for g in features if str(g) in feature_positions]
+    if len(selected) < 2:
+        return {feature: [] for feature in features}
+
+    profiles: List[List[float]] = []
+    for col_data in (category_feature_means.get("columns") or {}).values():
+        if not isinstance(col_data, dict):
+            continue
+        means = col_data.get("means") or {}
+        for values in means.values():
+            if isinstance(values, list) and len(values) == len(mean_features):
+                profiles.append([float(values[feature_positions[g]] or 0.0) for g in selected])
+    if len(profiles) < 2:
+        return {feature: [] for feature in features}
+
+    X = np.asarray(profiles, dtype=float)
+    X[~np.isfinite(X)] = 0
+    corr = np.corrcoef(X.T)
+    result = {feature: [] for feature in features}
+    for i, feature in enumerate(selected):
+        scores = corr[i].copy()
+        scores[i] = -2.0
+        top_idx = np.argsort(scores)[::-1][: int(top_n)]
+        result[feature] = [
+            {"gene": selected[j], "r": round(float(corr[i, j]), 3)}
+            for j in top_idx
+            if j != i and np.isfinite(corr[i, j]) and corr[i, j] > 0
+        ]
+    return result
+
+
+def _category_feature_means_from_pseudobulk_de(
+    pseudobulk_de: Optional[dict],
+    features: List[str],
+    max_features: int,
+) -> Optional[dict]:
+    """Build viewer category mean payload from pseudobulk DE aggregate summaries."""
+    if not isinstance(pseudobulk_de, dict) or int(max_features) <= 0:
+        return None
+    requested = [str(feature) for feature in features if str(feature)]
+    if not requested:
+        return None
+    selected = requested[: int(max_features)]
+    columns = {}
+    feature_order: List[str] = []
+    for annotation_col, by_source in pseudobulk_de.items():
+        if not isinstance(by_source, dict):
+            continue
+        summary = by_source.get("_summary") or {}
+        cmeans = summary.get("category_gene_means") or {}
+        src_features = [str(g) for g in (cmeans.get("genes") or [])]
+        if not src_features:
+            continue
+        src_pos = {feature: idx for idx, feature in enumerate(src_features)}
+        keep = [feature for feature in selected if feature in src_pos]
+        if not keep:
+            continue
+        if not feature_order:
+            feature_order = keep
+        else:
+            keep = [feature for feature in feature_order if feature in src_pos]
+        idx = [src_pos[feature] for feature in keep]
+        means = {}
+        for category, values in (cmeans.get("means") or {}).items():
+            if isinstance(values, list) and len(values) == len(src_features):
+                means[str(category)] = [values[i] for i in idx]
+        background_values = cmeans.get("background") or []
+        background = (
+            [background_values[i] for i in idx]
+            if isinstance(background_values, list) and len(background_values) == len(src_features)
+            else [0.0 for _ in idx]
+        )
+        if means:
+            columns[str(annotation_col)] = {
+                "categories": [str(c) for c in (cmeans.get("categories") or means.keys())],
+                "means": means,
+                "background": background,
+                "n_cells": cmeans.get("n_cells") or {},
+                "source": "pseudobulk_de",
+            }
+    if not columns or not feature_order:
+        return None
+    return {"genes": feature_order, "columns": columns, "source": "pseudobulk_de"}
+
+
 @dataclass
 class SectionData:
     """Data for a single tissue section."""
@@ -1801,6 +1963,11 @@ class SpatialDataset:
         interaction_markers_top_genes: int = 20,
         interaction_markers_min_cells: int = 30,
         interaction_markers_min_neighbors: int = 1,
+        analytics_modalities: Optional[Sequence[str]] = None,
+        analytics_features: Optional[Sequence[str]] = None,
+        gene_correlation_top_n: int = 0,
+        category_means_n_genes: int = 0,
+        spatial_variable_genes_n: int = 0,
         section_rotations: Optional[Dict[str, float]] = None,
         deconvolutions: Optional[Dict[str, str]] = None,
     ) -> Dict:
@@ -2509,6 +2676,12 @@ class SpatialDataset:
             for layer_name, layer_matrix in (mod.layers or {}).items():
                 if getattr(layer_matrix, "shape", None) == mod.matrix.shape:
                     mod_adata.layers[str(layer_name)] = layer_matrix
+            for obsm_key, obsm_value in (getattr(self.adata, "obsm", {}) or {}).items():
+                if getattr(obsm_value, "shape", (None,))[0] == self.adata.n_obs:
+                    mod_adata.obsm[str(obsm_key)] = obsm_value.copy() if hasattr(obsm_value, "copy") else obsm_value
+            for obsp_key, obsp_value in (getattr(self.adata, "obsp", {}) or {}).items():
+                if getattr(obsp_value, "shape", None) == (self.adata.n_obs, self.adata.n_obs):
+                    mod_adata.obsp[str(obsp_key)] = obsp_value.copy() if hasattr(obsp_value, "copy") else obsp_value
             return mod_adata
 
         pseudobulk_modality_names = _normalize_pseudobulk_modalities(pseudobulk_modalities)
@@ -2527,6 +2700,10 @@ class SpatialDataset:
             )
             for modality_name in modality_names
         }
+        if analytics_modalities is None:
+            analytics_modality_names = list(modality_names)
+        else:
+            analytics_modality_names = [str(name) for name in analytics_modalities if str(name) in modality_names]
 
         replicate_override = str(pseudobulk_replicate_annotation or "").strip()
         pseudobulk_replicate_name = replicate_override or str(self.section_key)
@@ -3271,6 +3448,87 @@ class SpatialDataset:
             )
             for modality_name, modality_payload in pseudobulk_de_by_modality.items()
         }
+        requested_feature_names = [
+            str(feature)
+            for feature in (analytics_features if analytics_features is not None else (features or []))
+            if str(feature)
+        ]
+        requested_features_by_modality = {
+            modality_name: [
+                feature
+                for feature in requested_feature_names
+                if feature in set(features_by_modality.get(modality_name) or [])
+            ]
+            for modality_name in modality_names
+        }
+
+        def _flatten_marker_features(payload: Any) -> List[str]:
+            flattened: List[str] = []
+            if not isinstance(payload, dict):
+                return flattened
+            for by_category in payload.values():
+                if not isinstance(by_category, dict):
+                    continue
+                for values in by_category.values():
+                    if isinstance(values, list):
+                        flattened.extend(str(value) for value in values if str(value))
+            return flattened
+
+        def _analytics_features_for_modality(modality_name: str) -> List[str]:
+            available = set(features_by_modality.get(modality_name) or [])
+            requested = requested_features_by_modality.get(modality_name) or []
+            markers = _flatten_marker_features(marker_features_by_modality.get(modality_name))
+            return [
+                feature
+                for feature in dict.fromkeys([*requested, *markers])
+                if feature in available
+            ]
+
+        category_feature_means_by_modality: Dict[str, Optional[dict]] = {
+            modality_name: None for modality_name in modality_names
+        }
+        feature_correlations_by_modality: Dict[str, dict] = {
+            modality_name: {} for modality_name in modality_names
+        }
+        spatial_variable_features_by_modality: Dict[str, list] = {
+            modality_name: [] for modality_name in modality_names
+        }
+
+        if int(category_means_n_genes) > 0:
+            for modality_name in analytics_modality_names:
+                features_for_means = _analytics_features_for_modality(modality_name)
+                category_feature_means_by_modality[modality_name] = _category_feature_means_from_pseudobulk_de(
+                    pseudobulk_de_by_modality.get(modality_name),
+                    features_for_means,
+                    int(category_means_n_genes),
+                )
+
+        if int(gene_correlation_top_n) > 0:
+            for modality_name in analytics_modality_names:
+                features_for_correlations = _analytics_features_for_modality(modality_name)
+                mean_payload = category_feature_means_by_modality.get(modality_name)
+                required_feature_count = len([feature for feature in features_for_correlations if str(feature)])
+                available_mean_count = len((mean_payload or {}).get("genes") or [])
+                if required_feature_count and available_mean_count < required_feature_count:
+                    mean_payload = _category_feature_means_from_pseudobulk_de(
+                        pseudobulk_de_by_modality.get(modality_name),
+                        features_for_correlations,
+                        max(required_feature_count, int(category_means_n_genes)),
+                    )
+                feature_correlations_by_modality[modality_name] = _compute_feature_correlations_from_category_means(
+                    mean_payload,
+                    features_for_correlations,
+                    top_n=int(gene_correlation_top_n),
+                )
+
+        if int(spatial_variable_genes_n) > 0:
+            for modality_name in analytics_modality_names:
+                modality_adata = _adata_for_pseudobulk_modality(modality_name)
+                spatial_variable_features_by_modality[modality_name] = _compute_morans_i_for_features(
+                    modality_adata,
+                    list(features_by_modality.get(modality_name) or []),
+                    n_features=int(spatial_variable_genes_n),
+                )
 
         return {
             "initial_annotation": annotation,
@@ -3314,7 +3572,7 @@ class SpatialDataset:
             "features_by_modality": features_by_modality,
             "embedded_features_by_modality": embedded_features_by_modality,
             "feature_state_by_modality": feature_state_by_modality,
-            "requested_features_by_modality": {},
+            "requested_features_by_modality": requested_features_by_modality,
             "metadata_filters": metadata_filters,
             "section_metadata": list(self.section_metadata),
             "section_metadata_extra": list(self.section_metadata_extra),
@@ -3335,15 +3593,9 @@ class SpatialDataset:
             "neighbors_key": neighbor_graph_key,
             "neighbor_stats": neighbor_stats,
             "interaction_markers_by_modality": interaction_markers_by_modality,
-            "category_feature_means_by_modality": {
-                modality_name: None for modality_name in modality_names
-            },
-            "feature_correlations_by_modality": {
-                modality_name: {} for modality_name in modality_names
-            },
-            "spatial_variable_features_by_modality": {
-                modality_name: [] for modality_name in modality_names
-            },
+            "category_feature_means_by_modality": category_feature_means_by_modality,
+            "feature_correlations_by_modality": feature_correlations_by_modality,
+            "spatial_variable_features_by_modality": spatial_variable_features_by_modality,
             "pathway_settings_by_modality": {
                 modality_name: {"available": False, "reason": "not_computed"}
                 for modality_name in modality_names

--- a/karospace/data_loader.py
+++ b/karospace/data_loader.py
@@ -1,16 +1,13 @@
 """
-Data loading utilities for spatial transcriptomics data.
+Data loading utilities for spatial and multimodal data.
 
-Handles loading h5ad files with scanpy and extracting spatial coordinates,
-gene expression, and metadata for visualization.
+Handles loading h5ad files and extracting spatial coordinates, feature values,
+and metadata for visualization.
 """
 
 import json
 import os
 import re
-import shutil
-import tempfile
-from copy import deepcopy
 from dataclasses import dataclass, field
 from itertools import combinations, product
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
@@ -26,23 +23,13 @@ from scipy.sparse import issparse
 from .console import log_detail, log_step, log_warning
 
 
-sc = ad  # Compatibility alias; this module only needs AnnData/read_h5ad, not Scanpy.
 COMPANION_ANALYTICS_STORAGE = "json-string-v1"
 COMPANION_ANALYTICS_JSON_FIELDS = {
-    # KaroSpaceCompanion emits cell-level cluster DE under "cluster_de_json"
-    # (t-test / Wilcoxon — the same paradigm as the Python single-sample Welch
-    # fallback), so map it onto the viewer's pseudobulk_de channel; the viewer
-    # derives per-cluster marker genes from this. A future Companion may emit
-    # "pseudobulk_de_json" directly, so support both — the explicit pseudobulk
-    # key is listed last and wins if a file carries both.
-    "cluster_de_json": "pseudobulk_de",
     "pseudobulk_de_json": "pseudobulk_de",
     "neighbor_stats_json": "neighbor_stats",
     "interaction_markers_json": "interaction_markers",
     "gene_correlations_json": "gene_correlations",
     "spatial_variable_genes_json": "spatial_variable_genes",
-    # Companion writes the per-cluster mean matrix as "cluster_gene_means_json".
-    "cluster_gene_means_json": "category_gene_means",
 }
 
 
@@ -479,152 +466,9 @@ def _compute_positive_fraction(
     return out
 
 
-def _format_h5ad_removed_paths(paths: List[str], limit: int = 8) -> str:
-    if len(paths) <= limit:
-        return ", ".join(paths)
-    return ", ".join(paths[:limit]) + f", ... ({len(paths) - limit} more)"
-
-
-def _h5ad_attr_text(value: Any) -> str:
-    if isinstance(value, bytes):
-        return value.decode("utf-8", "replace")
-    if isinstance(value, np.bytes_):
-        return value.item().decode("utf-8", "replace")
-    return str(value)
-
-
-def _copy_h5ad_for_repair(src_path: str) -> str:
-    fd, tmp_path = tempfile.mkstemp(suffix=".h5ad")
-    os.close(fd)
-    shutil.copy2(src_path, tmp_path)
-    return tmp_path
-
-
-def _strip_null_encoded_h5ad_entries(src_path: str) -> Tuple[str, List[str]]:
-    """Copy an h5ad file and remove null-encoded optional metadata entries."""
-    import h5py
-
-    tmp_path = _copy_h5ad_for_repair(src_path)
-
-    removed_paths: List[str] = []
-    with h5py.File(tmp_path, "r+") as handle:
-        if "uns" not in handle:
-            return tmp_path, removed_paths
-
-        def _walk(group, prefix: str = "") -> None:
-            for key in list(group.keys()):
-                obj = group[key]
-                path = f"{prefix}/{key}" if prefix else f"/{key}"
-                if _h5ad_attr_text(obj.attrs.get("encoding-type", "")).lower() == "null":
-                    removed_paths.append(path)
-                    del group[key]
-                    continue
-                if isinstance(obj, h5py.Group):
-                    _walk(obj, path)
-
-        _walk(handle["uns"], "/uns")
-
-    return tmp_path, removed_paths
-
-
-def _strip_optional_uns_h5ad_entries(src_path: str) -> Tuple[str, List[str]]:
-    """Copy an h5ad file and clear optional ``uns`` metadata for legacy read retries."""
-    import h5py
-
-    tmp_path = _copy_h5ad_for_repair(src_path)
-
-    removed_paths: List[str] = []
-    with h5py.File(tmp_path, "r+") as handle:
-        if "uns" not in handle:
-            return tmp_path, removed_paths
-
-        removed_paths = [f"/uns/{key}" for key in handle["uns"].keys()]
-        del handle["uns"]
-        uns = handle.create_group("uns")
-        uns.attrs["encoding-type"] = "dict"
-        uns.attrs["encoding-version"] = "0.1.0"
-
-    return tmp_path, removed_paths
-
-
-def _is_h5ad_encoding_error(exc: Exception) -> bool:
-    messages = []
-    current: Optional[BaseException] = exc
-    while current is not None:
-        messages.append(str(current))
-        current = current.__cause__ or current.__context__
-    text = "\n".join(messages)
-    return any(
-        needle in text
-        for needle in (
-            "No read method registered for IOSpec",
-            "IOSpec(",
-            "encoding_type=",
-            "encoding-type",
-        )
-    )
-
-
-def _read_h5ad_with_fallback(path: str) -> sc.AnnData:
-    """Read h5ad, retrying with legacy optional metadata stripped if needed."""
-    try:
-        return sc.read_h5ad(path)
-    except PermissionError as exc:
-        message = f"Unable to read h5ad file: {path}."
-        if str(path).startswith("/Volumes/"):
-            message += (
-                " macOS denied access to the mounted volume. Grant your terminal or IDE access "
-                "to external/removable volumes or Full Disk Access, or copy the file to a local "
-                "path such as ~/Downloads and retry."
-            )
-        else:
-            message += (
-                " The OS denied access. Check file permissions for the current process or copy "
-                "the file to a readable local path and retry."
-            )
-        raise PermissionError(message) from exc
-    except Exception as exc:
-        if not _is_h5ad_encoding_error(exc):
-            raise
-
-        repair_attempts = []
-        if "encoding_type='null'" in str(exc) or 'encoding_type="null"' in str(exc):
-            repair_attempts.append(
-                (
-                    "unsupported null-encoded H5AD metadata",
-                    _strip_null_encoded_h5ad_entries,
-                    "null metadata field(s)",
-                )
-            )
-        repair_attempts.append(
-            (
-                "legacy H5AD optional metadata encoding",
-                _strip_optional_uns_h5ad_entries,
-                "optional uns entry/entries",
-            )
-        )
-
-        for description, repair, label in repair_attempts:
-            temp_path = None
-            try:
-                temp_path, removed_paths = repair(path)
-                if not removed_paths:
-                    continue
-                print(f"  Detected {description}; retrying with a sanitized temporary copy...")
-                print(f"  Removed {len(removed_paths)} {label}: {_format_h5ad_removed_paths(removed_paths)}")
-                return sc.read_h5ad(temp_path)
-            except Exception:
-                continue
-            finally:
-                if temp_path and os.path.exists(temp_path):
-                    os.remove(temp_path)
-
-        raise
-
-
 def _looks_like_spatialdata(obj: Any) -> bool:
     """Return whether ``obj`` behaves like a SpatialData container."""
-    return hasattr(obj, "tables") and not isinstance(obj, sc.AnnData)
+    return hasattr(obj, "tables") and not isinstance(obj, ad.AnnData)
 
 
 def _read_spatialdata_zarr(path: str) -> Any:
@@ -677,7 +521,7 @@ def _select_spatialdata_table_key(
 def _coerce_spatialdata_table(
     sdata: Any,
     spatialdata_table: Optional[str] = None,
-) -> Tuple[sc.AnnData, str]:
+) -> Tuple[ad.AnnData, str]:
     tables = getattr(sdata, "tables", None)
     if tables is None or not hasattr(tables, "keys"):
         raise ValueError("SpatialData input does not expose a tables mapping.")
@@ -686,7 +530,7 @@ def _coerce_spatialdata_table(
     chosen_key = _select_spatialdata_table_key(table_keys, spatialdata_table)
 
     table = tables[chosen_key]
-    if not isinstance(table, sc.AnnData):
+    if not isinstance(table, ad.AnnData):
         if hasattr(table, "to_adata"):
             table = table.to_adata()
         else:
@@ -699,7 +543,7 @@ def _coerce_spatialdata_table(
 def _read_spatialdata_zarr_table_direct(
     path: str,
     spatialdata_table: Optional[str] = None,
-) -> Tuple[sc.AnnData, Optional[str]]:
+) -> Tuple[ad.AnnData, Optional[str]]:
     """Read an AnnData table from a SpatialData Zarr store without loading images."""
     path_obj = os.fspath(path)
     tables_dir = os.path.join(path_obj, "tables")
@@ -711,14 +555,14 @@ def _read_spatialdata_zarr_table_direct(
         ]
         chosen_key = _select_spatialdata_table_key(table_keys, spatialdata_table)
         table_path = os.path.join(tables_dir, str(chosen_key))
-        return sc.read_zarr(table_path), str(chosen_key)
+        return ad.read_zarr(table_path), str(chosen_key)
 
     if spatialdata_table:
         raise ValueError(
             f"SpatialData table '{spatialdata_table}' was requested, but {path} "
             "does not contain a SpatialData 'tables' directory."
         )
-    return sc.read_zarr(path_obj), None
+    return ad.read_zarr(path_obj), None
 
 
 def _compact_exception_message(exc: Exception, limit: int = 260) -> str:
@@ -731,8 +575,8 @@ def _compact_exception_message(exc: Exception, limit: int = 260) -> str:
 def _coerce_input_to_anndata(
     data: Any,
     spatialdata_table: Optional[str] = None,
-) -> Tuple[sc.AnnData, str, Optional[str]]:
-    if isinstance(data, sc.AnnData):
+) -> Tuple[ad.AnnData, str, Optional[str]]:
+    if isinstance(data, ad.AnnData):
         return data, "AnnData object", None
 
     if _looks_like_spatialdata(data):
@@ -766,7 +610,7 @@ def _coerce_input_to_anndata(
                     level=1,
                 )
                 return adata, f"SpatialData store {path}{table_label}", table_key
-        return _read_h5ad_with_fallback(path), path, None
+        return ad.read_h5ad(path), path, None
 
     raise TypeError(
         "Input must be a path to an .h5ad file, a SpatialData .zarr store, "
@@ -787,7 +631,7 @@ def _normalize_spatialdata_region_list(value: Any) -> List[str]:
     return [str(value)]
 
 
-def _get_spatialdata_attrs(adata: sc.AnnData) -> Dict[str, Any]:
+def _get_spatialdata_attrs(adata: ad.AnnData) -> Dict[str, Any]:
     attrs = adata.uns.get("spatialdata_attrs", {})
     if hasattr(attrs, "get"):
         return attrs
@@ -798,7 +642,7 @@ def _get_spatialdata_attrs(adata: sc.AnnData) -> Dict[str, Any]:
 
 
 def _resolve_section_key_for_spatialdata(
-    adata: sc.AnnData,
+    adata: ad.AnnData,
     section_key: str,
     spatialdata_table_key: Optional[str],
 ) -> str:
@@ -845,6 +689,18 @@ def inspect_input_file(data: Any, spatialdata_table: Optional[str] = None) -> Di
     """
     max_examples = 10
     adata, source_label, table_key = _coerce_input_to_anndata(data, spatialdata_table)
+    modalities = _detect_modalities(adata)
+    default_modality = "rna" if "rna" in modalities else (next(iter(modalities)) if modalities else "rna")
+    feature_modalities = [
+        {
+            "name": name,
+            "label": modality.label or name,
+            "value_kind": modality.value_kind,
+            "n_features": len(modality.feature_names),
+            "is_default": name == default_modality,
+        }
+        for name, modality in modalities.items()
+    ]
     metadata: List[Dict[str, Any]] = []
     for column in adata.obs.columns:
         series = adata.obs[column]
@@ -873,6 +729,7 @@ def inspect_input_file(data: Any, spatialdata_table: Optional[str] = None) -> Di
         "spatialdata_table": table_key,
         "n_cells": int(adata.n_obs),
         "n_genes": int(adata.n_vars),
+        "feature_modalities": feature_modalities,
         "metadata": metadata,
     }
 
@@ -951,13 +808,6 @@ def _load_companion_analytics(adata) -> Dict[str, Any]:
     analytics: Dict[str, Any] = {}
     if "analytics_columns" in companion:
         analytics["analytics_columns"] = _normalize_uns_text_list(companion.get("analytics_columns"))
-    # Plain string scalar (not JSON): the cell-level DE method Companion used
-    # ("ttest" / "wilcoxon"). Used to tag reused cluster DE so the viewer badge
-    # labels it as cell-level markers rather than a DESeq2 pseudobulk result.
-    if "analytics_cluster_de_method" in companion:
-        analytics["cluster_de_method"] = _normalize_uns_text(
-            companion.get("analytics_cluster_de_method")
-        )
 
     for uns_key, analytics_key in COMPANION_ANALYTICS_JSON_FIELDS.items():
         if uns_key not in companion:
@@ -976,105 +826,6 @@ def _load_companion_analytics(adata) -> Dict[str, Any]:
     return analytics
 
 
-def _companion_de_source_tag(method: Optional[str]) -> str:
-    """Map Companion's DE-method scalar to a viewer badge source tag."""
-    normalized = str(method or "").strip().lower().replace("-", "").replace("_", "")
-    if normalized == "wilcoxon":
-        return "companion_wilcoxon"
-    # Companion's default (and TTest enum) is a cell-level Welch t-test.
-    return "companion_ttest"
-
-
-def _backfill_companion_pseudobulk_summary(
-    payload: Any,
-    annotation_key: str,
-    companion_gene_means: Any,
-    method: Optional[str],
-) -> Any:
-    """Give a reused Companion cluster-DE payload the _summary the viewer expects.
-
-    Companion emits cell-level t-test / Wilcoxon DE (no ``_summary``, no method
-    tag) and stores per-cluster means in a separate ``cluster_gene_means_json``
-    field. Stitch the two together so (a) the DE-method badge labels these as
-    cell-level markers instead of defaulting to the DESeq2 label, and (b) the
-    category-means / category-vs-rest panels render. Idempotent: a future
-    Companion that already writes ``_summary.category_gene_means`` is left alone
-    apart from ensuring a source tag.
-    """
-    if not isinstance(payload, dict):
-        return payload
-    source_tag = _companion_de_source_tag(method)
-
-    existing_summary = payload.get("_summary")
-    if isinstance(existing_summary, dict) and isinstance(
-        existing_summary.get("category_gene_means"), dict
-    ):
-        existing_summary["category_gene_means"].setdefault("source", source_tag)
-        existing_summary.setdefault("source", source_tag)
-        return payload
-
-    # Per-category cell counts aren't in cluster_gene_means_json; recover them
-    # from any contrast leaf's n_source (source category == that leaf's source).
-    n_cells: Dict[str, int] = {}
-    for source_cat, refs in payload.items():
-        if str(source_cat).startswith("_") or not isinstance(refs, dict):
-            continue
-        for ref_result in refs.values():
-            if isinstance(ref_result, dict) and ref_result.get("n_source") is not None:
-                try:
-                    n_cells[str(source_cat)] = int(ref_result["n_source"])
-                except (TypeError, ValueError):
-                    pass
-                break
-
-    category_gene_means = None
-    if isinstance(companion_gene_means, dict):
-        columns = companion_gene_means.get("columns")
-        column = columns.get(annotation_key) if isinstance(columns, dict) else None
-        if isinstance(column, dict):
-            category_gene_means = {
-                "genes": list(companion_gene_means.get("genes") or []),
-                "categories": list(column.get("categories") or []),
-                "means": dict(column.get("means") or {}),
-                "background": list(column.get("background") or []),
-                "n_cells": n_cells,
-                "source": source_tag,
-            }
-
-    summary = dict(existing_summary) if isinstance(existing_summary, dict) else {}
-    if category_gene_means is not None:
-        summary["category_gene_means"] = category_gene_means
-    summary.setdefault("source", source_tag)
-    payload["_summary"] = summary
-    return payload
-
-
-def _strip_category_pseudobulk_sample_diagnostics(payload: Any) -> Any:
-    """Drop legacy all-category PCA/distance diagnostics from category DE payloads.
-
-    Pairwise diagnostics live under ``_summary.pair_diagnostics`` and are kept.
-    Contact-marker diagnostics are handled separately in the interaction marker
-    payload.
-    """
-    if not isinstance(payload, dict):
-        return payload
-    cleaned = deepcopy(payload)
-
-    def _walk(node: Any) -> None:
-        if not isinstance(node, dict):
-            return
-        node.pop("pseudobulk_samples", None)
-        for value in node.values():
-            if isinstance(value, dict):
-                _walk(value)
-            elif isinstance(value, list):
-                for item in value:
-                    _walk(item)
-
-    _walk(cleaned)
-    return cleaned
-
-
 def _compact_json_float(value: Any, significant_digits: int = 6) -> Optional[float]:
     try:
         val = float(value)
@@ -1084,30 +835,6 @@ def _compact_json_float(value: Any, significant_digits: int = 6) -> Optional[flo
         return None
     digits = max(1, int(significant_digits))
     return float(f"{val:.{digits}g}")
-
-
-def _drop_legacy_logfoldchanges(payload: Any) -> Any:
-    """Remove legacy logfoldchanges keys and compact floats before viewer serialization."""
-    if not isinstance(payload, dict):
-        return payload
-
-    def _walk(node: Any) -> Any:
-        if isinstance(node, dict):
-            if "logfoldchanges" in node:
-                if "log2foldchanges" not in node:
-                    node["log2foldchanges"] = node.get("logfoldchanges")
-                node.pop("logfoldchanges", None)
-            for key, value in list(node.items()):
-                node[key] = _walk(value)
-            return node
-        elif isinstance(node, list):
-            return [_walk(item) for item in node]
-        if isinstance(node, (float, np.floating)):
-            return _compact_json_float(node, 6)
-        return node
-
-    _walk(payload)
-    return payload
 
 
 def _select_top_variable_features(adata: Any, n: int) -> List[str]:
@@ -1123,14 +850,28 @@ def _select_top_variable_features(adata: Any, n: int) -> List[str]:
     return [str(adata.var_names[i]) for i in top_idx]
 
 
-def _compute_morans_i_for_features(adata: Any, features: List[str], n_features: int = 200) -> list:
+def _compute_morans_i_for_features(
+    adata: Any,
+    features: List[str],
+    n_features: int = 200,
+    *,
+    modality_name: Optional[str] = None,
+) -> list:
     """Compute Moran's I spatial autocorrelation for the top variable features."""
     W = None
-    for key in ("spatial_connectivities", "connectivities", "neighbors", "neighbor_graph"):
+    graph_keys = ("spatial_connectivities", "connectivities", "neighbors", "neighbor_graph")
+    for key in graph_keys:
         if key in adata.obsp:
             W = adata.obsp[key]
             break
     if W is None:
+        modality_label = f" for modality '{modality_name}'" if modality_name else ""
+        log_warning(
+            "Spatially variable feature calculation skipped"
+            f"{modality_label}: no spatial graph found in adata.obsp "
+            f"(looked for {', '.join(graph_keys)}).",
+            level=1,
+        )
         return []
 
     if not sp.issparse(W):
@@ -1329,7 +1070,7 @@ class Modality:
 @dataclass
 class SpatialDataset:
     """Container for spatial transcriptomics dataset."""
-    adata: sc.AnnData
+    adata: ad.AnnData
     sections: List[SectionData]
     section_key: str
     obs_columns: List[str]
@@ -1387,7 +1128,7 @@ class SpatialDataset:
         modality: Optional[str] = None,
     ) -> Tuple[np.ndarray, bool, Optional[List[str]]]:
         """
-        Get annotation or gene values for all cells.
+        Get annotation or feature values for all cells.
 
         Parameters
         ----------
@@ -2022,7 +1763,7 @@ class SpatialDataset:
             Exclude cells below this total raw-count threshold before pseudobulk
             aggregation. Zero disables filtering.
         pseudobulk_min_gene_counts : int
-            Exclude genes below this total raw pseudobulk-count threshold in the
+            Exclude features below this total raw pseudobulk-count threshold in the
             shared DESeq2 fit. Zero disables filtering.
         pseudobulk_min_cells_per_pseudobulk : int
             Minimum cells required in each replicate x annotation pseudobulk
@@ -2032,7 +1773,7 @@ class SpatialDataset:
             contrast.
             Pseudobulk DE always requires at least two replicates.
         pseudobulk_min_pct_expressed : float
-            Minimum fraction of cells expressing a gene required in at least one
+            Minimum fraction of cells with a positive feature value required in at least one
             compared group before DE results are reported. Values > 1 are interpreted
             as percentages.
         pseudobulk_p_adjust_method : str
@@ -2048,9 +1789,9 @@ class SpatialDataset:
             maximum number of parallel shared-fit contrasts. Must be at least
             one.
         pseudobulk_embed_top_n_per_comparison : int
-            Maximum significant DE genes to auto-embed per category or contact
-            comparison in embedded mode. Ignored in sidecar mode, where all gene
-            expression vectors are written to the sidecar.
+            Maximum significant DE features to auto-embed per category or contact
+            comparison in embedded mode. Ignored in sidecar mode, where all feature
+            vectors are written to the sidecar.
         interaction_marker_annotations : list, optional
             Internal list of obs columns to compute contact-conditioned
             pseudobulk interaction markers for. Empty/None disables them.
@@ -2063,7 +1804,7 @@ class SpatialDataset:
         interaction_markers_top_targets : int
             Number of target categories to evaluate per source (ranked by z-score or edge count).
         interaction_markers_top_genes : int
-            Number of top genes to keep per source-target interaction.
+            Number of top features to keep per source-target interaction.
         interaction_markers_min_cells : int
             Minimum cells required per replicate in both contact+ and contact-
             pseudobulk samples.
@@ -2599,7 +2340,7 @@ class SpatialDataset:
                 )
             return rows or None
 
-        def _compute_full_dispersion_stats(log_as_neighbor_child: bool = False) -> Dict[str, List[Dict[str, Any]]]:
+        def _compute_full_dispersion_stats() -> Dict[str, List[Dict[str, Any]]]:
             dispersion: Dict[str, List[Dict[str, Any]]] = {}
             candidates: Dict[str, Tuple[List[str], np.ndarray]] = {}
             for col, cdata in annotation_data.items():
@@ -2615,7 +2356,7 @@ class SpatialDataset:
                 f"Computing full-cell spatial dispersion for {len(candidates)} annotation"
                 f"{'s' if len(candidates) != 1 else ''}; output feeds Neighbors > Dispersion."
             )
-            log_detail(message, level=1)
+            log_step(message)
             for annotation_col, (cats, labels) in candidates.items():
                 rows = _compute_full_dispersion_for_labels(
                     categories=cats,
@@ -2627,7 +2368,7 @@ class SpatialDataset:
                     log_detail(
                         f"{annotation_col}: stored dispersion rows for {len(rows)} categor"
                         f"{'ies' if len(rows) != 1 else 'y'}.",
-                        level=2,
+                        level=1,
                     )
             return dispersion
 
@@ -2672,7 +2413,7 @@ class SpatialDataset:
             if var.shape[0] != int(mod.matrix.shape[1]):
                 var = pd.DataFrame(index=[str(i) for i in range(int(mod.matrix.shape[1]))])
             var.index = var.index.map(str)
-            mod_adata = sc.AnnData(X=mod.matrix, obs=self.adata.obs.copy(), var=var)
+            mod_adata = ad.AnnData(X=mod.matrix, obs=self.adata.obs.copy(), var=var)
             for layer_name, layer_matrix in (mod.layers or {}).items():
                 if getattr(layer_matrix, "shape", None) == mod.matrix.shape:
                     mod_adata.layers[str(layer_name)] = layer_matrix
@@ -2700,10 +2441,121 @@ class SpatialDataset:
             )
             for modality_name in modality_names
         }
+        embedded_feature_names = [
+            str(feature)
+            for feature in (features or [])
+            if str(feature)
+        ]
+        analytics_requested_feature_names = [
+            str(feature)
+            for feature in (analytics_features if analytics_features is not None else (features or []))
+            if str(feature)
+        ]
+        feature_sets_by_modality = {
+            modality_name: set(features_by_modality.get(modality_name) or [])
+            for modality_name in modality_names
+        }
+        embedded_requested_features_by_modality = {
+            modality_name: [
+                feature
+                for feature in embedded_feature_names
+                if feature in feature_sets_by_modality.get(modality_name, set())
+            ]
+            for modality_name in modality_names
+        }
+        requested_features_by_modality = {
+            modality_name: [
+                feature
+                for feature in analytics_requested_feature_names
+                if feature in feature_sets_by_modality.get(modality_name, set())
+            ]
+            for modality_name in modality_names
+        }
         if analytics_modalities is None:
             analytics_modality_names = list(modality_names)
         else:
             analytics_modality_names = [str(name) for name in analytics_modalities if str(name) in modality_names]
+
+        def _significant_de_genes(
+            payload: Any,
+            padj_threshold: float,
+            log2fc_threshold: float,
+            *,
+            exclude_category_vs_rest: bool = False,
+            limit_per_comparison: int = 20,
+        ) -> List[str]:
+            found: List[str] = []
+            limit = int(limit_per_comparison)
+            if limit == 0:
+                return found
+
+            def _walk(node: Any, key: Optional[str] = None) -> None:
+                if not isinstance(node, dict):
+                    return
+                if exclude_category_vs_rest and key == "__rest__":
+                    return
+                genes_list = node.get("genes")
+                padj_list = node.get("pvals_adj")
+                log2fc_list = node.get("log2foldchanges")
+                if (
+                    isinstance(genes_list, list)
+                    and isinstance(padj_list, list)
+                    and isinstance(log2fc_list, list)
+                ):
+                    ranked = []
+                    for idx, (gene, padj, log2fc) in enumerate(zip(genes_list, padj_list, log2fc_list)):
+                        try:
+                            padj_value = float(padj)
+                            log2fc_value = float(log2fc)
+                        except (TypeError, ValueError):
+                            continue
+                        if (
+                            np.isfinite(padj_value)
+                            and np.isfinite(log2fc_value)
+                            and padj_value < padj_threshold
+                            and abs(log2fc_value) >= log2fc_threshold
+                        ):
+                            ranked.append((padj_value, -abs(log2fc_value), idx, str(gene)))
+                    ranked.sort(key=lambda item: (item[0], item[1], item[2], item[3]))
+                    if limit > 0:
+                        ranked = ranked[:limit]
+                    found.extend(gene for *_score, gene in ranked)
+                for child_key, value in node.items():
+                    if isinstance(value, dict):
+                        _walk(value, str(child_key))
+
+            _walk(payload)
+            return found
+
+        def _html_embedded_feature_candidates_for_modality(
+            modality_name: str,
+            pseudobulk_payload: Optional[Mapping[str, Any]] = None,
+            interaction_payload: Optional[Mapping[str, Any]] = None,
+        ) -> List[str]:
+            available = feature_sets_by_modality.get(modality_name, set())
+            requested = list(embedded_requested_features_by_modality.get(modality_name) or [])
+            auto_features: List[str] = []
+            auto_features.extend(
+                _significant_de_genes(
+                    pseudobulk_payload or {},
+                    float(pseudobulk_padj_cutoff),
+                    float(pseudobulk_log2fc_cutoff),
+                    limit_per_comparison=int(pseudobulk_embed_top_n_per_comparison),
+                )
+            )
+            auto_features.extend(
+                _significant_de_genes(
+                    interaction_payload or {},
+                    float(pseudobulk_padj_cutoff),
+                    float(pseudobulk_log2fc_cutoff),
+                    limit_per_comparison=int(pseudobulk_embed_top_n_per_comparison),
+                )
+            )
+            return [
+                feature
+                for feature in dict.fromkeys([*requested, *auto_features])
+                if feature in available
+            ]
 
         replicate_override = str(pseudobulk_replicate_annotation or "").strip()
         pseudobulk_replicate_name = replicate_override or str(self.section_key)
@@ -2722,8 +2574,6 @@ class SpatialDataset:
             modality_name: {} for modality_name in pseudobulk_modality_names
         }
         companion_pseudobulk_de = companion_analytics.get("pseudobulk_de")
-        companion_gene_means = companion_analytics.get("category_gene_means")
-        companion_de_method = companion_analytics.get("cluster_de_method")
         if requested_pseudobulk_de_annotations:
             pseudobulk_min_cells_n = int(pseudobulk_min_cells_per_pseudobulk)
             pseudobulk_min_cell_counts_n = int(pseudobulk_min_cell_counts)
@@ -2783,19 +2633,7 @@ class SpatialDataset:
                             f"{'s' if len(reused_pseudobulk_de_annotations) != 1 else ''}."
                         )
                         for annotation_key in reused_pseudobulk_de_annotations:
-                            reused_payload = _strip_category_pseudobulk_sample_diagnostics(
-                                companion_pseudobulk_de[annotation_key]
-                            )
-                            # Companion cluster DE lacks _summary and a method tag;
-                            # stitch in per-cluster means + a cell-level source tag so
-                            # the badge/category panels render correctly.
-                            reused_payload = _backfill_companion_pseudobulk_summary(
-                                reused_payload,
-                                annotation_key,
-                                companion_gene_means,
-                                companion_de_method,
-                            )
-                            modality_pseudobulk_de[annotation_key] = reused_payload
+                            modality_pseudobulk_de[annotation_key] = companion_pseudobulk_de[annotation_key]
                     pending_pseudobulk_de_annotations = [
                         annotation_key
                         for annotation_key in pending_pseudobulk_de_annotations
@@ -2873,6 +2711,17 @@ class SpatialDataset:
                         n_cpus=max(1, int(pseudobulk_n_cpus)),
                     )
                     if annotation_results:
+                        embedded_feature_count = len(
+                            _html_embedded_feature_candidates_for_modality(
+                                modality_name,
+                                {annotation_key: annotation_results},
+                            )
+                        )
+                        log_detail(
+                            f"Features selected for HTML embedding for modality "
+                            f"{modality_name}: {embedded_feature_count:,}.",
+                            level=2,
+                        )
                         modality_pseudobulk_de[annotation_key] = annotation_results
                     elif not sample_metadata_model:
                         # Pseudobulk DESeq2 needs >= 2 biological replicates. When it
@@ -2934,16 +2783,18 @@ class SpatialDataset:
             for annotation_key in requested_neighbor_stats_annotations
             if annotation_key not in neighbor_stats
         ]
-        printed_neighbor_stats_header = False
         if neighbor_graph is not None and pending_neighbor_stats_annotations:
+            log_step(
+                f"Computing neighbor composition stats for {len(pending_neighbor_stats_annotations)} "
+                f"annotation column{'s' if len(pending_neighbor_stats_annotations) != 1 else ''}; "
+                "output feeds Neighbors > Enrichment and Neighbors > Interactions."
+            )
             for annotation_key in pending_neighbor_stats_annotations:
-                log_step(f"Neighbor stats: annotation column {annotation_key}")
+                log_step(f"Neighbor stats: annotation column {annotation_key}", level=1)
                 log_detail(
-                    "Computing observed neighbor composition; output feeds Neighbors > Enrichment "
-                    "and Neighbors > Interactions.",
-                    level=1,
+                    "Computing observed neighbor composition.",
+                    level=2,
                 )
-                printed_neighbor_stats_header = True
                 entry, context = _prepare_neighbor_stats_annotations(annotation_key)
                 if entry is None or context is None:
                     continue
@@ -2951,7 +2802,7 @@ class SpatialDataset:
                 neighbor_stats_context[annotation_key] = context
                 log_detail(
                     f"Stored neighbor matrix for {len(entry.get('categories') or [])} categories.",
-                    level=1,
+                    level=2,
                 )
 
         # Compute contact-conditioned interaction markers:
@@ -3084,62 +2935,7 @@ class SpatialDataset:
             else {}
         )
 
-        dispersion_stats = _compute_full_dispersion_stats(
-            log_as_neighbor_child=printed_neighbor_stats_header
-        )
-
-        def _significant_de_genes(
-            payload: Any,
-            padj_threshold: float,
-            log2fc_threshold: float,
-            *,
-            exclude_category_vs_rest: bool = False,
-            limit_per_comparison: int = 20,
-        ) -> List[str]:
-            found: List[str] = []
-            limit = int(limit_per_comparison)
-            if limit == 0:
-                return found
-
-            def _walk(node: Any, key: Optional[str] = None) -> None:
-                if not isinstance(node, dict):
-                    return
-                if exclude_category_vs_rest and key == "__rest__":
-                    return
-                genes_list = node.get("genes")
-                padj_list = node.get("pvals_adj")
-                log2fc_list = node.get("log2foldchanges")
-                if not isinstance(log2fc_list, list):
-                    log2fc_list = node.get("logfoldchanges")
-                if (
-                    isinstance(genes_list, list)
-                    and isinstance(padj_list, list)
-                    and isinstance(log2fc_list, list)
-                ):
-                    ranked = []
-                    for idx, (gene, padj, log2fc) in enumerate(zip(genes_list, padj_list, log2fc_list)):
-                        try:
-                            padj_value = float(padj)
-                            log2fc_value = float(log2fc)
-                        except (TypeError, ValueError):
-                            continue
-                        if (
-                            np.isfinite(padj_value)
-                            and np.isfinite(log2fc_value)
-                            and padj_value < padj_threshold
-                            and abs(log2fc_value) >= log2fc_threshold
-                        ):
-                            ranked.append((padj_value, -abs(log2fc_value), idx, str(gene)))
-                    ranked.sort(key=lambda item: (item[0], item[1], item[2], item[3]))
-                    if limit > 0:
-                        ranked = ranked[:limit]
-                    found.extend(gene for *_score, gene in ranked)
-                for child_key, value in node.items():
-                    if isinstance(value, dict):
-                        _walk(value, str(child_key))
-
-            _walk(payload)
-            return found
+        dispersion_stats = _compute_full_dispersion_stats()
 
         def _pseudobulk_de_marker_genes(
             payload: Any,
@@ -3172,7 +2968,7 @@ class SpatialDataset:
                             continue
                         genes_list = result.get("genes")
                         padj_list = result.get("pvals_adj")
-                        log2fc_list = result.get("log2foldchanges") or result.get("logfoldchanges")
+                        log2fc_list = result.get("log2foldchanges")
                         if (
                             not isinstance(genes_list, list)
                             or not isinstance(padj_list, list)
@@ -3208,37 +3004,31 @@ class SpatialDataset:
                     markers[str(color_name)] = color_markers
             return markers
 
-        requested_features = list(features or [])
         de_embed_limit = int(pseudobulk_embed_top_n_per_comparison)
-        de_gene_candidates = []
-        de_gene_candidates.extend(
-            _significant_de_genes(
+        de_gene_candidates = list(dict.fromkeys([
+            *_significant_de_genes(
                 pseudobulk_de,
                 float(pseudobulk_padj_cutoff),
                 float(pseudobulk_log2fc_cutoff),
                 limit_per_comparison=de_embed_limit,
-            )
-        )
-        de_gene_candidates.extend(
-            _significant_de_genes(
+            ),
+            *_significant_de_genes(
                 interaction_markers,
                 float(pseudobulk_padj_cutoff),
                 float(pseudobulk_log2fc_cutoff),
                 limit_per_comparison=de_embed_limit,
-            )
-        )
-        export_genes = list(
-            dict.fromkeys(
-                gene
-                for gene in [*requested_features, *de_gene_candidates]
-                if gene in self.adata.var_names
-            )
+            ),
+        ]))
+        export_genes = _html_embedded_feature_candidates_for_modality(
+            default_modality_name,
+            pseudobulk_de,
+            interaction_markers,
         )
         if de_gene_candidates:
-            log_step("Preparing expression viewer gene payload")
+            log_step("Preparing viewer feature payload")
             log_detail(
-                f"Embedding {len(export_genes)} requested/significant DE gene"
-                f"{'s' if len(export_genes) != 1 else ''} in the HTML expression viewer "
+                f"Embedding {len(export_genes)} requested/significant DE feature"
+                f"{'s' if len(export_genes) != 1 else ''} in the HTML feature viewer "
                 f"(padj < {float(pseudobulk_padj_cutoff):g}, "
                 f"|log2FC| >= {float(pseudobulk_log2fc_cutoff):g}; "
                 f"automatic cap={de_embed_limit} per comparison).",
@@ -3249,9 +3039,6 @@ class SpatialDataset:
             float(pseudobulk_padj_cutoff),
             float(pseudobulk_log2fc_cutoff),
         )
-        pseudobulk_de = _drop_legacy_logfoldchanges(pseudobulk_de)
-        interaction_markers = _drop_legacy_logfoldchanges(interaction_markers)
-
         feature_data = self._collect_feature_data(export_genes)
         feature_encodings = self._resolve_feature_encodings(feature_data, feature_encoding, feature_sparse_zero_threshold)
         embedded_features_by_modality: Dict[str, List[str]] = {
@@ -3305,7 +3092,7 @@ class SpatialDataset:
                     "b64": _b64(np.ascontiguousarray(sec_matrix, dtype="<f4")),
                 }
 
-            # Build gene expression values for this section
+            # Build feature values for this section
             section_features_dense = {}
             section_features_sparse = {}
             for gene, gdata in feature_data.items():
@@ -3440,6 +3227,64 @@ class SpatialDataset:
             "feature_value_encodings": feature_value_encodings,
             "sections": default_modality_section_features,
         }
+        for modality_name in modality_names:
+            if modality_name == default_modality_name:
+                continue
+            modality_requested_features = _html_embedded_feature_candidates_for_modality(
+                modality_name,
+                pseudobulk_de_by_modality.get(modality_name),
+                interaction_markers_by_modality.get(modality_name),
+            )
+            if not modality_requested_features:
+                continue
+            modality_feature_data = self._collect_feature_data(
+                modality_requested_features,
+                modality=modality_name,
+            )
+            modality_feature_encodings = self._resolve_feature_encodings(
+                modality_feature_data,
+                feature_encoding,
+                feature_sparse_zero_threshold,
+            )
+            modality_feature_value_encodings = {
+                feature: "float32" for feature in modality_feature_data
+            }
+            modality_section_features: Dict[str, Dict[str, Dict[str, Any]]] = {}
+            for section in self.sections:
+                idx = export_section_indices[section.section_id]
+                section_features_dense = {}
+                section_features_sparse = {}
+                for feature, fdata in modality_feature_data.items():
+                    section_vals = fdata["values"][idx]
+                    mode = modality_feature_encodings.get(feature, "dense")
+                    payload = self._serialize_feature_section_values(
+                        section_vals=np.asarray(section_vals),
+                        mode=mode,
+                        feature_sparse_pack=feature_sparse_pack,
+                        feature_sparse_pack_min_nnz=feature_sparse_pack_min_nnz,
+                        b64_encoder=_b64,
+                    )
+                    if "sparse" in payload:
+                        section_features_sparse[feature] = payload["sparse"]
+                    else:
+                        section_features_dense[feature] = payload["dense"]
+                modality_section_features[section.section_id] = {
+                    "features": section_features_dense,
+                    "features_sparse": section_features_sparse,
+                }
+            embedded_features_by_modality[modality_name] = list(modality_feature_data.keys())
+            feature_state_by_modality[modality_name] = {
+                "features_meta": {
+                    feature: {
+                        "vmin": fdata["vmin"],
+                        "vmax": fdata["vmax"],
+                    }
+                    for feature, fdata in modality_feature_data.items()
+                },
+                "feature_encodings": modality_feature_encodings,
+                "feature_value_encodings": modality_feature_value_encodings,
+                "sections": modality_section_features,
+            }
         marker_features_by_modality = {
             modality_name: _pseudobulk_de_marker_genes(
                 modality_payload,
@@ -3447,19 +3292,6 @@ class SpatialDataset:
                 float(pseudobulk_log2fc_cutoff),
             )
             for modality_name, modality_payload in pseudobulk_de_by_modality.items()
-        }
-        requested_feature_names = [
-            str(feature)
-            for feature in (analytics_features if analytics_features is not None else (features or []))
-            if str(feature)
-        ]
-        requested_features_by_modality = {
-            modality_name: [
-                feature
-                for feature in requested_feature_names
-                if feature in set(features_by_modality.get(modality_name) or [])
-            ]
-            for modality_name in modality_names
         }
 
         def _flatten_marker_features(payload: Any) -> List[str]:
@@ -3528,6 +3360,7 @@ class SpatialDataset:
                     modality_adata,
                     list(features_by_modality.get(modality_name) or []),
                     n_features=int(spatial_variable_genes_n),
+                    modality_name=modality_name,
                 )
 
         return {
@@ -3629,7 +3462,7 @@ def _coerce_modality_var(uns_var: Any, expected_rows: int) -> Optional[pd.DataFr
     return df
 
 
-def _detect_modalities(adata: sc.AnnData) -> Dict[str, Modality]:
+def _detect_modalities(adata: ad.AnnData) -> Dict[str, Modality]:
     modalities: Dict[str, Modality] = {}
     rna_var = adata.var.copy()
     rna_layers: Dict[str, Any] = {}
@@ -3722,7 +3555,7 @@ def load_spatial_data(
     """
     adata, source_label, spatialdata_table_key = _coerce_input_to_anndata(path, spatialdata_table)
     log_step(f"Loading input data from {source_label}")
-    log_detail(f"Loaded AnnData table with {adata.n_obs:,} cells x {adata.n_vars:,} genes.")
+    log_detail(f"Loaded AnnData table with {adata.n_obs:,} cells x {adata.n_vars:,} features.")
 
     section_key = _resolve_section_key_for_spatialdata(adata, section_key, spatialdata_table_key)
 

--- a/karospace/data_loader.py
+++ b/karospace/data_loader.py
@@ -2513,6 +2513,20 @@ class SpatialDataset:
 
         pseudobulk_modality_names = _normalize_pseudobulk_modalities(pseudobulk_modalities)
         primary_pseudobulk_modality = pseudobulk_modality_names[0] if pseudobulk_modality_names else None
+        modality_names = list(self.modalities.keys()) or [str(self.default_modality or "rna")]
+        default_modality_name = (
+            str(self.default_modality)
+            if str(self.default_modality) in modality_names
+            else modality_names[0]
+        )
+        features_by_modality = {
+            modality_name: (
+                list(self.modalities[modality_name].feature_names)
+                if self.modalities and modality_name in self.modalities
+                else list(self.var_names)
+            )
+            for modality_name in modality_names
+        }
 
         replicate_override = str(pseudobulk_replicate_annotation or "").strip()
         pseudobulk_replicate_name = replicate_override or str(self.section_key)
@@ -2527,7 +2541,9 @@ class SpatialDataset:
             pseudobulk_simple_constrast_categories,
             requested_pseudobulk_de_annotations,
         )
-        pseudobulk_de_by_modality: Dict[str, Dict[str, Any]] = {}
+        pseudobulk_de_by_modality: Dict[str, Dict[str, Any]] = {
+            modality_name: {} for modality_name in pseudobulk_modality_names
+        }
         companion_pseudobulk_de = companion_analytics.get("pseudobulk_de")
         companion_gene_means = companion_analytics.get("category_gene_means")
         companion_de_method = companion_analytics.get("cluster_de_method")
@@ -2764,7 +2780,9 @@ class SpatialDataset:
         # Compute contact-conditioned interaction markers:
         # for source S and target T, compare source cells contacting T vs source cells not contacting T.
         requested_interaction_marker_annotations = list(interaction_marker_annotations or [])
-        interaction_markers_by_modality: Dict[str, Dict[str, Any]] = {}
+        interaction_markers_by_modality: Dict[str, Dict[str, Any]] = {
+            modality_name: {} for modality_name in pseudobulk_modality_names
+        }
         companion_interaction_markers = companion_analytics.get("interaction_markers")
         if neighbor_graph is not None and requested_interaction_marker_annotations:
             top_targets = int(interaction_markers_top_targets)
@@ -3059,6 +3077,23 @@ class SpatialDataset:
 
         feature_data = self._collect_feature_data(export_genes)
         feature_encodings = self._resolve_feature_encodings(feature_data, feature_encoding, feature_sparse_zero_threshold)
+        embedded_features_by_modality: Dict[str, List[str]] = {
+            modality_name: [] for modality_name in modality_names
+        }
+        embedded_features_by_modality[default_modality_name] = list(feature_data.keys())
+        feature_value_encodings = {
+            feature: "float32" for feature in feature_data
+        }
+        feature_state_by_modality: Dict[str, Dict[str, Any]] = {
+            modality_name: {
+                "features_meta": {},
+                "feature_encodings": {},
+                "feature_value_encodings": {},
+                "sections": {},
+            }
+            for modality_name in modality_names
+        }
+        default_modality_section_features: Dict[str, Dict[str, Dict[str, Any]]] = {}
 
         # Build section data with all color layers
         sections_data = []
@@ -3094,8 +3129,8 @@ class SpatialDataset:
                 }
 
             # Build gene expression values for this section
-            section_genes_dense = {}
-            section_genes_sparse = {}
+            section_features_dense = {}
+            section_features_sparse = {}
             for gene, gdata in feature_data.items():
                 section_vals = gdata["values"][idx]
                 mode = feature_encodings.get(gene, "dense")
@@ -3107,9 +3142,13 @@ class SpatialDataset:
                     b64_encoder=_b64,
                 )
                 if "sparse" in payload:
-                    section_genes_sparse[gene] = payload["sparse"]
+                    section_features_sparse[gene] = payload["sparse"]
                 else:
-                    section_genes_dense[gene] = payload["dense"]
+                    section_features_dense[gene] = payload["dense"]
+            default_modality_section_features[section.section_id] = {
+                "features": section_features_dense,
+                "features_sparse": section_features_sparse,
+            }
 
             section_entry = {
                 "id": section.section_id,
@@ -3125,8 +3164,6 @@ class SpatialDataset:
                 "colors": section_colors,
                 "colors_b64": section_colors_b64,
                 "proportions_b64": section_proportions_b64,
-                "genes": section_genes_dense,
-                "genes_sparse": section_genes_sparse,
                 "bounds": {
                     "xmin": float(section_coords[:, 0].min()) if len(idx) > 0 else 0,
                     "xmax": float(section_coords[:, 0].max()) if len(idx) > 0 else 0,
@@ -3213,13 +3250,27 @@ class SpatialDataset:
                 "vmax": None,
             }
 
-        # Build gene metadata
+        # Build embedded feature metadata for the default modality.
         features_meta = {}
         for gene, gdata in feature_data.items():
             features_meta[gene] = {
                 "vmin": gdata["vmin"],
                 "vmax": gdata["vmax"],
             }
+        feature_state_by_modality[default_modality_name] = {
+            "features_meta": features_meta,
+            "feature_encodings": feature_encodings,
+            "feature_value_encodings": feature_value_encodings,
+            "sections": default_modality_section_features,
+        }
+        marker_features_by_modality = {
+            modality_name: _pseudobulk_de_marker_genes(
+                modality_payload,
+                float(pseudobulk_padj_cutoff),
+                float(pseudobulk_log2fc_cutoff),
+            )
+            for modality_name, modality_payload in pseudobulk_de_by_modality.items()
+        }
 
         return {
             "initial_annotation": annotation,
@@ -3241,28 +3292,62 @@ class SpatialDataset:
                 "embed_top_n_per_comparison": int(pseudobulk_embed_top_n_per_comparison),
             },
             "annotations_meta": annotations_meta,
-            "features_meta": features_meta,
-            "feature_encodings": feature_encodings,
+            "modalities": [
+                {
+                    "name": modality_name,
+                    "label": (
+                        self.modalities[modality_name].label
+                        if self.modalities and modality_name in self.modalities
+                        else modality_name
+                    ),
+                    "value_kind": (
+                        self.modalities[modality_name].value_kind
+                        if self.modalities and modality_name in self.modalities
+                        else "counts"
+                    ),
+                    "n_features": len(features_by_modality[modality_name]),
+                    "is_default": modality_name == default_modality_name,
+                }
+                for modality_name in modality_names
+            ],
+            "default_modality": default_modality_name,
+            "features_by_modality": features_by_modality,
+            "embedded_features_by_modality": embedded_features_by_modality,
+            "feature_state_by_modality": feature_state_by_modality,
+            "requested_features_by_modality": {},
             "metadata_filters": metadata_filters,
             "section_metadata": list(self.section_metadata),
             "section_metadata_extra": list(self.section_metadata_extra),
             "n_sections": len(sections_data),
             "total_cells": sum(s["n_cells"] for s in sections_data),
-            "loaded_features": len(features_meta),
+            "loaded_features_by_modality": {
+                modality_name: len(features)
+                for modality_name, features in embedded_features_by_modality.items()
+            },
             "sections": sections_data,
             "available_annotations": list(annotation_data.keys()) + list(decon_data.keys()),
             "available_deconvolutions": list(decon_data.keys()),
-            "available_features": list(feature_data.keys()),
-            "marker_genes": marker_genes,
-            "pseudobulk_de": pseudobulk_de,
+            "marker_features_by_modality": marker_features_by_modality,
             "pseudobulk_de_by_modality": pseudobulk_de_by_modality,
             "has_umap": umap_coords is not None,
             "umap_bounds": umap_bounds,
             "has_neighbors": neighbor_graph is not None,
             "neighbors_key": neighbor_graph_key,
             "neighbor_stats": neighbor_stats,
-            "interaction_markers": interaction_markers,
             "interaction_markers_by_modality": interaction_markers_by_modality,
+            "category_feature_means_by_modality": {
+                modality_name: None for modality_name in modality_names
+            },
+            "feature_correlations_by_modality": {
+                modality_name: {} for modality_name in modality_names
+            },
+            "spatial_variable_features_by_modality": {
+                modality_name: [] for modality_name in modality_names
+            },
+            "pathway_settings_by_modality": {
+                modality_name: {"available": False, "reason": "not_computed"}
+                for modality_name in modality_names
+            },
             "dispersion_stats": dispersion_stats,
         }
 

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -7252,7 +7252,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             <button class="legend-toggle active" id="legend-toggle" title="Toggle legend panel" data-help="Show or hide the legend panel with annotation keys, category toggles, and spotlight controls.">
                 Legend
             </button>
-            <button class="insights-toggle" id="insights-toggle" title="Toggle Insights panel" data-help="Insights opens Overview, Genes, Compare, and Neighbors views for the current dataset and selection state.">
+            <button class="insights-toggle" id="insights-toggle" title="Toggle Insights panel" data-help="Insights opens Overview, Features, Compare, and Neighbors views for the current dataset and selection state.">
                 Insights
             </button>
         </div>
@@ -7907,9 +7907,41 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function isViewerFeatureLoadable(feature, modality = getVisualModality()) {{
         return isEmbeddedViewerFeature(feature, modality) || isSidecarViewerFeature(feature, modality);
     }}
-    function getCategoryVsRestGenes(annotationCol = explorationColorCol || currentAnnotation || '') {{
+    function getExplorationModality() {{
+        return getPanelModality('exploration');
+    }}
+    function setExplorationModality(modality) {{
+        return setPanelModality('exploration', modality);
+    }}
+    function getModalityPayload(payloadName, modality = getExplorationModality()) {{
+        let root = DATA[payloadName];
+        if (payloadName === 'pseudobulk_de_by_modality') root = DATA.pseudobulk_de_by_modality;
+        else if (payloadName === 'marker_features_by_modality') root = DATA.marker_features_by_modality;
+        else if (payloadName === 'category_feature_means_by_modality') root = DATA.category_feature_means_by_modality;
+        else if (payloadName === 'feature_correlations_by_modality') root = DATA.feature_correlations_by_modality;
+        else if (payloadName === 'spatial_variable_features_by_modality') root = DATA.spatial_variable_features_by_modality;
+        if (!root || typeof root !== 'object') return null;
+        return root[modality] || null;
+    }}
+    function getExplorationPseudobulkDEPayload(modality = getExplorationModality()) {{
+        return getModalityPayload('pseudobulk_de_by_modality', modality) || {{}};
+    }}
+    function getExplorationMarkerFeaturesPayload(modality = getExplorationModality()) {{
+        return getModalityPayload('marker_features_by_modality', modality) || {{}};
+    }}
+    function getExplorationCategoryFeatureMeansPayload(modality = getExplorationModality()) {{
+        return getModalityPayload('category_feature_means_by_modality', modality) || null;
+    }}
+    function getExplorationFeatureCorrelationsPayload(modality = getExplorationModality()) {{
+        return getModalityPayload('feature_correlations_by_modality', modality) || {{}};
+    }}
+    function getExplorationSpatialVariableFeaturesPayload(modality = getExplorationModality()) {{
+        const payload = getModalityPayload('spatial_variable_features_by_modality', modality);
+        return Array.isArray(payload) ? payload : [];
+    }}
+    function getCategoryVsRestGenes(annotationCol = explorationColorCol || currentAnnotation || '', modality = getExplorationModality()) {{
         const pseudobulkKey = getPseudobulkDEColorKey(annotationCol);
-        const byCategory = (DATA.pseudobulk_de || {{}})[pseudobulkKey] || {{}};
+        const byCategory = getExplorationPseudobulkDEPayload(modality)[pseudobulkKey] || {{}};
         const summaryGenes = byCategory?._summary?.category_gene_means?.genes;
         if (Array.isArray(summaryGenes) && summaryGenes.length) {{
             return uniqueSortedFeatures(summaryGenes);
@@ -7922,18 +7954,19 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }});
         return uniqueSortedFeatures(genes);
     }}
-    function renderInsightsGeneSearchOptions(selected = '', placeholder = 'All genes') {{
+    function renderInsightsGeneSearchOptions(selected = '', placeholder = 'All features') {{
+        const modality = getExplorationModality();
         const selectedValue = String(selected || '');
-        const embedded = getGeneInputFeatureList();
+        const embedded = getFeatureDatalistValuesForModality(modality);
         const embeddedSet = new Set(embedded);
-        const categoryVsRest = getCategoryVsRestGenes()
+        const categoryVsRest = getCategoryVsRestGenes(explorationColorCol || currentAnnotation || '', modality)
             .filter(gene => !embeddedSet.has(gene));
         const allFeatures = new Set([...embedded, ...categoryVsRest]);
         const current = allFeatures.has(selectedValue) ? selectedValue : '';
         const emptySelected = current ? '' : ' selected';
         const options = [`<option value=""${{emptySelected}}>${{escapeHtml(placeholder)}}</option>`];
         if (embedded.length) {{
-            options.push('<optgroup label="Embedded genes">');
+            options.push(`<optgroup label="${{escapeHtml(getModalityDisplayLabel(modality))}} features">`);
             embedded.forEach((gene) => {{
                 const isSelected = gene === current ? ' selected' : '';
                 options.push(`<option value="${{escapeHtml(gene)}}"${{isSelected}}>${{escapeHtml(gene)}}</option>`);
@@ -7941,7 +7974,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             options.push('</optgroup>');
         }}
         if (categoryVsRest.length) {{
-            options.push('<optgroup label="Balanced-rest genes (not embedded)">');
+            options.push('<optgroup label="Balanced-rest features (not embedded)">');
             categoryVsRest.forEach((gene) => {{
                 const isSelected = gene === current ? ' selected' : '';
                 options.push(`<option value="${{escapeHtml(gene)}}"${{isSelected}}>${{escapeHtml(gene)}}</option>`);
@@ -7952,7 +7985,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
     function refreshLoadedGeneFilterDropdowns() {{
         [
-            ['marker-gene-search', 'All genes'],
+            ['marker-gene-search', 'All features'],
         ].forEach(([id, placeholder]) => {{
             const select = document.getElementById(id);
             if (!select) return;
@@ -7961,7 +7994,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
     function getInsightsSelectedGene() {{
         const value = String(document.getElementById('marker-gene-search')?.value || '').trim();
-        return value ? (resolveCanonicalFeatureName(value) || value) : '';
+        return value ? (resolveCanonicalFeatureName(value, getExplorationModality()) || value) : '';
     }}
     function getFeatureDatalistValuesForModality(modality = getVisualModality()) {{
         if (isModuleModality(modality)) return uniqueSortedFeatures(getGeneModuleDatalistValues());
@@ -9425,10 +9458,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const openTutorialVisualizationLeafMenu = (topLevel, subtab, nestedBranch = null) => {{
             if (typeof closeModal === 'function') closeModal();
             if (typeof openInsightsMode === 'function') openInsightsMode('exploration');
+            topLevel = normalizeInsightsTopLevelName(topLevel);
             insightsTreeOpen = true;
             insightsTreeOpenBranch = topLevel;
             insightsTreeOpenCompareBranch = topLevel === 'compare' ? nestedBranch : null;
-            insightsTreeOpenGenesBranch = topLevel === 'genes' ? nestedBranch : null;
+            insightsTreeOpenGenesBranch = topLevel === 'features' ? nestedBranch : null;
             insightsTreeSelectedLeaf = null;
             syncInsightsModeClasses?.();
             syncInsightsTabClasses?.();
@@ -9680,8 +9714,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 'The Visualization menu is the navigation tree.'
             ], {{ action: () => {{ if (typeof openInsightsMode === 'function') openInsightsMode('exploration'); }}, onNext: () => {{ const tree = document.querySelector('[data-insights-tree]'); if (!tree?.classList.contains('is-open')) safeTutorialClick('[data-insights-tree-root]'); }}, nextLabel: tryIt }}),
             step('Visualization menu options', ['.insights-tree-panel-content', '[data-insights-tree]'], [
-                'The menu options open Overview, Genes, Compare, and Neighbors panels.',
-                'Overview summarizes section composition and metadata trends; Genes focuses marker, spatial, distribution, and mean-expression gene views; Compare contains selection, region, annotation, pseudobulk, and relationship comparisons; Neighbors contains spatial adjacency, interaction, and dispersion analyses.'
+                'The menu options open Overview, Features, Compare, and Neighbors panels.',
+                'Overview summarizes section composition and metadata trends; Features focuses marker, spatial, distribution, and mean-expression feature views; Compare contains selection, region, annotation, pseudobulk, and relationship comparisons; Neighbors contains spatial adjacency, interaction, and dispersion analyses.'
             ], {{ action: () => {{ if (typeof openInsightsMode === 'function') openInsightsMode('exploration'); const tree = document.querySelector('[data-insights-tree]'); if (!tree?.classList.contains('is-open')) safeTutorialClick('[data-insights-tree-root]'); }}, nextLabel: tryIt }}),
             step('Open Overview > Summary', '[data-insights-tree-leaf="summary"][data-insights-tree-parent="overview"]', [
                 'Open Visualization, then Overview, then Summary to inspect annotation composition across section metadata.',
@@ -9707,53 +9741,53 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             step('Overview Sections view switch', '.samples-view-icon-toggle', [
                 'The section composition switch changes the same data between stacked bars and a heatmap.'
             ], {{ action: () => openTutorialInsightsPanel('overview', 'sections'), scrollDelay: 720, nextLabel: tryIt }}),
-            step('Open Genes > Markers', '[data-insights-tree-leaf="de-genes"][data-insights-tree-parent="genes"]', [
-                'Open Visualization, then Genes, then Markers to inspect exported pseudobulk marker genes.'
-            ], {{ action: () => openTutorialVisualizationLeafMenu('genes', 'de-genes'), task: 'Click Markers in the Genes options.', nextLabel: tryIt }}),
-            step('Genes Markers panel', ['#marker-genes', '#genes-tab-de-genes-content'], [
-                'The marker panel lists pseudobulk-derived marker genes by category when available.',
-                'Genes that were not embedded may be shown but disabled for direct expression viewing.'
+            step('Open Features > Markers', '[data-insights-tree-leaf="de-genes"][data-insights-tree-parent="features"]', [
+                'Open Visualization, then Features, then Markers to inspect exported pseudobulk marker features.'
+            ], {{ action: () => openTutorialVisualizationLeafMenu('genes', 'de-genes'), task: 'Click Markers in the Features options.', nextLabel: tryIt }}),
+            step('Features Markers panel', ['#marker-genes', '#genes-tab-de-genes-content'], [
+                'The marker panel lists pseudobulk-derived marker features by category when available.',
+                'Features that were not embedded may be shown but disabled for direct expression viewing.'
             ], {{ action: () => openTutorialInsightsPanel('genes', 'de-genes'), nextLabel: tryIt }}),
-            step('Genes Markers view switch', '[data-gene-subtab-toggle="de-genes"]', [
-                'The marker view switch changes between a compact gene list and a heatmap.'
+            step('Features Markers view switch', '[data-gene-subtab-toggle="de-genes"]', [
+                'The marker view switch changes between a compact feature list and a heatmap.'
             ], {{ action: () => openTutorialInsightsPanel('genes', 'de-genes'), scrollDelay: 720, nextLabel: tryIt }}),
-            step('Open Genes > Spatial', '[data-insights-tree-leaf="spatial"][data-insights-tree-parent="genes"]', [
-                'Open Visualization, then Genes, then Spatial to inspect spatially variable genes.'
-            ], {{ action: () => openTutorialVisualizationLeafMenu('genes', 'spatial'), task: 'Click Spatial in the Genes options.', nextLabel: tryIt }}),
-            step('Genes Spatial panel', ['#spatially-variable-genes', '#genes-tab-spatial-content'], [
-                'The Spatial genes panel shows Moran Index rankings computed at export.',
-                'High values suggest genes with stronger spatial autocorrelation.'
+            step('Open Features > Spatial', '[data-insights-tree-leaf="spatial"][data-insights-tree-parent="features"]', [
+                'Open Visualization, then Features, then Spatial to inspect spatially variable features.'
+            ], {{ action: () => openTutorialVisualizationLeafMenu('genes', 'spatial'), task: 'Click Spatial in the Features options.', nextLabel: tryIt }}),
+            step('Features Spatial panel', ['#spatially-variable-genes', '#genes-tab-spatial-content'], [
+                'The Spatial features panel shows Moran Index rankings computed at export.',
+                'High values suggest features with stronger spatial autocorrelation.'
             ], {{ action: () => openTutorialInsightsPanel('genes', 'spatial'), nextLabel: tryIt }}),
-            step('Genes Spatial view switch', '[data-gene-subtab-toggle="spatial"]', [
+            step('Features Spatial view switch', '[data-gene-subtab-toggle="spatial"]', [
                 'The Spatial panel can be shown as a ranked list or as a graph.'
             ], {{ action: () => openTutorialInsightsPanel('genes', 'spatial'), nextLabel: tryIt }}),
-            step('Open Genes > Distribution > Per cell', '[data-insights-tree-leaf="distribution"][data-insights-tree-parent="genes"]', [
-                'Open Visualization, then Genes, then Distribution, then Per cell to inspect expression distributions.',
+            step('Open Features > Distribution > Per cell', '[data-insights-tree-leaf="distribution"][data-insights-tree-parent="features"]', [
+                'Open Visualization, then Features, then Distribution, then Per cell to inspect feature distributions.',
                 'All calculation in this section is done on cells embedded in the HTML file.'
-            ], {{ action: () => openTutorialVisualizationLeafMenu('genes', 'distribution', 'distribution'), task: 'Click Per cell in the Genes > Distribution options.', nextLabel: tryIt }}),
-            step('Genes Distribution per cell gene search', '.marker-gene-search-wrap', [
-                'Enter or select a gene in the Search control.'
-            ], {{ action: () => openTutorialInsightsPanel('genes', 'distribution'), task: 'Enter or select a gene in Search.', requiresInsightsGeneSelected: true, nextLabel: tryIt }}),
-            step('Genes Distribution per cell panel', ['#gene-distribution-panel', '#genes-tab-distribution-content'], [
+            ], {{ action: () => openTutorialVisualizationLeafMenu('genes', 'distribution', 'distribution'), task: 'Click Per cell in the Features > Distribution options.', nextLabel: tryIt }}),
+            step('Features Distribution per cell search', '.marker-gene-search-wrap', [
+                'Enter or select a feature in the Search control.'
+            ], {{ action: () => openTutorialInsightsPanel('genes', 'distribution'), task: 'Enter or select a feature in Search.', requiresInsightsGeneSelected: true, nextLabel: tryIt }}),
+            step('Features Distribution per cell panel', ['#gene-distribution-panel', '#genes-tab-distribution-content'], [
                 'The distribution panel summarizes expression distributions across categories.'
             ], {{ action: () => {{ openTutorialInsightsPanel('genes', 'distribution'); ensureTutorialInsightsGeneSelected(); }}, nextLabel: tryIt }}),
-            step('Genes Distribution per cell controls', '#gene-distribution-panel .pseudobulk-de-controls', [
+            step('Features Distribution per cell controls', '#gene-distribution-panel .pseudobulk-de-controls', [
                 'These controls restrict the per-cell distribution to a selected annotation or sample-metadata group.'
             ], {{ action: () => {{ openTutorialInsightsPanel('genes', 'distribution'); ensureTutorialInsightsGeneSelected(); }}, nextLabel: tryIt }}),
-            step('Genes Distribution per cell view switch', '.samples-view-toggle[data-gene-subtab-toggle="distribution"]', [
+            step('Features Distribution per cell view switch', '.samples-view-toggle[data-gene-subtab-toggle="distribution"]', [
                 'The distribution view switch changes between a table and a violin/boxplot.'
             ], {{ action: () => openTutorialInsightsPanel('genes', 'distribution'), prepareDelay: 420, scrollDelay: 520, spotlightPadding: 2, nextLabel: tryIt }}),
-            step('Open Genes > Distribution > Per sample', '[data-insights-tree-leaf="means"][data-insights-tree-parent="genes"]', [
-                'Open Visualization, then Genes, then Distribution, then Per sample to inspect pseudobulk statistics.',
+            step('Open Features > Distribution > Per sample', '[data-insights-tree-leaf="means"][data-insights-tree-parent="features"]', [
+                'Open Visualization, then Features, then Distribution, then Per sample to inspect pseudobulk statistics.',
                 'All calculation in this section is done on the raw data before the creation of the HTML file.'
-            ], {{ action: () => openTutorialVisualizationLeafMenu('genes', 'means', 'distribution'), task: 'Click Per sample in the Genes > Distribution options.', nextLabel: tryIt }}),
-            step('Genes Distribution per sample gene search', '.marker-gene-search-wrap', [
-                'Enter or select a gene in the Search control before inspecting the per-sample means panel.'
-            ], {{ action: () => openTutorialInsightsPanel('genes', 'means'), task: 'Enter or select a gene in Search.', requiresInsightsGeneSelected: true, nextLabel: tryIt }}),
-            step('Genes Distribution per sample panel', ['#pseudobulk-gene-means', '#genes-tab-means-content'], [
+            ], {{ action: () => openTutorialVisualizationLeafMenu('genes', 'means', 'distribution'), task: 'Click Per sample in the Features > Distribution options.', nextLabel: tryIt }}),
+            step('Features Distribution per sample search', '.marker-gene-search-wrap', [
+                'Enter or select a feature in the Search control before inspecting the per-sample means panel.'
+            ], {{ action: () => openTutorialInsightsPanel('genes', 'means'), task: 'Enter or select a feature in Search.', requiresInsightsGeneSelected: true, nextLabel: tryIt }}),
+            step('Features Distribution per sample panel', ['#pseudobulk-gene-means', '#genes-tab-means-content'], [
                 'The means panel uses pseudobulk mean per category to compare expression across categories.'
             ], {{ action: () => {{ openTutorialInsightsPanel('genes', 'means'); ensureTutorialInsightsGeneSelected(); }}, nextLabel: tryIt }}),
-            step('Genes Distribution per sample view switch', '.samples-view-toggle[data-gene-subtab-toggle="means"]', [
+            step('Features Distribution per sample view switch', '.samples-view-toggle[data-gene-subtab-toggle="means"]', [
                 'The per-sample means view can switch between category means and a barplot.'
             ], {{ action: () => openTutorialInsightsPanel('genes', 'means'), prepareDelay: 420, scrollDelay: 520, spotlightPadding: 2, nextLabel: tryIt }}),
             step('Open Compare > Per cell > Selections', '[data-insights-tree-leaf="selection"][data-insights-tree-parent="compare"]', [
@@ -9902,7 +9936,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ['Module gene picker', 'Module'],
             ['Exploration annotation selector', 'Exploration'],
             ['Open Overview > Summary', 'Exploration > Overview'],
-            ['Open Genes > Markers', 'Exploration > Genes'],
+            ['Open Features > Markers', 'Exploration > Features'],
             ['Open Compare > Per cell > Selections', 'Exploration > Compare'],
             ['Open Neighbors > Enrichment', 'Exploration > Neighbors'],
             ['Finish the tutorial', 'Finish']
@@ -9910,7 +9944,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const chaptersAfterModuleWithoutTasks = new Set([
             'Exploration',
             'Exploration > Overview',
-            'Exploration > Genes',
+            'Exploration > Features',
             'Exploration > Compare',
             'Exploration > Neighbors',
             'Finish',
@@ -10428,10 +10462,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const map = {{
             'Open Overview > Summary': ['overview', 'summary', null],
             'Open Overview > Sections': ['overview', 'sections', null],
-            'Open Genes > Markers': ['genes', 'de-genes', null],
-            'Open Genes > Spatial': ['genes', 'spatial', null],
-            'Open Genes > Distribution > Per cell': ['genes', 'distribution', 'distribution'],
-            'Open Genes > Distribution > Per sample': ['genes', 'means', 'distribution'],
+            'Open Features > Markers': ['features', 'de-genes', null],
+            'Open Features > Spatial': ['features', 'spatial', null],
+            'Open Features > Distribution > Per cell': ['features', 'distribution', 'distribution'],
+            'Open Features > Distribution > Per sample': ['features', 'means', 'distribution'],
             'Open Compare > Per cell > Selections': ['compare', 'selection', 'quick'],
             'Open Compare > Per cell > Regions': ['compare', 'regions', 'quick'],
             'Open Compare > Per cell > Annotations': ['compare', 'groups', 'quick'],
@@ -14524,7 +14558,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     function renderGeneTokenButton(gene, options = {{}}) {{
         const rawToken = String(gene || '').trim();
-        const token = resolveViewerFeatureToken(rawToken);
+        const tokenModality = options.modality || null;
+        const token = tokenModality
+            ? (resolveFeatureTokenForModality(rawToken, tokenModality) || rawToken)
+            : resolveViewerFeatureToken(rawToken);
         if (!token && options.allowUnknown !== true) return '';
         const module = getGeneModuleByToken(token);
         const label = module ? getGeneDisplayLabel(token) : (token || rawToken);
@@ -14534,11 +14571,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (options.isActive) classes.push('active');
         if (options.isSearchActive) classes.push('search-active');
         if (!canActivate) classes.push('disabled');
-        else if (!module && !DATA.features_meta?.[token]) classes.push('unloaded');
+        else if (!module && !isFeatureLoadedForModality(token, tokenModality || getVisualModality())) classes.push('unloaded');
         const showMeta = options.showMeta !== false;
         const metaLabel = options.metaLabel !== undefined
             ? options.metaLabel
-            : (!canActivate ? 'not embedded' : (module ? `${{module.genes.length}} genes` : (DATA.features_meta?.[token] ? 'loaded' : 'sidecar')));
+            : (!canActivate ? 'not embedded' : (module ? `${{module.genes.length}} genes` : (isFeatureLoadedForModality(token, tokenModality || getVisualModality()) ? 'loaded' : 'sidecar')));
         const metaHtml = showMeta && metaLabel
             ? `<span class="gene-token-meta">${{escapeHtml(metaLabel)}}</span>`
             : '';
@@ -14547,6 +14584,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 type="button"
                 class="${{classes.join(' ')}}"
                 ${{canActivate ? `data-gene-activate="${{escapeHtml(token)}}"` : ''}}
+                ${{canActivate && tokenModality ? `data-gene-modality="${{escapeHtml(tokenModality)}}"` : ''}}
                 title="${{escapeHtml(options.title || label)}}"
                 ${{canActivate ? '' : 'disabled'}}
             >
@@ -14578,6 +14616,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             btn.addEventListener('click', async () => {{
                 const gene = btn.getAttribute('data-gene-activate') || '';
                 if (!gene) return;
+                const modality = btn.getAttribute('data-gene-modality') || '';
+                if (modality && getVisualModality() !== modality && typeof setActiveModality === 'function') {{
+                    await setActiveModality(modality);
+                }}
                 const ok = await activateViewerGene(gene, {{ showErrors: true }});
                 if (ok && typeof rerenderFn === 'function') rerenderFn();
             }});
@@ -14661,11 +14703,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         `);
 
         const currentGeneModule = getGeneModuleByToken(currentGene);
-        if (currentGene && !currentGeneModule && DATA.gene_correlations?.[currentGene]?.length) {{
-            const corrData = DATA.gene_correlations[currentGene];
+        const explorationModality = getExplorationModality();
+        const featureCorrelations = getExplorationFeatureCorrelationsPayload(explorationModality);
+        if (currentGene && !currentGeneModule && featureCorrelations?.[currentGene]?.length) {{
+            const corrData = featureCorrelations[currentGene];
             const corrRows = `<div class="gene-token-grid">${{corrData.map(({{gene, r}}) =>
                 renderGeneTokenButton(gene, {{
                     isActive: gene === currentGene,
+                    modality: explorationModality,
                     metaLabel: `r=${{r.toFixed(2)}}`,
                     title: `Pearson r = ${{r.toFixed(2)}} with ${{escapeHtml(currentGene)}}`,
                 }})
@@ -14676,11 +14721,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     ${{corrRows}}
                 </div>
             `);
-        }} else if (currentGene && !currentGeneModule && !DATA.gene_correlations?.[currentGene]?.length) {{
-            const originallyEmbedded = Array.isArray(DATA.embedded_features) && DATA.embedded_features.includes(currentGene);
+        }} else if (currentGene && !currentGeneModule && !featureCorrelations?.[currentGene]?.length) {{
+            const originallyEmbedded = getEmbeddedFeatureSet(explorationModality).has(currentGene);
             const emptyText = DATA.feature_manifest_url && !originallyEmbedded
-                ? 'No precomputed correlations for this sidecar-loaded gene.'
-                : 'No positive precomputed correlations for this gene among the embedded genes.';
+                ? 'No precomputed correlations for this sidecar-loaded feature.'
+                : 'No positive precomputed correlations for this feature among the embedded features.';
             sections.push(`
                 <div class="gene-discovery-section">
                     <div class="gene-discovery-label">Correlated with ${{escapeHtml(currentGene)}}</div>
@@ -14689,18 +14734,20 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             `);
         }}
 
-        if (DATA.spatial_variable_genes?.length) {{
-            const topSVG = DATA.spatial_variable_genes.slice(0, 12);
+        const spatialFeatures = getExplorationSpatialVariableFeaturesPayload(explorationModality);
+        if (spatialFeatures.length) {{
+            const topSVG = spatialFeatures.slice(0, 12);
             const svgRows = `<div class="gene-token-grid">${{topSVG.map((item) =>
                 renderGeneTokenButton(item.gene, {{
                     isActive: item.gene === currentGene,
+                    modality: explorationModality,
                     metaLabel: `I=${{item.I.toFixed(2)}}`,
                     title: `Moran's I = ${{item.I.toFixed(4)}}`,
                 }})
             ).join('')}}</div>`;
             sections.push(`
                 <div class="gene-discovery-section">
-                    <div class="gene-discovery-label">Spatially variable genes</div>
+                    <div class="gene-discovery-label">Spatially variable features</div>
                     ${{svgRows}}
                 </div>
             `);
@@ -19368,22 +19415,22 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function getAvailableMarkerGeneColors() {{
-        return Object.entries(DATA.marker_genes || {{}})
+        return Object.entries(getExplorationMarkerFeaturesPayload())
             .filter(([, groups]) => groups && typeof groups === 'object' && Object.keys(groups).length > 0)
             .map(([color]) => color)
             .sort((a, b) => a.localeCompare(b));
     }}
 
-    function getAvailablePseudobulkDEColors() {{
-        return Object.entries(DATA.pseudobulk_de || {{}})
+    function getAvailablePseudobulkDEColors(modality = getExplorationModality()) {{
+        return Object.entries(getExplorationPseudobulkDEPayload(modality))
             .filter(([, groups]) => groups && typeof groups === 'object' && Object.keys(groups).some((key) => !String(key).startsWith('_')))
             .map(([color]) => color)
             .sort((a, b) => a.localeCompare(b));
     }}
 
-    function getPseudobulkDEColorKey(annotationCol) {{
+    function getPseudobulkDEColorKey(annotationCol, modality = getExplorationModality()) {{
         const key = String(annotationCol || '');
-        const payload = DATA.pseudobulk_de || {{}};
+        const payload = getExplorationPseudobulkDEPayload(modality);
         if (payload[key]) return key;
         if (key.startsWith(SECTION_METADATA_COLOR_PREFIX)) {{
             const metadataKey = key.slice(SECTION_METADATA_COLOR_PREFIX.length);
@@ -19392,8 +19439,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return key;
     }}
 
-    function hasPseudobulkDEForAnnotation(annotationCol) {{
-        const groups = annotationCol ? (DATA.pseudobulk_de || {{}})[getPseudobulkDEColorKey(annotationCol)] : null;
+    function hasPseudobulkDEForAnnotation(annotationCol, modality = getExplorationModality()) {{
+        const groups = annotationCol ? getExplorationPseudobulkDEPayload(modality)[getPseudobulkDEColorKey(annotationCol, modality)] : null;
         return !!(groups && typeof groups === 'object'
             && Object.keys(groups).some((key) => !String(key).startsWith('_')));
     }}
@@ -19404,8 +19451,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         // ranking is never misread as a formal DESeq2 result. Discriminator is
         // written into _summary.category_gene_means.source by pseudobulk.py.
         if (!annotationCol || !hasPseudobulkDEForAnnotation(annotationCol)) return '';
-        const key = getPseudobulkDEColorKey(annotationCol);
-        const groups = (DATA.pseudobulk_de || {{}})[key] || {{}};
+        const modality = getExplorationModality();
+        const key = getPseudobulkDEColorKey(annotationCol, modality);
+        const groups = getExplorationPseudobulkDEPayload(modality)[key] || {{}};
         const summary = groups._summary || {{}};
         const source = String(
             (summary.category_gene_means && summary.category_gene_means.source)
@@ -19423,22 +19471,23 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return '<span class="de-method-badge de-method-deseq2" title="Pseudobulk differential expression: cells summed into per-replicate pseudobulk samples and fit with DESeq2 (~ replicate + annotation), then evaluated as a category-vs-category contrast.">Pseudobulk DE &middot; DESeq2</span>';
     }}
 
-    function renderPseudobulkDEWarning(annotationCol) {{
-        if (!annotationCol || hasPseudobulkDEForAnnotation(annotationCol)) return '';
-        const availableColors = getAvailablePseudobulkDEColors();
+    function renderPseudobulkDEWarning(annotationCol, modality = getExplorationModality()) {{
+        if (!annotationCol || hasPseudobulkDEForAnnotation(annotationCol, modality)) return '';
+        const availableColors = getAvailablePseudobulkDEColors(modality);
         const chips = availableColors.length
             ? availableColors.map((color) => renderAggChip(formatMetadataLabel(color), 'color-mix(in srgb, #e2a400 18%, #ffffff)')).join('')
             : renderAggChip('none', 'color-mix(in srgb, #e2a400 18%, #ffffff)');
-        return `<div class="genes-warning">No pseudobulk DE genes available for this annotation.<br>Available DE for: ${{chips}}</div>`;
+        return `<div class="genes-warning">No pseudobulk DE features available for this annotation in ${{escapeHtml(getModalityDisplayLabel(modality))}}.<br>Available DE for: ${{chips}}</div>`;
     }}
 
     function renderGenesDetailsWarnings() {{
         const container = document.getElementById('genes-details-warnings');
         if (!container) return;
         const annotationCol = explorationColorCol || currentAnnotation;
+        const modality = getExplorationModality();
         const warnings = [];
         if (insightsGenesTab !== 'distribution') {{
-            const pseudobulkWarning = renderPseudobulkDEWarning(annotationCol);
+            const pseudobulkWarning = renderPseudobulkDEWarning(annotationCol, modality);
             if (pseudobulkWarning) warnings.push(pseudobulkWarning);
         }}
         if (insightsGenesTab === 'distribution') {{
@@ -19453,7 +19502,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     function syncGenesDetailsContentVisibility() {{
         const annotationCol = explorationColorCol || currentAnnotation;
-        const hasDE = hasPseudobulkDEForAnnotation(annotationCol);
+        const hasDE = hasPseudobulkDEForAnnotation(annotationCol, getExplorationModality());
         const details = document.getElementById('genes-details-content');
         const search = document.getElementById('genes-search-section');
         if (details) {{
@@ -19466,7 +19515,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     function getMarkerGenesForColorCategory(annotationCol, category) {{
         if (!annotationCol || category === null || category === undefined || category === BLEND_ALL_CATEGORIES) return [];
-        const byColor = (DATA.marker_genes || {{}})[annotationCol];
+        const byColor = getExplorationMarkerFeaturesPayload()[annotationCol];
         if (!byColor || typeof byColor !== 'object') return [];
         const rawCategory = resolveRawCategoryValue(annotationCol, category);
         if (Array.isArray(byColor[category])) return byColor[category];
@@ -19483,7 +19532,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function getAvailableComparisonColors() {{
-        const withDE = new Set(Object.keys(DATA.pseudobulk_de || {{}}));
+        const withDE = new Set(Object.keys(getExplorationPseudobulkDEPayload()));
         return Array.from(new Set([...getCategoricalColorColumns(), ...getAvailablePseudobulkDEColors()])).sort((a, b) => {{
             const aHas = withDE.has(a), bHas = withDE.has(b);
             if (aHas !== bHas) return bHas - aHas;
@@ -19494,20 +19543,21 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function getPseudobulkDECategories(annotationCol) {{
         if (!annotationCol) return [];
         const fromMeta = getCategoriesForColorColumn(annotationCol).map(value => String(value));
-        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol);
-        const fromData = Object.keys((DATA.pseudobulk_de || {{}})[pseudobulkKey] || {{}})
+        const modality = getExplorationModality();
+        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol, modality);
+        const fromData = Object.keys(getExplorationPseudobulkDEPayload(modality)[pseudobulkKey] || {{}})
             .filter((value) => !String(value).startsWith('_'))
             .map((value) => formatCategoryLabel(annotationCol, value));
         return Array.from(new Set([...fromMeta, ...fromData]));
     }}
 
-    function normalizeGeneEntries(genes, limit = 0) {{
+    function normalizeGeneEntries(genes, limit = 0, modality = getExplorationModality()) {{
         const seen = new Set();
         const entries = [];
         (Array.isArray(genes) ? genes : []).forEach((gene) => {{
             const raw = String(gene || '').trim();
             if (!raw) return;
-            const canonical = resolveCanonicalFeatureName(raw);
+            const canonical = resolveCanonicalFeatureName(raw, modality);
             const key = (canonical || raw).toLowerCase();
             if (seen.has(key)) return;
             seen.add(key);
@@ -19516,19 +19566,19 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return limit > 0 ? entries.slice(0, limit) : entries;
     }}
 
-    function getMarkerGeneEntries(annotationCol, category, limit = 0) {{
-        return normalizeGeneEntries(getMarkerGenesForColorCategory(annotationCol, category), limit);
+    function getMarkerGeneEntries(annotationCol, category, limit = 0, modality = getExplorationModality()) {{
+        return normalizeGeneEntries(getMarkerGenesForColorCategory(annotationCol, category), limit, modality);
     }}
 
-    function getMarkerOverlapEntries(annotationCol, sourceCategory, referenceCategory, limit = 0) {{
-        const sourceEntries = getMarkerGeneEntries(annotationCol, sourceCategory, 0);
+    function getMarkerOverlapEntries(annotationCol, sourceCategory, referenceCategory, limit = 0, modality = getExplorationModality()) {{
+        const sourceEntries = getMarkerGeneEntries(annotationCol, sourceCategory, 0, modality);
         const sourceMap = new Map();
         sourceEntries.forEach((entry) => {{
             sourceMap.set((entry.canonical || entry.raw).toLowerCase(), entry);
         }});
         const overlap = [];
         const seen = new Set();
-        getMarkerGeneEntries(annotationCol, referenceCategory, 0).forEach((entry) => {{
+        getMarkerGeneEntries(annotationCol, referenceCategory, 0, modality).forEach((entry) => {{
             const key = (entry.canonical || entry.raw).toLowerCase();
             if (!sourceMap.has(key) || seen.has(key)) return;
             seen.add(key);
@@ -24387,32 +24437,45 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
     }}
 
-    const INSIGHTS_TOP_LEVEL_TABS = ['overview', 'genes', 'compare', 'neighbors'];
+    function normalizeInsightsTopLevelName(topLevel) {{
+        return topLevel === 'genes' ? 'features' : topLevel;
+    }}
+
+    function getInsightsDomTopLevel(topLevel) {{
+        return normalizeInsightsTopLevelName(topLevel) === 'features' ? 'genes' : topLevel;
+    }}
+
+    const INSIGHTS_TOP_LEVEL_TABS = ['overview', 'features', 'compare', 'neighbors'];
     const INSIGHTS_SUBTABS = {{
         overview: ['summary', 'sections'],
-        genes: ['de-genes', 'spatial', 'distribution', 'means'],
+        features: ['de-genes', 'spatial', 'distribution', 'means'],
         compare: ['groups', 'regions', 'selection', 'cell-de', 'complex-contrast', 'river'],
         neighbors: ['enrichment', 'interactions', 'dispersion'],
     }};
 
     function normalizeInsightsTabsState() {{
+        insightsTopLevelTab = normalizeInsightsTopLevelName(insightsTopLevelTab);
+        if (insightsTreeOpenBranch) insightsTreeOpenBranch = normalizeInsightsTopLevelName(insightsTreeOpenBranch);
+        if (insightsTreeSelectedLeaf) insightsTreeSelectedLeaf.topLevel = normalizeInsightsTopLevelName(insightsTreeSelectedLeaf.topLevel);
         if (!INSIGHTS_TOP_LEVEL_TABS.includes(insightsTopLevelTab)) insightsTopLevelTab = 'overview';
         if (!INSIGHTS_SUBTABS.overview.includes(insightsOverviewTab)) insightsOverviewTab = 'summary';
-        if (!INSIGHTS_SUBTABS.genes.includes(insightsGenesTab)) insightsGenesTab = 'de-genes';
+        if (!INSIGHTS_SUBTABS.features.includes(insightsGenesTab)) insightsGenesTab = 'de-genes';
         if (!INSIGHTS_SUBTABS.compare.includes(insightsCompareTab)) insightsCompareTab = 'groups';
         if (!INSIGHTS_SUBTABS.neighbors.includes(insightsNeighborsTab)) insightsNeighborsTab = 'enrichment';
     }}
 
     function getActiveInsightsSubtab(topLevel) {{
         normalizeInsightsTabsState();
-        if (topLevel === 'genes') return insightsGenesTab;
+        topLevel = normalizeInsightsTopLevelName(topLevel);
+        if (topLevel === 'features') return insightsGenesTab;
         if (topLevel === 'compare') return insightsCompareTab;
         if (topLevel === 'neighbors') return insightsNeighborsTab;
         return insightsOverviewTab;
     }}
 
     function setActiveInsightsSubtab(topLevel, value) {{
-        if (topLevel === 'genes') {{
+        topLevel = normalizeInsightsTopLevelName(topLevel);
+        if (topLevel === 'features') {{
             insightsGenesTab = value;
             return;
         }}
@@ -24429,18 +24492,19 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     const INSIGHTS_TREE_TOP_LABELS = {{
         overview: 'Overview',
-        genes: 'Genes',
+        features: 'Features',
         compare: 'Compare',
         neighbors: 'Neighbors',
     }};
     const INSIGHTS_TREE_LEAF_LABELS = {{
         overview: {{ summary: 'Summary', sections: 'Sections' }},
-        genes: {{ 'de-genes': 'Markers', spatial: 'Spatial', distribution: 'Per cell', means: 'Per sample' }},
+        features: {{ 'de-genes': 'Markers', spatial: 'Spatial', distribution: 'Per cell', means: 'Per sample' }},
         compare: {{ groups: 'Annotations', regions: 'Regions', selection: 'Selections', 'cell-de': 'Simple design', 'complex-contrast': 'Complex design', river: 'Relationships' }},
         neighbors: {{ enrichment: 'Enrichment', interactions: 'Interactions', dispersion: 'Dispersion' }},
     }};
 
     function getInsightsTreePath(topLevel, subtab) {{
+        topLevel = normalizeInsightsTopLevelName(topLevel);
         const path = [INSIGHTS_TREE_TOP_LABELS[topLevel] || topLevel];
         if (topLevel === 'compare') {{
             const group = ['groups', 'regions', 'selection'].includes(subtab)
@@ -24448,7 +24512,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 : (['cell-de', 'complex-contrast'].includes(subtab) ? 'Per sample' : 'Relationships');
             if (group !== 'Relationships') path.push(group);
         }}
-        if (topLevel === 'genes' && ['distribution', 'means'].includes(subtab)) {{
+        if (topLevel === 'features' && ['distribution', 'means'].includes(subtab)) {{
             path.push('Distribution');
         }}
         const leaf = INSIGHTS_TREE_LEAF_LABELS[topLevel]?.[subtab];
@@ -24469,7 +24533,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
         }});
         document.querySelectorAll('[data-insights-tree-node]').forEach((node) => {{
-            const topLevel = node.getAttribute('data-insights-tree-node') || 'overview';
+            const topLevel = normalizeInsightsTopLevelName(node.getAttribute('data-insights-tree-node') || 'overview');
             const isOpen = insightsTreeOpen && insightsTreeOpenBranch === topLevel;
             const hideSibling = insightsTreeOpen && !!insightsTreeOpenBranch && !isOpen;
             node.classList.toggle('is-open', isOpen);
@@ -24490,22 +24554,22 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }});
         document.querySelectorAll('[data-insights-tree-genes-node]').forEach((node) => {{
             const branch = node.getAttribute('data-insights-tree-genes-node') || '';
-            const isOpen = insightsTreeOpen && insightsTreeOpenBranch === 'genes' && insightsTreeOpenGenesBranch === branch;
+            const isOpen = insightsTreeOpen && insightsTreeOpenBranch === 'features' && insightsTreeOpenGenesBranch === branch;
             node.classList.toggle('is-open', isOpen);
             node.querySelector('[data-insights-tree-genes-branch]')?.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
         }});
         document.querySelectorAll('[data-insights-tree-leaf]').forEach((leaf) => {{
-            const topLevel = leaf.getAttribute('data-insights-tree-parent') || 'overview';
+            const topLevel = normalizeInsightsTopLevelName(leaf.getAttribute('data-insights-tree-parent') || 'overview');
             const subtab = leaf.getAttribute('data-insights-tree-leaf') || '';
             const hideRelationship = topLevel === 'compare'
                 && subtab === 'river'
                 && insightsTreeOpen
                 && insightsTreeOpenBranch === 'compare'
                 && !!insightsTreeOpenCompareBranch;
-            const hideGenesDirectLeaf = topLevel === 'genes'
+            const hideGenesDirectLeaf = topLevel === 'features'
                 && leaf.hasAttribute('data-insights-tree-genes-direct-leaf')
                 && insightsTreeOpen
-                && insightsTreeOpenBranch === 'genes'
+                && insightsTreeOpenBranch === 'features'
                 && !!insightsTreeOpenGenesBranch;
             leaf.classList.toggle('is-selected', insightsTreeSelectedLeaf?.topLevel === topLevel && insightsTreeSelectedLeaf?.subtab === subtab);
             leaf.classList.toggle('is-sibling-hidden', hideRelationship || hideGenesDirectLeaf);
@@ -24518,12 +24582,13 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const hasSelectedLeaf = !!insightsTreeSelectedLeaf;
         INSIGHTS_TOP_LEVEL_TABS.forEach((topLevel) => {{
             const topLevelSelected = hasSelectedLeaf && insightsTreeSelectedLeaf.topLevel === topLevel;
-            document.getElementById(`insights-tab-${{topLevel}}`)?.classList.toggle('active', topLevelSelected);
-            document.getElementById(`insights-tab-${{topLevel}}-content`)?.classList.toggle('active', topLevelSelected);
+            const domTopLevel = getInsightsDomTopLevel(topLevel);
+            document.getElementById(`insights-tab-${{domTopLevel}}`)?.classList.toggle('active', topLevelSelected);
+            document.getElementById(`insights-tab-${{domTopLevel}}-content`)?.classList.toggle('active', topLevelSelected);
             (INSIGHTS_SUBTABS[topLevel] || []).forEach((subtab) => {{
                 const isActive = topLevelSelected && insightsTreeSelectedLeaf.subtab === subtab;
-                document.getElementById(`${{topLevel}}-tab-${{subtab}}`)?.classList.toggle('active', isActive);
-                document.getElementById(`${{topLevel}}-tab-${{subtab}}-content`)?.classList.toggle('active', isActive);
+                document.getElementById(`${{domTopLevel}}-tab-${{subtab}}`)?.classList.toggle('active', isActive);
+                document.getElementById(`${{domTopLevel}}-tab-${{subtab}}-content`)?.classList.toggle('active', isActive);
             }});
         }});
     }}
@@ -24582,7 +24647,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             return;
         }}
 
-        if (insightsTopLevelTab === 'genes') {{
+        if (insightsTopLevelTab === 'features') {{
             renderGenesDetailsWarnings();
             syncGenesDetailsContentVisibility();
             if (insightsGenesTab === 'de-genes') {{
@@ -24624,6 +24689,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function activateInsightsTopLevelTab(topLevel, focusSubtab = null) {{
+        topLevel = normalizeInsightsTopLevelName(topLevel);
         if (!INSIGHTS_TOP_LEVEL_TABS.includes(topLevel)) return;
         insightsTopLevelTab = topLevel;
         if (focusSubtab && INSIGHTS_SUBTABS[topLevel]?.includes(focusSubtab)) {{
@@ -24633,6 +24699,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function activateInsightsSubtab(topLevel, subtab) {{
+        topLevel = normalizeInsightsTopLevelName(topLevel);
         if (!INSIGHTS_SUBTABS[topLevel]?.includes(subtab)) return;
         insightsTopLevelTab = topLevel;
         setActiveInsightsSubtab(topLevel, subtab);
@@ -25374,18 +25441,18 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                                         <button class="insights-tab insights-tree-trigger insights-tree-leaf" type="button" data-insights-tree-leaf="sections" data-insights-tree-parent="overview">Sections</button>
                                     </div></div>
                                 </div>
-                                <div class="insights-tree-node" data-insights-tree-node="genes">
-                                    <button class="insights-tab insights-tree-trigger has-children" type="button" data-insights-tree-branch="genes" aria-expanded="false"><span data-insights-tree-label>Genes</span></button>
+                                <div class="insights-tree-node" data-insights-tree-node="features">
+                                    <button class="insights-tab insights-tree-trigger has-children" type="button" data-insights-tree-branch="features" aria-expanded="false"><span data-insights-tree-label>Features</span></button>
                                     <div class="insights-tree-children"><div class="insights-tree-children-content">
                                         <div class="insights-tree-node" data-insights-tree-genes-node="distribution">
                                             <button class="insights-tab insights-tree-trigger has-children" type="button" data-insights-tree-genes-branch="distribution" aria-expanded="false">Distribution</button>
                                             <div class="insights-tree-children"><div class="insights-tree-children-content">
-                                                <button class="insights-tab insights-tree-trigger insights-tree-leaf" type="button" data-insights-tree-leaf="distribution" data-insights-tree-parent="genes">Per cell</button>
-                                                <button class="insights-tab insights-tree-trigger insights-tree-leaf" type="button" data-insights-tree-leaf="means" data-insights-tree-parent="genes">Per sample</button>
+                                                <button class="insights-tab insights-tree-trigger insights-tree-leaf" type="button" data-insights-tree-leaf="distribution" data-insights-tree-parent="features">Per cell</button>
+                                                <button class="insights-tab insights-tree-trigger insights-tree-leaf" type="button" data-insights-tree-leaf="means" data-insights-tree-parent="features">Per sample</button>
                                             </div></div>
                                         </div>
-                                        <button class="insights-tab insights-tree-trigger insights-tree-leaf" type="button" data-insights-tree-leaf="de-genes" data-insights-tree-parent="genes" data-insights-tree-genes-direct-leaf>Markers</button>
-                                        <button class="insights-tab insights-tree-trigger insights-tree-leaf" type="button" data-insights-tree-leaf="spatial" data-insights-tree-parent="genes" data-insights-tree-genes-direct-leaf>Spatial</button>
+                                        <button class="insights-tab insights-tree-trigger insights-tree-leaf" type="button" data-insights-tree-leaf="de-genes" data-insights-tree-parent="features" data-insights-tree-genes-direct-leaf>Markers</button>
+                                        <button class="insights-tab insights-tree-trigger insights-tree-leaf" type="button" data-insights-tree-leaf="spatial" data-insights-tree-parent="features" data-insights-tree-genes-direct-leaf>Spatial</button>
                                     </div></div>
                                 </div>
                                 <div class="insights-tree-node" data-insights-tree-node="compare">
@@ -25454,19 +25521,23 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 <div class="insights-tab-content" id="insights-tab-genes-content">
                     <div id="genes-details-warnings"></div>
                     <div id="genes-details-content">
+                    <div class="insights-panel-section" id="exploration-feature-modality-section">
+                        <label for="exploration-feature-modality-select">Feature namespace</label>
+                        <select id="exploration-feature-modality-select"></select>
+                    </div>
                     <div class="insights-panel-section" id="genes-search-section">
                         <label for="marker-gene-search">Search</label>
                         <div class="marker-gene-search-wrap">
-                            <select class="marker-search" id="marker-gene-search" aria-label="Search pseudobulk genes">
-                                ${{renderInsightsGeneSearchOptions('', 'All genes')}}
+                            <select class="marker-search" id="marker-gene-search" aria-label="Search pseudobulk features">
+                                ${{renderInsightsGeneSearchOptions('', 'All features')}}
                             </select>
-                            <button class="marker-gene-clear-btn" id="marker-gene-search-clear" type="button" title="Clear selected gene" aria-label="Clear selected gene">&times;</button>
+                            <button class="marker-gene-clear-btn" id="marker-gene-search-clear" type="button" title="Clear selected feature" aria-label="Clear selected feature">&times;</button>
                         </div>
                     </div>
                     <div class="insights-tab-content active" id="genes-tab-de-genes-content">
                         <div class="samples-view-toggle gene-subtab-view-toggle" data-gene-subtab-toggle="de-genes"></div>
                         <div class="gene-subtab-action-row" id="marker-genes-action-row">
-                            <button class="selection-summary-compare-btn icon-only" type="button" id="marker-genes-export-btn" title="Download pseudobulk DE genes CSV" aria-label="Download pseudobulk DE genes CSV">${{LEGEND_EXPORT_ICON}}</button>
+                            <button class="selection-summary-compare-btn icon-only" type="button" id="marker-genes-export-btn" title="Download pseudobulk DE features CSV" aria-label="Download pseudobulk DE features CSV">${{LEGEND_EXPORT_ICON}}</button>
                             <span id="marker-genes-calc-info">${{renderCalcInfoButton('de_genes')}}</span>
                         </div>
                         <div class="marker-genes" id="marker-genes"></div>
@@ -25641,6 +25712,41 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }});
         }}
 
+        const explorationFeatureModalitySection = document.getElementById('exploration-feature-modality-section');
+        const explorationFeatureModalitySelect = document.getElementById('exploration-feature-modality-select');
+        if (explorationFeatureModalitySelect) {{
+            const modalityOptions = MODALITY_DESCRIPTORS.length
+                ? MODALITY_DESCRIPTORS.map(desc => ({{ value: desc.name, label: desc.label || desc.name }}))
+                : [{{ value: DEFAULT_MODALITY_NAME, label: getModalityDisplayLabel(DEFAULT_MODALITY_NAME) }}];
+            const validModalities = modalityOptions.map(entry => entry.value).filter(Boolean);
+            if (!validModalities.includes(getExplorationModality())) {{
+                setExplorationModality(validModalities[0] || DEFAULT_MODALITY_NAME);
+            }}
+            explorationFeatureModalitySelect.replaceChildren();
+            modalityOptions.forEach((entry) => {{
+                const option = document.createElement('option');
+                option.value = entry.value;
+                option.textContent = entry.label;
+                if (entry.value === getExplorationModality()) option.selected = true;
+                explorationFeatureModalitySelect.appendChild(option);
+            }});
+            if (explorationFeatureModalitySection) {{
+                explorationFeatureModalitySection.style.display = modalityOptions.length > 1 ? '' : 'none';
+            }}
+            explorationFeatureModalitySelect.addEventListener('change', async () => {{
+                const nextModality = explorationFeatureModalitySelect.value || DEFAULT_MODALITY_NAME;
+                setExplorationModality(nextModality);
+                const markerSearch = document.getElementById('marker-gene-search');
+                if (markerSearch) {{
+                    markerSearch.value = '';
+                    refreshLoadedGeneFilterDropdowns();
+                }}
+                await activateViewerGene('', {{ showErrors: false }});
+                renderGeneDiscoveryPanel?.();
+                renderActiveInsightsPanel();
+            }});
+        }}
+
         const groupBy = document.getElementById('annotation-section-key');
         groupBy.addEventListener('change', () => {{
             renderOverviewAggregation();
@@ -25666,7 +25772,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }});
         panel.querySelectorAll('[data-insights-tree-branch]').forEach((button) => {{
             button.addEventListener('click', () => {{
-                const topLevel = button.getAttribute('data-insights-tree-branch') || 'overview';
+                const topLevel = normalizeInsightsTopLevelName(button.getAttribute('data-insights-tree-branch') || 'overview');
                 const wasOpen = insightsTreeOpen && insightsTreeOpenBranch === topLevel;
                 insightsTreeOpen = true;
                 insightsTreeOpenBranch = wasOpen ? null : topLevel;
@@ -25691,18 +25797,18 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         panel.querySelectorAll('[data-insights-tree-genes-branch]').forEach((button) => {{
             button.addEventListener('click', () => {{
                 const branch = button.getAttribute('data-insights-tree-genes-branch') || 'distribution';
-                const wasOpen = insightsTreeOpen && insightsTreeOpenBranch === 'genes' && insightsTreeOpenGenesBranch === branch;
+                const wasOpen = insightsTreeOpen && insightsTreeOpenBranch === 'features' && insightsTreeOpenGenesBranch === branch;
                 insightsTreeOpen = true;
-                insightsTreeOpenBranch = 'genes';
+                insightsTreeOpenBranch = 'features';
                 insightsTreeOpenGenesBranch = wasOpen ? null : branch;
                 insightsTreeOpenCompareBranch = null;
                 insightsTreeSelectedLeaf = null;
-                activateInsightsTopLevelTab('genes');
+                activateInsightsTopLevelTab('features');
             }});
         }});
         panel.querySelectorAll('[data-insights-tree-leaf]').forEach((button) => {{
             button.addEventListener('click', () => {{
-                const topLevel = button.getAttribute('data-insights-tree-parent') || 'overview';
+                const topLevel = normalizeInsightsTopLevelName(button.getAttribute('data-insights-tree-parent') || 'overview');
                 const subtab = button.getAttribute('data-insights-tree-leaf') || '';
                 if (!INSIGHTS_SUBTABS[topLevel]?.includes(subtab)) return;
                 insightsTreeSelectedLeaf = {{ topLevel, subtab }};
@@ -25741,7 +25847,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 advanceTutorialIfReady();
                 return;
             }}
-            if (isViewerFeatureLoadable(gene)) {{
+            const modality = getExplorationModality();
+            if (isViewerFeatureLoadable(gene, modality)) {{
+                if (getVisualModality() !== modality && typeof setActiveModality === 'function') {{
+                    await setActiveModality(modality);
+                }}
                 await activateViewerGene(gene, {{ showErrors: true }});
                 advanceTutorialIfReady();
                 return;
@@ -26638,9 +26748,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return sorted[base] + rest * (next - sorted[base]);
     }}
 
-    function getRestOrFallbackDEResults(annotationCol, category) {{
-        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol);
-        const byCategory = (DATA.pseudobulk_de || {{}})[pseudobulkKey] || {{}};
+    function getRestOrFallbackDEResults(annotationCol, category, modality = getExplorationModality()) {{
+        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol, modality);
+        const byCategory = getExplorationPseudobulkDEPayload(modality)[pseudobulkKey] || {{}};
         const rawCategory = resolveRawCategoryValue(annotationCol, category);
         const bucket = byCategory[String(rawCategory)] || byCategory[String(category)] || null;
         if (!bucket || typeof bucket !== 'object') return [];
@@ -26675,7 +26785,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return significant;
     }}
 
-    function computeCategoryGeneMeans(annotationCol, genes, categories) {{
+    function computeCategoryGeneMeans(annotationCol, genes, categories, modality = getExplorationModality()) {{
         const sums = new Map();
         const counts = new Map();
         genes.forEach((gene) => {{
@@ -26690,7 +26800,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             if (!colVals) return;
             const geneValues = new Map();
             genes.forEach((gene) => {{
-                const vals = getSectionGeneValues(section, gene);
+                const vals = getSectionGeneValues(section, gene, modality);
                 if (vals) geneValues.set(gene, vals);
             }});
             if (!geneValues.size) return;
@@ -26716,8 +26826,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}));
     }}
 
-    function getClusterGeneMeansColumn(annotationCol) {{
-        const data = DATA.category_gene_means;
+    function getClusterGeneMeansColumn(annotationCol, modality = getExplorationModality()) {{
+        const data = getExplorationCategoryFeatureMeansPayload(modality);
         const genes = Array.isArray(data?.genes) ? data.genes.map(g => String(g)) : [];
         const columns = data?.columns || {{}};
         const column = columns[annotationCol] || null;
@@ -26725,8 +26835,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return {{ genes, column }};
     }}
 
-    function computeClusterGeneMeanMatrix(annotationCol, genes, categories) {{
-        const payload = getPseudobulkGeneMeansPayload(annotationCol) || getClusterGeneMeansColumn(annotationCol);
+    function computeClusterGeneMeanMatrix(annotationCol, genes, categories, modality = getExplorationModality()) {{
+        const payload = getPseudobulkGeneMeansPayload(annotationCol, modality) || getClusterGeneMeansColumn(annotationCol, modality);
         if (!payload) return null;
         const meanGenes = payload.genes;
         const colData = payload.column;
@@ -26742,10 +26852,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }});
     }}
 
-    function getGeneDEHeatmapData(annotationCol, selectedGene = '', topN = 3) {{
+    function getGeneDEHeatmapData(annotationCol, selectedGene = '', topN = 3, modality = getExplorationModality()) {{
         const annotationMeta = DATA.annotations_meta?.[annotationCol];
         if (!annotationMeta || annotationMeta.is_continuous) return null;
-        const meanPayload = getPseudobulkGeneMeansPayload(annotationCol) || getClusterGeneMeansColumn(annotationCol);
+        const meanPayload = getPseudobulkGeneMeansPayload(annotationCol, modality) || getClusterGeneMeansColumn(annotationCol, modality);
         if (!meanPayload) return null;
         const meanGeneSet = new Set(meanPayload.genes);
         const meanGeneByLower = new Map(meanPayload.genes.map(gene => [String(gene).toLowerCase(), gene]));
@@ -26753,7 +26863,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const token = String(gene || '').trim();
             if (!token) return '';
             if (meanGeneSet.has(token)) return token;
-            const canonical = resolveCanonicalFeatureName(token);
+            const canonical = resolveCanonicalFeatureName(token, modality);
             if (canonical && meanGeneSet.has(canonical)) return canonical;
             return meanGeneByLower.get(token.toLowerCase()) || '';
         }}
@@ -26769,7 +26879,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const limit = Math.max(1, Math.min(10000, Number(topN) || 3));
         categories.forEach((category) => {{
             let categoryVisible = 0;
-            getRestOrFallbackDEResults(annotationCol, category).forEach((comparison) => {{
+            getRestOrFallbackDEResults(annotationCol, category, modality).forEach((comparison) => {{
                 if (comparison.reference !== '__rest__') return;
                 const result = comparison.result || {{}};
                 const significantGenes = getSignificantDEResultGeneSet(result);
@@ -26798,12 +26908,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!genes.length || !fullGenes.length) {{
             return {{ categories, genes: [], means: [], zscores: [], deStars, source: 'category_gene_means' }};
         }}
-        const fullMeans = computeClusterGeneMeanMatrix(annotationCol, fullGenes, categories);
+        const fullMeans = computeClusterGeneMeanMatrix(annotationCol, fullGenes, categories, modality);
         const values = fullMeans.flat().filter(Number.isFinite);
         const mean = values.reduce((sum, value) => sum + value, 0) / Math.max(values.length, 1);
         const variance = values.reduce((sum, value) => sum + Math.pow(value - mean, 2), 0) / Math.max(values.length, 1);
         const sd = Math.sqrt(variance) || 1;
-        const means = computeClusterGeneMeanMatrix(annotationCol, genes, categories);
+        const means = computeClusterGeneMeanMatrix(annotationCol, genes, categories, modality);
         return {{ categories, genes, means, zscores: means.map(row => row.map(value => Number.isFinite(value) ? (value - mean) / sd : null)), deStars, source: 'category_gene_means' }};
     }}
 
@@ -27037,7 +27147,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const exportBtn = document.getElementById('marker-genes-export-btn');
         const calcInfo = document.getElementById('marker-genes-calc-info');
         const selectedGene = getInsightsSelectedGene();
-        const markers = DATA.marker_genes || {{}};
+        const modality = getExplorationModality();
+        const markers = getExplorationMarkerFeaturesPayload(modality);
         const viewMode = getGeneSubtabView(subtab);
         if (calcInfo) calcInfo.innerHTML = renderCalcInfoButton(viewMode === 'graph' ? 'de_heatmap' : 'de_genes');
         renderGenesDetailsWarnings();
@@ -27051,8 +27162,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             return;
         }}
 
-        const markerPseudobulkKey = getPseudobulkDEColorKey(markerColorCol);
-        const deForColor = (DATA.pseudobulk_de || {{}})[markerPseudobulkKey] || null;
+        const markerPseudobulkKey = getPseudobulkDEColorKey(markerColorCol, modality);
+        const deForColor = getExplorationPseudobulkDEPayload(modality)[markerPseudobulkKey] || null;
         const hasDEForColor = !!(deForColor && typeof deForColor === 'object' && Object.keys(deForColor).some((key) => !String(key).startsWith('_')));
         const groupMarkers = markers[markerColorCol] || markers[markerPseudobulkKey] || {{}};
         if (!hasDEForColor) {{
@@ -27082,10 +27193,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
 
         if (viewMode === 'graph') {{
-            const heatmapData = getGeneDEHeatmapData(markerColorCol, selectedGene, markerHeatmapTopN);
+            const heatmapData = getGeneDEHeatmapData(markerColorCol, selectedGene, markerHeatmapTopN, modality);
             const heatmapControls = selectedGene
                 ? ''
-                : `<div class="marker-heatmap-controls"><label for="marker-heatmap-topn">Top N genes per category</label><input id="marker-heatmap-topn" type="number" min="1" max="10000" step="1" value="${{Math.max(1, Math.min(10000, Number(markerHeatmapTopN) || 3))}}" aria-label="Top N marker genes per category to display"></div>`;
+                : `<div class="marker-heatmap-controls"><label for="marker-heatmap-topn">Top N features per category</label><input id="marker-heatmap-topn" type="number" min="1" max="10000" step="1" value="${{Math.max(1, Math.min(10000, Number(markerHeatmapTopN) || 3))}}" aria-label="Top N marker features per category to display"></div>`;
             container.innerHTML = heatmapControls + toggleHtml + buildGeneDEHeatmap(heatmapData, markerColorCol);
             bindGeneSubtabViewToggle(container, subtab, renderMarkerGenes);
             bindPseudobulkDEPlotInteractions(container, renderMarkerGenes);
@@ -27106,7 +27217,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     if (!raw) return null;
                     return {{
                         raw,
-                        canonical: resolveCanonicalFeatureName(raw),
+                        canonical: resolveCanonicalFeatureName(raw, modality),
                     }};
                 }})
                 .filter(Boolean);
@@ -27118,19 +27229,20 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
             const geneButtons = genes.length
                 ? genes.map((entry) => {{
-                    const loadable = isViewerFeatureLoadable(entry.raw);
+                    const loadable = isViewerFeatureLoadable(entry.raw, modality);
                     return renderGeneTokenButton(entry.raw, {{
                         allowUnknown: true,
                         disableActivation: !loadable,
                         isActive: loadable && !!entry.canonical && entry.canonical === currentGene,
                         isSearchActive: !!selectedGene && (entry.raw === selectedGene || entry.canonical === selectedGene),
+                        modality,
                         showMeta: false,
                         title: loadable
-                            ? 'Load pseudobulk DE gene into the viewer'
-                            : 'This category-vs-balanced-rest gene is not available for expression viewing',
+                            ? 'Load pseudobulk DE feature into the viewer'
+                            : 'This category-vs-balanced-rest feature is not available for expression viewing',
                     }});
                 }}).join('')
-                : '<div class="marker-empty">No pseudobulk DE genes found.</div>';
+                : '<div class="marker-empty">No pseudobulk DE features found.</div>';
             const isSpotlit = linkedSpotlightEnabled && spotlightPinnedCategory === key;
             return `
                 <div class="marker-group">
@@ -27142,7 +27254,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
         if (rows.length === 0) {{
             if (exportBtn) exportBtn.disabled = false;
-            container.innerHTML = toggleHtml + '<div class="marker-empty">No pseudobulk DE genes match your selection.</div>';
+            container.innerHTML = toggleHtml + '<div class="marker-empty">No pseudobulk DE features match your selection.</div>';
             bindGeneSubtabViewToggle(container, subtab, renderMarkerGenes);
             return;
         }}
@@ -27287,7 +27399,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }};
     }}
 
-    function computeGeneDistributionStats(gene, spec, restrictSpec, restrictValue) {{
+    function computeGeneDistributionStats(gene, spec, restrictSpec, restrictValue, modality = getExplorationModality()) {{
         if (!gene || !spec || !spec.key) return null;
         const restrict = buildGeneDistributionRestrictPredicate(restrictSpec, restrictValue);
 
@@ -27296,7 +27408,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const groups = new Map();
             (DATA.sections || []).forEach((section) => {{
                 if (restrict && !restrict.sectionAllows(section)) return;
-                const vals = getSectionGeneValues(section, gene);
+                const vals = getSectionGeneValues(section, gene, modality);
                 if (!vals || !vals.length) return;
                 const raw = section.metadata ? section.metadata[metaKey] : undefined;
                 const groupVal = (raw === undefined || raw === null || raw === '') ? 'unknown' : String(raw);
@@ -27318,7 +27430,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         cats.forEach((cat) => groups.set(String(cat), []));
         (DATA.sections || []).forEach((section) => {{
             if (restrict && !restrict.sectionAllows(section)) return;
-            const vals = getSectionGeneValues(section, gene);
+            const vals = getSectionGeneValues(section, gene, modality);
             const colVals = getSectionColorValues(section, spec.key);
             if (!vals || !colVals) return;
             const n = Math.min(vals.length, colVals.length);
@@ -27335,14 +27447,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return finalizeDistributionBuckets(groups);
     }}
 
-    function computePseudobulkGeneDistributionStats(gene, annotationCol) {{
-        const payload = getClusterGeneMeansColumn(annotationCol);
+    function computePseudobulkGeneDistributionStats(gene, annotationCol, modality = getExplorationModality()) {{
+        const payload = getClusterGeneMeansColumn(annotationCol, modality);
         if (!gene || !payload) return null;
         const geneToken = String(gene || '').trim();
         const geneIndex = new Map(payload.genes.map((g, idx) => [String(g), idx]));
         let idx = geneIndex.get(geneToken);
         if (idx === undefined) {{
-            const canonical = resolveCanonicalFeatureName(geneToken);
+            const canonical = resolveCanonicalFeatureName(geneToken, modality);
             if (canonical) idx = geneIndex.get(canonical);
         }}
         if (idx === undefined) {{
@@ -27442,6 +27554,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!container) return;
         const subtab = 'distribution';
         const selectedGene = getInsightsSelectedGene();
+        const modality = getExplorationModality();
         if (!selectedGene) {{
             setInsightsGeneSubtabContentVisibility(subtab, false);
             container.innerHTML = '';
@@ -27456,8 +27569,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             exportBtn.onclick = (event) => {{
                 event.preventDefault();
                 event.stopPropagation();
-                const gene = sanitizeFilenamePart(getInsightsSelectedGene() || 'gene');
-                downloadGeneGraphSvg('gene-distribution-panel', `karospace-gene-distribution-${{gene}}`, 'No distribution graph is available to export.');
+                const gene = sanitizeFilenamePart(getInsightsSelectedGene() || 'feature');
+                const modName = sanitizeFilenamePart(modality || 'modality');
+                downloadGeneGraphSvg('gene-distribution-panel', `karospace-feature-distribution-${{modName}}-${{gene}}`, 'No distribution graph is available to export.');
             }};
         }}
 
@@ -27475,7 +27589,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             return;
         }}
         if (!annotationCol || !annotationMeta || annotationMeta.is_continuous || !(annotationMeta.categories || []).length) {{
-            container.innerHTML = toggleHtml + '<div class="marker-empty">Choose a categorical Exploration annotation to view gene distribution.</div>';
+            container.innerHTML = toggleHtml + '<div class="marker-empty">Choose a categorical Exploration annotation to view feature distribution.</div>';
             bindGeneSubtabViewToggle(container, subtab, renderGeneDistributionInsights);
             return;
         }}
@@ -27531,9 +27645,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             spec,
             activeRestrict ? restrictSpec : null,
             activeRestrict ? geneDistributionRestrictValue : null,
+            modality,
         );
         if (!stats || !stats.length) {{
-            container.innerHTML = toggleHtml + controlsHtml + '<div class="marker-empty">No data available for this gene × group combination.</div>';
+            container.innerHTML = toggleHtml + controlsHtml + '<div class="marker-empty">No data available for this feature × group combination.</div>';
             bindGeneSubtabViewToggle(container, subtab, renderGeneDistributionInsights);
             wireGeneDistributionInputs(container);
             return;
@@ -27574,7 +27689,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ? ` \u2014 restricted to ${{escapeHtml(formatMetadataLabel(restrictSpec.key))}} = <strong>${{escapeHtml(String(geneDistributionRestrictValue))}}</strong>`
             : '';
         const tableHtml = `
-            <div class="gene-distribution-summary">Expression of <strong>${{escapeHtml(selectedGene)}}</strong> across ${{escapeHtml(formatMetadataLabel(spec.key))}}${{restrictLabel}}</div>
+            <div class="gene-distribution-summary">Expression of <strong>${{escapeHtml(selectedGene)}}</strong> in ${{escapeHtml(getModalityDisplayLabel(modality))}} across ${{escapeHtml(formatMetadataLabel(spec.key))}}${{restrictLabel}}</div>
             <table class="gene-distribution-table">
                 <thead>
                     <tr>
@@ -27590,7 +27705,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         `;
 
         const graphHtml = `
-            <div class="gene-distribution-summary">Expression of <strong>${{escapeHtml(selectedGene)}}</strong> across ${{escapeHtml(formatMetadataLabel(spec.key))}}${{restrictLabel}}</div>
+            <div class="gene-distribution-summary">Expression of <strong>${{escapeHtml(selectedGene)}}</strong> in ${{escapeHtml(getModalityDisplayLabel(modality))}} across ${{escapeHtml(formatMetadataLabel(spec.key))}}${{restrictLabel}}</div>
             ${{buildGeneDistributionBoxplot(sorted, spec)}}
         `;
         container.innerHTML = toggleHtml + controlsHtml + (isGraphView ? graphHtml : tableHtml);
@@ -27599,9 +27714,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (isGraphView) bindPseudobulkDEPlotInteractions(container, renderGeneDistributionInsights);
     }}
 
-    function getPseudobulkGeneMeansPayload(annotationCol) {{
-        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol);
-        const summary = (DATA.pseudobulk_de || {{}})[pseudobulkKey]?._summary?.category_gene_means;
+    function getPseudobulkGeneMeansPayload(annotationCol, modality = getExplorationModality()) {{
+        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol, modality);
+        const summary = getExplorationPseudobulkDEPayload(modality)[pseudobulkKey]?._summary?.category_gene_means;
         const summaryGenes = Array.isArray(summary?.genes) ? summary.genes.map(gene => String(gene)) : [];
         if (summaryGenes.length && summary?.means) {{
             return {{
@@ -27615,9 +27730,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 }},
             }};
         }}
-        // Compatibility fallback for viewers exported before category means were
-        // stored alongside the balanced-rest pseudobulk results.
-        const data = DATA.category_gene_means;
+        const data = getExplorationCategoryFeatureMeansPayload(modality);
         const genes = Array.isArray(data?.genes) ? data.genes.map(gene => String(gene)) : [];
         const column = data?.columns?.[annotationCol];
         return genes.length && column?.means ? {{ genes, column }} : null;
@@ -27629,7 +27742,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const subtab = 'means';
         const selectedCol = explorationColorCol || currentAnnotation || '';
         const geneRaw = getInsightsSelectedGene();
-        if (!hasPseudobulkDEForAnnotation(selectedCol) || !geneRaw) {{
+        const modality = getExplorationModality();
+        if (!hasPseudobulkDEForAnnotation(selectedCol, modality) || !geneRaw) {{
             setInsightsGeneSubtabContentVisibility(subtab, false);
             container.innerHTML = '';
             return;
@@ -27643,11 +27757,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             exportBtn.onclick = (event) => {{
                 event.preventDefault();
                 event.stopPropagation();
-                const gene = sanitizeFilenamePart(getInsightsSelectedGene() || 'gene');
-                downloadGeneGraphSvg('pseudobulk-gene-means', `karospace-gene-means-${{gene}}`, 'No means graph is available to export.');
+                const gene = sanitizeFilenamePart(getInsightsSelectedGene() || 'feature');
+                const modName = sanitizeFilenamePart(modality || 'modality');
+                downloadGeneGraphSvg('pseudobulk-gene-means', `karospace-feature-means-${{modName}}-${{gene}}`, 'No means graph is available to export.');
             }};
         }}
-        const payload = getPseudobulkGeneMeansPayload(selectedCol);
+        const payload = getPseudobulkGeneMeansPayload(selectedCol, modality);
         if (!payload) {{
             container.innerHTML = toggleHtml + '<div class="marker-empty">No pseudobulk-derived category means are available.</div>';
             bindGeneSubtabViewToggle(container, subtab, renderPseudobulkGeneMeans);
@@ -27655,7 +27770,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
         const genes = payload.genes;
         if (!genes.includes(geneRaw)) {{
-            container.innerHTML = toggleHtml + '<div class="marker-empty">No pseudobulk-derived category means are available for the selected gene.</div>';
+            container.innerHTML = toggleHtml + '<div class="marker-empty">No pseudobulk-derived category means are available for the selected feature.</div>';
             bindGeneSubtabViewToggle(container, subtab, renderPseudobulkGeneMeans);
             return;
         }}
@@ -27695,7 +27810,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}).join('');
 
         const listHtml = `
-            <div class="gene-distribution-summary">Pseudobulk-derived category means for <strong>${{escapeHtml(selectedGene)}}</strong>. Background mean: ${{Number.isFinite(background) ? background.toFixed(4) : 'n/a'}}.</div>
+            <div class="gene-distribution-summary">Pseudobulk-derived category means for <strong>${{escapeHtml(selectedGene)}}</strong> in ${{escapeHtml(getModalityDisplayLabel(modality))}}. Background mean: ${{Number.isFinite(background) ? background.toFixed(4) : 'n/a'}}.</div>
             <table class="gene-distribution-table">
                 <thead>
                     <tr><th>Category</th><th>Mean</th><th>Cells</th></tr>
@@ -27704,7 +27819,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             </table>
         `;
         const graphHtml = `
-            <div class="gene-distribution-summary">Pseudobulk-derived category means for <strong>${{escapeHtml(selectedGene)}}</strong>. Background mean: ${{Number.isFinite(background) ? background.toFixed(4) : 'n/a'}}.</div>
+            <div class="gene-distribution-summary">Pseudobulk-derived category means for <strong>${{escapeHtml(selectedGene)}}</strong> in ${{escapeHtml(getModalityDisplayLabel(modality))}}. Background mean: ${{Number.isFinite(background) ? background.toFixed(4) : 'n/a'}}.</div>
             ${{buildPseudobulkMeanDeviationPlot(meanRows, background, selectedCol)}}
         `;
         container.innerHTML = toggleHtml + (isGraphView ? graphHtml : listHtml);
@@ -27734,10 +27849,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const subtab = 'spatial';
         const toggleHtml = renderGeneSubtabViewToggle(subtab);
         const selectedGene = getInsightsSelectedGene();
-        const entries = Array.isArray(DATA.spatial_variable_genes) ? DATA.spatial_variable_genes : [];
+        const modality = getExplorationModality();
+        const entries = getExplorationSpatialVariableFeaturesPayload(modality);
 
         if (!entries.length) {{
-            container.innerHTML = toggleHtml + '<div class="marker-empty">No spatially variable genes were precomputed for this viewer.</div>';
+            container.innerHTML = toggleHtml + '<div class="marker-empty">No spatially variable features were precomputed for this modality.</div>';
             bindGeneSubtabViewToggle(container, subtab, renderSpatialVariableGenes);
             return;
         }}
@@ -27757,7 +27873,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             .filter((entry) => !selectedGene || entry.gene === selectedGene);
 
         if (!filtered.length) {{
-            container.innerHTML = toggleHtml + '<div class="marker-empty">No spatially variable genes match your selected gene.</div>';
+            container.innerHTML = toggleHtml + '<div class="marker-empty">No spatially variable features match your selected feature.</div>';
             bindGeneSubtabViewToggle(container, subtab, renderSpatialVariableGenes);
             return;
         }}
@@ -27776,15 +27892,16 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     <span class="spatial-gene-rank">#${{entry.rank}}</span>
                     ${{renderGeneTokenButton(entry.gene, {{
                         isActive: entry.gene === currentGene,
+                        modality,
                         showMeta: false,
-                        title: `Load spatially variable gene into the viewer (Moran's I ${{entry.score.toFixed(4)}})`,
+                        title: `Load spatially variable feature into the viewer (Moran's I ${{entry.score.toFixed(4)}})`,
                     }})}}
                     <span class="spatial-gene-score">${{scoreLabel}}</span>
                 </div>
             `;
         }}).join('');
 
-        container.innerHTML = toggleHtml + `<div class="gene-distribution-summary">Moran Index for ${{filtered.length.toLocaleString()}} gene${{filtered.length === 1 ? '' : 's'}}</div>` + rows;
+        container.innerHTML = toggleHtml + `<div class="gene-distribution-summary">Moran Index for ${{filtered.length.toLocaleString()}} feature${{filtered.length === 1 ? '' : 's'}} in ${{escapeHtml(getModalityDisplayLabel(modality))}}</div>` + rows;
         bindGeneSubtabViewToggle(container, subtab, renderSpatialVariableGenes);
         bindGeneActivateButtons(container, renderSpatialVariableGenes);
     }}
@@ -35787,7 +35904,7 @@ def export_to_html(
         log_detail(
             f"Running Moran's I for up to {int(spatial_variable_genes_n)} variable genes "
             f"on the full input cell set ({int(dataset.adata.n_obs):,} cells); "
-            "output feeds Insights > Exploration > Genes > Spatial."
+            "output feeds Insights > Exploration > Features > Spatial."
         )
         data["spatial_variable_features_by_modality"][default_modality_name] = _compute_morans_i(
             dataset.adata, list(dataset.var_names), n_genes=int(spatial_variable_genes_n)
@@ -35806,7 +35923,7 @@ def export_to_html(
         log_detail(
             f"Using up to {int(category_means_n_genes)} embedded DE genes from the current "
             "pseudobulk analysis; output feeds Insights > Exploration > "
-            "Genes > Distribution > Per sample."
+            "Features > Distribution > Per sample."
         )
         data["category_feature_means_by_modality"][default_modality_name] = _category_gene_means_from_pseudobulk_de(
             (data.get("pseudobulk_de_by_modality") or {}).get(default_modality_name),

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -752,188 +752,6 @@ def package_sidecar_viewer(
     return str(resolved_output_path)
 
 
-def _select_top_variable_genes(adata, n: int) -> List[str]:
-    """Return up to n gene names ranked by expression variance across cells."""
-    X = adata.X
-    if hasattr(X, "toarray"):
-        # For sparse matrices compute variance without densifying the whole thing.
-        # Var(X) = E[X^2] - E[X]^2
-        mean_sq = np.asarray(X.power(2).mean(axis=0)).ravel()
-        sq_mean = np.asarray(X.mean(axis=0)).ravel() ** 2
-        variances = mean_sq - sq_mean
-    else:
-        variances = np.var(np.asarray(X, dtype=float), axis=0)
-    top_idx = np.argsort(variances)[::-1][:n]
-    return [adata.var_names[i] for i in top_idx]
-
-
-def _compute_morans_i(adata, genes: List[str], n_genes: int = 200) -> list:
-    """Compute Moran's I spatial autocorrelation for the top variable genes.
-
-    Returns a list of {gene, I} dicts sorted descending by I value, or [] if
-    no spatial weight matrix is found in adata.obsp.
-
-    W is kept sparse throughout. All genes are processed in a single sparse
-    matmul (W @ Z), so cost is O(G * nnz) rather than O(G * N^2).
-    """
-    import scipy.sparse as sp
-
-    # Find spatial weight matrix — keep sparse
-    W = None
-    for key in ("spatial_connectivities", "connectivities", "neighbors", "neighbor_graph"):
-        if key in adata.obsp:
-            W = adata.obsp[key]
-            break
-    if W is None:
-        return []
-
-    if not sp.issparse(W):
-        W = sp.csr_matrix(W)
-    else:
-        W = W.tocsr().astype(float)
-
-    N = W.shape[0]
-
-    # Row-normalize in place using sparse diagonal scaling
-    row_sums = np.asarray(W.sum(axis=1)).ravel()
-    row_sums[row_sums == 0] = 1.0
-    W = sp.diags(1.0 / row_sums) @ W
-    S0 = float(W.sum())
-    if S0 == 0:
-        return []
-
-    # Select top variable genes and densify only those (N × G, manageable)
-    selected = _select_top_variable_genes(adata, n_genes)
-    selected = [g for g in selected if g in set(genes)]
-    if not selected:
-        return []
-
-    X = adata[:, selected].X
-    if hasattr(X, "toarray"):
-        X = X.toarray()
-    X = np.asarray(X, dtype=float)          # (N, G)
-
-    # Center each gene
-    Z = X - X.mean(axis=0)                  # (N, G)
-
-    # One sparse matmul for all genes: W @ Z  →  (N, G)
-    WZ = W.dot(Z)                            # sparse × dense = dense (N, G)
-
-    num = N * (Z * WZ).sum(axis=0)          # (G,)
-    denom = S0 * (Z * Z).sum(axis=0)        # (G,)
-
-    valid = denom > 0
-    I_vals = np.where(valid, num / np.where(valid, denom, 1.0), 0.0)
-    I_vals = np.clip(I_vals, -1.0, 1.0)
-
-    results = [
-        {"gene": gene, "I": round(float(I_vals[j]), 4)}
-        for j, gene in enumerate(selected)
-        if valid[j]
-    ]
-    results.sort(key=lambda d: d["I"], reverse=True)
-    return results
-
-
-def _compute_gene_correlations_from_category_means(
-    category_gene_means: Optional[dict],
-    genes: List[str],
-    top_n: int = 10,
-) -> dict:
-    """Compute gene correlations across pseudobulk/category mean profiles."""
-    if not genes or int(top_n) < 1:
-        return {gene: [] for gene in genes} if genes else {}
-    if not category_gene_means or not isinstance(category_gene_means, dict):
-        return {gene: [] for gene in genes}
-    mean_genes = [str(g) for g in (category_gene_means.get("genes") or [])]
-    if len(mean_genes) < 2:
-        return {gene: [] for gene in genes}
-    gene_positions = {gene: idx for idx, gene in enumerate(mean_genes)}
-    selected = [str(g) for g in genes if str(g) in gene_positions]
-    if len(selected) < 2:
-        return {gene: [] for gene in genes}
-
-    profiles: List[List[float]] = []
-    for col_data in (category_gene_means.get("columns") or {}).values():
-        if not isinstance(col_data, dict):
-            continue
-        means = col_data.get("means") or {}
-        for values in means.values():
-            if isinstance(values, list) and len(values) == len(mean_genes):
-                profiles.append([float(values[gene_positions[g]] or 0.0) for g in selected])
-    if len(profiles) < 2:
-        return {gene: [] for gene in genes}
-
-    X = np.asarray(profiles, dtype=float)
-    X[~np.isfinite(X)] = 0
-    corr = np.corrcoef(X.T)
-    result = {gene: [] for gene in genes}
-    for i, gene in enumerate(selected):
-        scores = corr[i].copy()
-        scores[i] = -2.0
-        top_idx = np.argsort(scores)[::-1][: int(top_n)]
-        result[gene] = [
-            {"gene": selected[j], "r": round(float(corr[i, j]), 3)}
-            for j in top_idx
-            if j != i and np.isfinite(corr[i, j]) and corr[i, j] > 0
-        ]
-    return result
-
-
-def _category_gene_means_from_pseudobulk_de(
-    pseudobulk_de: Optional[dict],
-    genes: List[str],
-    max_genes: int,
-) -> Optional[dict]:
-    """Build viewer category mean payload from pseudobulk DE aggregate summaries."""
-    if not isinstance(pseudobulk_de, dict) or int(max_genes) <= 0:
-        return None
-    requested = [str(g) for g in genes if str(g)]
-    if not requested:
-        return None
-    selected = requested[: int(max_genes)]
-    columns = {}
-    gene_order: List[str] = []
-    for annotation_col, by_source in pseudobulk_de.items():
-        if not isinstance(by_source, dict):
-            continue
-        summary = by_source.get("_summary") or {}
-        cmeans = summary.get("category_gene_means") or {}
-        src_genes = [str(g) for g in (cmeans.get("genes") or [])]
-        if not src_genes:
-            continue
-        src_pos = {gene: idx for idx, gene in enumerate(src_genes)}
-        keep = [gene for gene in selected if gene in src_pos]
-        if not keep:
-            continue
-        if not gene_order:
-            gene_order = keep
-        else:
-            keep = [gene for gene in gene_order if gene in src_pos]
-        idx = [src_pos[gene] for gene in keep]
-        means = {}
-        for category, values in (cmeans.get("means") or {}).items():
-            if isinstance(values, list) and len(values) == len(src_genes):
-                means[str(category)] = [values[i] for i in idx]
-        background_values = cmeans.get("background") or []
-        background = (
-            [background_values[i] for i in idx]
-            if isinstance(background_values, list) and len(background_values) == len(src_genes)
-            else [0.0 for _ in idx]
-        )
-        if means:
-            columns[str(annotation_col)] = {
-                "categories": [str(c) for c in (cmeans.get("categories") or means.keys())],
-                "means": means,
-                "background": background,
-                "n_cells": cmeans.get("n_cells") or {},
-                "source": "pseudobulk_de",
-            }
-    if not columns or not gene_order:
-        return None
-    return {"genes": gene_order, "columns": columns, "source": "pseudobulk_de"}
-
-
 def _estimate_auto_spot_size(dataset: SpatialDataset, min_panel_size: int) -> float:
     """Estimate a reasonable default spot radius from section density."""
     panel_px = max(48.0, float(min_panel_size) - 16.0)  # Account for canvas padding.
@@ -35822,6 +35640,11 @@ def export_to_html(
         interaction_markers_top_genes=interaction_markers_top_genes,
         interaction_markers_min_cells=interaction_markers_min_cells,
         interaction_markers_min_neighbors=interaction_markers_min_neighbors,
+        analytics_modalities=selected_modalities,
+        analytics_features=requested_feature_names,
+        gene_correlation_top_n=int(gene_correlation_top_n),
+        category_means_n_genes=int(category_means_n_genes),
+        spatial_variable_genes_n=int(spatial_variable_genes_n),
         section_rotations=resolved_section_rotations,
         deconvolutions=deconvolutions,
     )
@@ -35870,6 +35693,17 @@ def export_to_html(
         log_detail(f"Requested image overlays for {len(section_images)} section(s).")
         _embed_section_images(data, section_images, max_px=section_images_max_px)
         log_detail("Section image overlay payload stored in the HTML data.")
+
+    pathway_modality_names = list(dict.fromkeys(selected_pseudobulk_modalities or [default_modality_name]))
+
+    def _is_pathway_compatible_modality(modality_name: str) -> bool:
+        if not available_modalities:
+            return True
+        mod = getattr(dataset, "modalities", {}).get(modality_name)
+        value_kind = str(getattr(mod, "value_kind", "") or "").strip().lower()
+        if not value_kind:
+            return modality_name == default_modality_name
+        return value_kind in {"counts", "count", "expression", "rna", "gene"}
 
     try:
         from .pathways import add_pathway_enrichment_to_pseudobulk_de
@@ -35994,46 +35828,57 @@ def export_to_html(
                     level=2,
                 )
 
-        pathway_modality_name = (
-            selected_pseudobulk_modalities[0]
-            if selected_pseudobulk_modalities
-            else default_modality_name
-        )
         pathway_settings_by_modality = dict(data.get("pathway_settings_by_modality") or {})
-        pathway_settings_by_modality[pathway_modality_name] = add_pathway_enrichment_to_pseudobulk_de(
-            (data.get("pseudobulk_de_by_modality") or {}).get(pathway_modality_name),
-            pathway_gmt=pathway_gmt,
-            top_n=int(pathway_top_n),
-            min_overlap=int(pathway_min_overlap),
-            gsea_permutations=int(pathway_gsea_permutations),
-            organism=str(pathway_organism or "Mouse"),
-            n_cpus=1,
-            progress_callback=_log_pathway_progress,
-        )
-        data["pathway_settings_by_modality"] = pathway_settings_by_modality
-        if not pathway_settings_by_modality[pathway_modality_name].get("available"):
-            reason = pathway_settings_by_modality[pathway_modality_name].get("reason") or "unavailable"
-            error = pathway_settings_by_modality[pathway_modality_name].get("error")
-            log_warning(f"pathway enrichment unavailable ({reason}{': ' + error if error else ''}).")
-        else:
-            log_detail(
-                f"Stored pathway enrichment for "
-                f"{int(pathway_settings_by_modality[pathway_modality_name].get('enriched_comparisons') or 0):,}/"
-                f"{int(pathway_settings_by_modality[pathway_modality_name].get('comparisons') or 0):,} pseudobulk comparisons.",
-                level=2,
+        pseudobulk_payloads = data.get("pseudobulk_de_by_modality") or {}
+        for pathway_modality_name in pathway_modality_names:
+            if not _is_pathway_compatible_modality(pathway_modality_name):
+                pathway_settings_by_modality[pathway_modality_name] = {
+                    "available": False,
+                    "reason": "unsupported_modality",
+                    "modality": pathway_modality_name,
+                }
+                log_detail(
+                    f"Skipping pathway enrichment for modality {pathway_modality_name} "
+                    "(not gene-compatible).",
+                    level=2,
+                )
+                continue
+            log_detail(f"Pathway modality: {pathway_modality_name}.", level=2)
+            pathway_settings_by_modality[pathway_modality_name] = add_pathway_enrichment_to_pseudobulk_de(
+                pseudobulk_payloads.get(pathway_modality_name),
+                pathway_gmt=pathway_gmt,
+                top_n=int(pathway_top_n),
+                min_overlap=int(pathway_min_overlap),
+                gsea_permutations=int(pathway_gsea_permutations),
+                organism=str(pathway_organism or "Mouse"),
+                n_cpus=1,
+                progress_callback=_log_pathway_progress,
             )
+        data["pathway_settings_by_modality"] = pathway_settings_by_modality
+        for pathway_modality_name in pathway_modality_names:
+            settings = pathway_settings_by_modality.get(pathway_modality_name) or {}
+            if not settings.get("available"):
+                reason = settings.get("reason") or "unavailable"
+                error = settings.get("error")
+                log_warning(
+                    f"pathway enrichment unavailable for modality {pathway_modality_name} "
+                    f"({reason}{': ' + error if error else ''})."
+                )
+            else:
+                log_detail(
+                    f"Stored pathway enrichment for modality {pathway_modality_name}: "
+                    f"{int(settings.get('enriched_comparisons') or 0):,}/"
+                    f"{int(settings.get('comparisons') or 0):,} pseudobulk comparisons.",
+                    level=2,
+                )
     except Exception as exc:
-        pathway_modality_name = (
-            selected_pseudobulk_modalities[0]
-            if selected_pseudobulk_modalities
-            else default_modality_name
-        )
         pathway_settings_by_modality = dict(data.get("pathway_settings_by_modality") or {})
-        pathway_settings_by_modality[pathway_modality_name] = {
-            "available": False,
-            "reason": "pathway_enrichment_failed",
-            "error": str(exc),
-        }
+        for pathway_modality_name in pathway_modality_names:
+            pathway_settings_by_modality[pathway_modality_name] = {
+                "available": False,
+                "reason": "pathway_enrichment_failed",
+                "error": str(exc),
+            }
         data["pathway_settings_by_modality"] = pathway_settings_by_modality
         log_warning(f"pathway enrichment failed ({exc}).")
 
@@ -36068,78 +35913,6 @@ def export_to_html(
     data.setdefault("feature_correlations_by_modality", {})
     data.setdefault("spatial_variable_features_by_modality", {})
     data.setdefault("pathway_settings_by_modality", {})
-
-    if int(spatial_variable_genes_n) > 0:
-        log_step("Computing spatially variable genes")
-        log_detail(
-            f"Running Moran's I for up to {int(spatial_variable_genes_n)} variable genes "
-            f"on the full input cell set ({int(dataset.adata.n_obs):,} cells); "
-            "output feeds Insights > Exploration > Features > Spatial."
-        )
-        data["spatial_variable_features_by_modality"][default_modality_name] = _compute_morans_i(
-            dataset.adata, list(dataset.var_names), n_genes=int(spatial_variable_genes_n)
-        )
-        log_detail(
-            "Stored "
-            f"{len(data['spatial_variable_features_by_modality'].get(default_modality_name) or [])} "
-            "spatially variable feature rows."
-        )
-    else:
-        data["spatial_variable_features_by_modality"][default_modality_name] = []
-
-    category_gene_means_for_correlations = None
-    if int(category_means_n_genes) > 0 and embedded_features:
-        log_step("Computing category gene means from pseudobulk DE genes")
-        log_detail(
-            f"Using up to {int(category_means_n_genes)} embedded DE genes from the current "
-            "pseudobulk analysis; output feeds Insights > Exploration > "
-            "Features > Distribution > Per sample."
-        )
-        data["category_feature_means_by_modality"][default_modality_name] = _category_gene_means_from_pseudobulk_de(
-            (data.get("pseudobulk_de_by_modality") or {}).get(default_modality_name),
-            embedded_features,
-            int(category_means_n_genes),
-        )
-        category_gene_means_for_correlations = data["category_feature_means_by_modality"][default_modality_name]
-        mean_rows = sum(
-            len((col_data or {}).get("means") or {})
-            for col_data in ((category_gene_means_for_correlations or {}).get("columns") or {}).values()
-            if isinstance(col_data, dict)
-        )
-        log_detail(f"Stored category mean payload for {mean_rows} category entries.")
-    else:
-        data["category_feature_means_by_modality"][default_modality_name] = None
-
-    if int(gene_correlation_top_n) > 0 and embedded_features:
-        log_step("Computing gene correlations from category means")
-        required_gene_count = len([g for g in embedded_features if str(g)])
-        available_mean_count = len((category_gene_means_for_correlations or {}).get("genes") or [])
-        if required_gene_count and available_mean_count < required_gene_count:
-            category_gene_means_for_correlations = _category_gene_means_from_pseudobulk_de(
-                (data.get("pseudobulk_de_by_modality") or {}).get(default_modality_name),
-                embedded_features,
-                required_gene_count,
-            )
-            log_detail(
-                "Built an internal category mean payload from current pseudobulk DE summaries "
-                "for gene correlations."
-            )
-        log_detail(
-            f"Keeping top {int(gene_correlation_top_n)} correlated genes per embedded gene "
-            "using pseudobulk-derived category means; output feeds gene discovery "
-            "related-gene suggestions."
-        )
-        data["feature_correlations_by_modality"][default_modality_name] = _compute_gene_correlations_from_category_means(
-            category_gene_means_for_correlations,
-            embedded_features,
-            top_n=int(gene_correlation_top_n),
-        )
-        log_detail(
-            "Stored correlations for "
-            f"{len(data['feature_correlations_by_modality'].get(default_modality_name) or {})} features."
-        )
-    else:
-        data["feature_correlations_by_modality"][default_modality_name] = {}
 
     resolved_spot_size, used_auto_spot_size = _resolve_spot_size(
         dataset=dataset,

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -7721,8 +7721,6 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
         }});
     }}
-    DATA.pseudobulk_de = DATA.pseudobulk_de || DATA.pseudobulk_de_json || {{}};
-    delete DATA.pseudobulk_de_json;
     const TUTORIAL_CONFIG = DATA.tutorial && typeof DATA.tutorial === 'object' ? DATA.tutorial : {{ enabled: false }};
     const PALETTE = {palette_json};
     const METADATA_LABELS = {metadata_labels_json};
@@ -7913,6 +7911,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function setExplorationModality(modality) {{
         return setPanelModality('exploration', modality);
     }}
+    function getPseudobulkPanelModality() {{
+        return getPanelModality('pseudobulk');
+    }}
+    function setPseudobulkPanelModality(modality) {{
+        return setPanelModality('pseudobulk', modality);
+    }}
     function getModalityPayload(payloadName, modality = getExplorationModality()) {{
         let root = DATA[payloadName];
         if (payloadName === 'pseudobulk_de_by_modality') root = DATA.pseudobulk_de_by_modality;
@@ -7925,6 +7929,39 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
     function getExplorationPseudobulkDEPayload(modality = getExplorationModality()) {{
         return getModalityPayload('pseudobulk_de_by_modality', modality) || {{}};
+    }}
+    function getPseudobulkDEPayloadForModality(modality = getPseudobulkPanelModality()) {{
+        return getModalityPayload('pseudobulk_de_by_modality', modality) || {{}};
+    }}
+    function getPseudobulkPathwaySettingsForModality(modality = getPseudobulkPanelModality()) {{
+        const root = DATA.pathway_settings_by_modality && typeof DATA.pathway_settings_by_modality === 'object'
+            ? DATA.pathway_settings_by_modality
+            : {{}};
+        const settings = root[modality];
+        return settings && typeof settings === 'object' ? settings : {{}};
+    }}
+    function modalityHasPseudobulkDE(modality) {{
+        return Object.values(getPseudobulkDEPayloadForModality(modality)).some((groups) => (
+            groups && typeof groups === 'object' && Object.keys(groups).some((key) => !String(key).startsWith('_'))
+        ));
+    }}
+    function getPseudobulkDEModalities() {{
+        const root = DATA.pseudobulk_de_by_modality && typeof DATA.pseudobulk_de_by_modality === 'object'
+            ? DATA.pseudobulk_de_by_modality
+            : {{}};
+        const registryNames = MODALITY_DESCRIPTORS
+            .map((descriptor) => descriptor?.name)
+            .filter(Boolean);
+        return uniqueSortedFeatures([...registryNames, ...Object.keys(root)])
+            .filter((modality) => modalityHasPseudobulkDE(modality));
+    }}
+    function ensurePseudobulkPanelModality() {{
+        const available = getPseudobulkDEModalities();
+        const current = getPseudobulkPanelModality();
+        if (available.length && !available.includes(current)) {{
+            return setPseudobulkPanelModality(available[0]);
+        }}
+        return current;
     }}
     function getExplorationMarkerFeaturesPayload(modality = getExplorationModality()) {{
         return getModalityPayload('marker_features_by_modality', modality) || {{}};
@@ -7940,7 +7977,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return Array.isArray(payload) ? payload : [];
     }}
     function getCategoryVsRestGenes(annotationCol = explorationColorCol || currentAnnotation || '', modality = getExplorationModality()) {{
-        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol);
+        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol, modality);
         const byCategory = getExplorationPseudobulkDEPayload(modality)[pseudobulkKey] || {{}};
         const summaryGenes = byCategory?._summary?.category_gene_means?.genes;
         if (Array.isArray(summaryGenes) && summaryGenes.length) {{
@@ -11243,11 +11280,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function tutorialHasPseudobulk() {{
-        const payload = DATA.pseudobulk_de || {{}};
-        return Object.entries(payload).some(([key, value]) => {{
-            if (String(key).startsWith('_') || !value || typeof value !== 'object') return false;
-            return Object.keys(value).some(k => !String(k).startsWith('_'));
-        }});
+        return getPseudobulkDEModalities().length > 0;
     }}
 
     function tutorialHasNeighborhoods() {{
@@ -11280,7 +11313,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function getTutorialPseudobulkGroupby() {{
         const available = typeof getAvailablePseudobulkDEColors === 'function'
             ? getAvailablePseudobulkDEColors()
-            : Object.keys(DATA.pseudobulk_de || {{}}).filter(key => !String(key).startsWith('_'));
+            : Object.keys(getPseudobulkDEPayloadForModality()).filter(key => !String(key).startsWith('_'));
         return available.find(color => hasPseudobulkDEForAnnotation?.(color)) || available[0] || null;
     }}
 
@@ -17267,9 +17300,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         downloadTextFile(csvText, filename, 'text/csv;charset=utf-8');
     }}
 
-    function buildMarkerGenesCsv(annotationCol) {{
-        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol);
-        const byColor = (DATA.pseudobulk_de || {{}})[pseudobulkKey] || null;
+    function buildMarkerGenesCsv(annotationCol, modality = getExplorationModality()) {{
+        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol, modality);
+        const byColor = getPseudobulkDEPayloadForModality(modality)[pseudobulkKey] || null;
         if (!byColor || typeof byColor !== 'object') return '';
         const rows = [['annotation_column', 'category', 'reference', 'rank', 'gene', 'base_mean', 'log2fc', 'pvalue', 'padj', 'score', 'pct_source', 'pct_reference']];
         Object.entries(byColor).forEach(([sourceCategory, bucket]) => {{
@@ -17303,8 +17336,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             .join('\\n');
     }}
 
-    function exportMarkerGenesCsv(annotationCol = currentAnnotation) {{
-        const csvText = buildMarkerGenesCsv(annotationCol);
+    function exportMarkerGenesCsv(annotationCol = currentAnnotation, modality = getExplorationModality()) {{
+        const csvText = buildMarkerGenesCsv(annotationCol, modality);
         if (!csvText) {{
             alert('No pseudobulk DE genes are available for this annotation to export.');
             return;
@@ -19421,16 +19454,16 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             .sort((a, b) => a.localeCompare(b));
     }}
 
-    function getAvailablePseudobulkDEColors(modality = getExplorationModality()) {{
-        return Object.entries(getExplorationPseudobulkDEPayload(modality))
+    function getAvailablePseudobulkDEColors(modality = getPseudobulkPanelModality()) {{
+        return Object.entries(getPseudobulkDEPayloadForModality(modality))
             .filter(([, groups]) => groups && typeof groups === 'object' && Object.keys(groups).some((key) => !String(key).startsWith('_')))
             .map(([color]) => color)
             .sort((a, b) => a.localeCompare(b));
     }}
 
-    function getPseudobulkDEColorKey(annotationCol, modality = getExplorationModality()) {{
+    function getPseudobulkDEColorKey(annotationCol, modality = getPseudobulkPanelModality()) {{
         const key = String(annotationCol || '');
-        const payload = getExplorationPseudobulkDEPayload(modality);
+        const payload = getPseudobulkDEPayloadForModality(modality);
         if (payload[key]) return key;
         if (key.startsWith(SECTION_METADATA_COLOR_PREFIX)) {{
             const metadataKey = key.slice(SECTION_METADATA_COLOR_PREFIX.length);
@@ -19439,21 +19472,20 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return key;
     }}
 
-    function hasPseudobulkDEForAnnotation(annotationCol, modality = getExplorationModality()) {{
-        const groups = annotationCol ? getExplorationPseudobulkDEPayload(modality)[getPseudobulkDEColorKey(annotationCol, modality)] : null;
+    function hasPseudobulkDEForAnnotation(annotationCol, modality = getPseudobulkPanelModality()) {{
+        const groups = annotationCol ? getPseudobulkDEPayloadForModality(modality)[getPseudobulkDEColorKey(annotationCol, modality)] : null;
         return !!(groups && typeof groups === 'object'
             && Object.keys(groups).some((key) => !String(key).startsWith('_')));
     }}
 
-    function getPseudobulkDEMethodBadge(annotationCol) {{
+    function getPseudobulkDEMethodBadge(annotationCol, modality = getPseudobulkPanelModality()) {{
         // Distinguish a true DESeq2 pseudobulk fit (>=2 biological replicates)
         // from the single-sample Welch fallback so the descriptive marker
         // ranking is never misread as a formal DESeq2 result. Discriminator is
         // written into _summary.category_gene_means.source by pseudobulk.py.
-        if (!annotationCol || !hasPseudobulkDEForAnnotation(annotationCol)) return '';
-        const modality = getExplorationModality();
+        if (!annotationCol || !hasPseudobulkDEForAnnotation(annotationCol, modality)) return '';
         const key = getPseudobulkDEColorKey(annotationCol, modality);
-        const groups = getExplorationPseudobulkDEPayload(modality)[key] || {{}};
+        const groups = getPseudobulkDEPayloadForModality(modality)[key] || {{}};
         const summary = groups._summary || {{}};
         const source = String(
             (summary.category_gene_means && summary.category_gene_means.source)
@@ -19531,21 +19563,20 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return [];
     }}
 
-    function getAvailableComparisonColors() {{
-        const withDE = new Set(Object.keys(getExplorationPseudobulkDEPayload()));
-        return Array.from(new Set([...getCategoricalColorColumns(), ...getAvailablePseudobulkDEColors()])).sort((a, b) => {{
+    function getAvailableComparisonColors(modality = getPseudobulkPanelModality()) {{
+        const withDE = new Set(getAvailablePseudobulkDEColors(modality));
+        return Array.from(new Set([...getCategoricalColorColumns(), ...getAvailablePseudobulkDEColors(modality)])).sort((a, b) => {{
             const aHas = withDE.has(a), bHas = withDE.has(b);
             if (aHas !== bHas) return bHas - aHas;
             return a.localeCompare(b);
         }});
     }}
 
-    function getPseudobulkDECategories(annotationCol) {{
+    function getPseudobulkDECategories(annotationCol, modality = getPseudobulkPanelModality()) {{
         if (!annotationCol) return [];
         const fromMeta = getCategoriesForColorColumn(annotationCol).map(value => String(value));
-        const modality = getExplorationModality();
         const pseudobulkKey = getPseudobulkDEColorKey(annotationCol, modality);
-        const fromData = Object.keys(getExplorationPseudobulkDEPayload(modality)[pseudobulkKey] || {{}})
+        const fromData = Object.keys(getPseudobulkDEPayloadForModality(modality)[pseudobulkKey] || {{}})
             .filter((value) => !String(value).startsWith('_'))
             .map((value) => formatCategoryLabel(annotationCol, value));
         return Array.from(new Set([...fromMeta, ...fromData]));
@@ -19670,19 +19701,19 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }};
     }}
 
-    function getPairwisePseudobulkDEResult(annotationCol, sourceCategory, referenceCategory) {{
-        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol);
+    function getPairwisePseudobulkDEResult(annotationCol, sourceCategory, referenceCategory, modality = getPseudobulkPanelModality()) {{
+        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol, modality);
         const rawSource = resolveRawCategoryValue(annotationCol, sourceCategory);
         const rawReference = resolveRawCategoryValue(annotationCol, referenceCategory);
-        return (((DATA.pseudobulk_de || {{}})[pseudobulkKey] || {{}})[rawSource] || {{}})[rawReference] || null;
+        return ((getPseudobulkDEPayloadForModality(modality)[pseudobulkKey] || {{}})[rawSource] || {{}})[rawReference] || null;
     }}
 
-    function getPseudobulkPairDiagnostics(annotationCol, sourceCategory, referenceCategory, result = null) {{
+    function getPseudobulkPairDiagnostics(annotationCol, sourceCategory, referenceCategory, result = null, modality = getPseudobulkPanelModality()) {{
         if (result?.pseudobulk_samples) return result.pseudobulk_samples;
-        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol);
+        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol, modality);
         const rawSource = resolveRawCategoryValue(annotationCol, sourceCategory);
         const rawReference = resolveRawCategoryValue(annotationCol, referenceCategory);
-        const diagnostics = (DATA.pseudobulk_de || {{}})[pseudobulkKey]?._summary?.pair_diagnostics || {{}};
+        const diagnostics = getPseudobulkDEPayloadForModality(modality)[pseudobulkKey]?._summary?.pair_diagnostics || {{}};
         return diagnostics?.[rawSource]?.[rawReference]
             || diagnostics?.[rawReference]?.[rawSource]
             || null;
@@ -25907,6 +25938,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             renderInteractionBrowser();
         }});
 
+        const pseudobulkDeModalitySelect = document.getElementById('pseudobulk-de-modality-select');
         const pseudobulkDeGroupbySelect = document.getElementById('pseudobulk-de-annotation');
         const pseudobulkDeSourceSelect = document.getElementById('pseudobulk-de-source');
         const pseudobulkDeReferenceSelect = document.getElementById('pseudobulk-de-reference');
@@ -25914,6 +25946,15 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
         const catCols = getCategoricalColorColumns();
         syncPseudobulkDEControls();
+        pseudobulkDeModalitySelect?.addEventListener('change', () => {{
+            setPseudobulkPanelModality(pseudobulkDeModalitySelect.value || DEFAULT_MODALITY_NAME);
+            pseudobulkDeGroupby = null;
+            pseudobulkDeSourceCategory = null;
+            pseudobulkDeReferenceCategory = null;
+            clusterDETableExpanded = false;
+            pathwayAnnotationSide = 'source';
+            renderPseudobulkDE();
+        }});
         pseudobulkDeGroupbySelect?.addEventListener('change', () => {{
             pseudobulkDeGroupby = pseudobulkDeGroupbySelect.value || null;
             pseudobulkDeSourceCategory = null;
@@ -26870,7 +26911,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const meanCategories = (meanPayload.column.categories || Object.keys(meanPayload.column.means || {{}})).map(cat => String(cat));
         const categories = meanCategories.length
             ? meanCategories
-            : (annotationMeta.categories || getPseudobulkDECategories(annotationCol)).map(cat => String(cat));
+            : (annotationMeta.categories || getPseudobulkDECategories(annotationCol, modality)).map(cat => String(cat));
         const selected = String(selectedGene || '').trim();
         const selectedMeanGene = resolveMeanGeneToken(selected);
         const fullGeneSet = new Set();
@@ -27187,7 +27228,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 exportBtn.onclick = (e) => {{
                     e.preventDefault();
                     e.stopPropagation();
-                    exportMarkerGenesCsv(markerColorCol);
+                    exportMarkerGenesCsv(markerColorCol, getExplorationModality());
                 }};
             }}
         }}
@@ -27911,18 +27952,19 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return `${{(100 * value).toFixed(1)}}%`;
     }}
 
-    function renderComparisonGeneTokenGrid(entries, emptyMessage, activateTitle = 'Load gene into the viewer') {{
+    function renderComparisonGeneTokenGrid(entries, emptyMessage, activateTitle = 'Load gene into the viewer', modality = getPseudobulkPanelModality()) {{
         if (!entries || !entries.length) {{
             return `<div class="agg-group-meta">${{escapeHtml(emptyMessage)}}</div>`;
         }}
         return `
             <div class="gene-token-grid">
                 ${{entries.map((entry) => {{
-                    const loadable = isViewerFeatureLoadable(entry.raw);
+                    const loadable = isViewerFeatureLoadable(entry.raw, modality);
                     return renderGeneTokenButton(entry.raw, {{
                         allowUnknown: true,
                         disableActivation: !loadable,
                         isActive: loadable && !!entry.canonical && entry.canonical === currentGene,
+                        modality,
                         showMeta: false,
                         title: loadable
                             ? activateTitle
@@ -28004,8 +28046,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         `;
     }}
 
-    function renderComparisonMarkerSummary(annotationCol, sourceCategory, referenceCategory) {{
-        const result = getPairwisePseudobulkDEResult(annotationCol, sourceCategory, referenceCategory);
+    function renderComparisonMarkerSummary(annotationCol, sourceCategory, referenceCategory, modality = getPseudobulkPanelModality()) {{
+        const result = getPairwisePseudobulkDEResult(annotationCol, sourceCategory, referenceCategory, modality);
         if (!result || result.available === false) {{
             return '';
         }}
@@ -28017,12 +28059,16 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const sourceMarkerEntries = normalizeGeneEntries(
             significantIndices
                 .filter((index) => Number(log2fc[index]) > 0)
-                .map((index) => genes[index])
+                .map((index) => genes[index]),
+            0,
+            modality
         );
         const referenceMarkerEntries = normalizeGeneEntries(
             significantIndices
                 .filter((index) => Number(log2fc[index]) < 0)
-                .map((index) => genes[index])
+                .map((index) => genes[index]),
+            0,
+            modality
         );
         const renderMarkerGroup = (entries, enrichedCategory, side) => {{
             const key = [annotationCol, sourceCategory, referenceCategory, side].map(value => String(value ?? '')).join('\\u001f');
@@ -28038,7 +28084,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     <span class="agg-group-title-main">${{renderAggCategoryChip(annotationCol, enrichedCategory)}}</span>
                     <span class="agg-group-title-actions"><span class="agg-chip agg-count-chip">${{entries.length.toLocaleString()}} genes</span></span>
                 </div>
-                ${{renderComparisonGeneTokenGrid(visibleEntries, 'No genes pass the current adjusted p-value and log\u2082FC thresholds in this direction.', 'Load pseudobulk marker into the viewer')}}
+                ${{renderComparisonGeneTokenGrid(visibleEntries, 'No genes pass the current adjusted p-value and log\u2082FC thresholds in this direction.', 'Load pseudobulk marker into the viewer', modality)}}
                 ${{link ? `<div class="pseudobulk-de-table-actions">${{link}}</div>` : ''}}
             </div>
         `;
@@ -28207,7 +28253,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         `;
     }}
 
-    function buildMAPlot(genes, baseMean, log2fc, pvals, pvalsAdj, pctSource = [], pctReference = [], minPctCutoff = 0, padjCutoff = 0.05, log2fcCutoff = 0.5, annotationCol = null, sourceCategory = null, referenceCategory = null) {{
+    function buildMAPlot(genes, baseMean, log2fc, pvals, pvalsAdj, pctSource = [], pctReference = [], minPctCutoff = 0, padjCutoff = 0.05, log2fcCutoff = 0.5, annotationCol = null, sourceCategory = null, referenceCategory = null, modality = getPseudobulkPanelModality()) {{
         if (!genes.length) return '';
         const maPadjThreshold = 0.1;
         const W = 390, H = 180, ml = 38, mr = 10, mt = 8, mb = 24;
@@ -28253,7 +28299,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const padjDisplay = formatAdjustedPValue(padj);
             const baseDisplay = formatScaleNumber(xValues[i]);
             const color = dotClass === 'red' ? '#d94f4f' : 'var(--border-color)';
-            const loadable = isViewerFeatureLoadable(gene);
+            const loadable = isViewerFeatureLoadable(gene, modality);
             const pctLine = 'pct expr: ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(sourcePct) ? sourcePct : NaN)) + ' / ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(referencePct) ? referencePct : NaN));
             const extraLine = loadable ? '' : '" data-tooltip-line6="Expression vector unavailable"';
             dots.push({{ dotClass, html: '<circle class="volcano-dot" cx="' + xs(xValues[i]).toFixed(1) + '" cy="' + ys(fc).toFixed(1) + '" r="2.8" fill="' + color + '" fill-opacity="0.78" data-volcano-gene="' + escapeHtml(gene) + '" data-gene-loadable="' + (loadable ? 'true' : 'false') + '" data-volcano-fc="' + fc.toFixed(3) + '" data-volcano-p="' + rawPDisplay + '" data-volcano-padj="' + padjDisplay + '" data-tooltip-title="' + escapeHtml(gene) + '" data-tooltip-line1="baseMean: ' + escapeHtml(baseDisplay) + '" data-tooltip-line2="logFC: ' + escapeHtml(fc.toFixed(3)) + '" data-tooltip-line3="pvalue: ' + escapeHtml(rawPDisplay) + '" data-tooltip-line4="adj. p: ' + escapeHtml(padjDisplay) + '" data-tooltip-line5="' + pctLine + extraLine + '"/>' }});
@@ -28381,7 +28427,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         );
     }}
 
-    function buildVolcanoPlot(genes, log2fc, pvalsAdj, pctSource = [], pctReference = [], minPctCutoff = 0, padjCutoff = 0.05, log2fcCutoff = 0.5, annotationCol = null, sourceCategory = null, referenceCategory = null) {{
+    function buildVolcanoPlot(genes, log2fc, pvalsAdj, pctSource = [], pctReference = [], minPctCutoff = 0, padjCutoff = 0.05, log2fcCutoff = 0.5, annotationCol = null, sourceCategory = null, referenceCategory = null, modality = getPseudobulkPanelModality()) {{
         if (!genes.length) return '';
         const padjThreshold = Math.min(Math.max(normalizePositiveThreshold(padjCutoff, 0.05), 0), 1);
         const fcThr = normalizePositiveThreshold(log2fcCutoff, 0.5);
@@ -28440,7 +28486,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const col = dotClass === 'source' ? sourceColor : (dotClass === 'reference' ? referenceColor : 'var(--border-color)');
             const safePAdj = Number.isFinite(pvalAdj) ? pvalAdj : 1;
             const padjDisplay = formatAdjustedPValue(safePAdj);
-            const loadable = isViewerFeatureLoadable(gene);
+            const loadable = isViewerFeatureLoadable(gene, modality);
             const pctLine = 'pct expr: ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(sourcePct) ? sourcePct : NaN)) + ' / ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(referencePct) ? referencePct : NaN));
             const extraLine = loadable ? '' : '" data-tooltip-line4="Expression vector unavailable"';
             dots.push({{ dotClass, html: '<circle class="volcano-dot" cx="' + xs(fc).toFixed(1) + '" cy="' + ys(nlpi).toFixed(1) + '" r="3" fill="' + col + '" fill-opacity="0.82" data-volcano-class="' + dotClass + '" data-volcano-gene="' + escapeHtml(gene) + '" data-gene-loadable="' + (loadable ? 'true' : 'false') + '" data-volcano-fc="' + fc.toFixed(3) + '" data-volcano-padj="' + padjDisplay + '" data-tooltip-title="' + escapeHtml(gene) + '" data-tooltip-line1="log\u2082FC: ' + escapeHtml(fc.toFixed(3)) + '" data-tooltip-line2="adj. p: ' + escapeHtml(padjDisplay) + '" data-tooltip-line3="' + pctLine + extraLine + '"/>' }});
@@ -28732,6 +28778,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function getPseudobulkDEFilenameStem() {{
         return [
             'karospace-pseudobulk-de',
+            sanitizeFilenamePart(getPseudobulkPanelModality() || DEFAULT_MODALITY_NAME),
             sanitizeFilenamePart(pseudobulkDeGroupby || 'annotation'),
             sanitizeFilenamePart(pseudobulkDeSourceCategory || 'A'),
             'vs',
@@ -28779,7 +28826,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function downloadCurrentPseudobulkDETable(format) {{
-        const result = getPairwisePseudobulkDEResult(pseudobulkDeGroupby, pseudobulkDeSourceCategory, pseudobulkDeReferenceCategory);
+        const result = getPairwisePseudobulkDEResult(
+            pseudobulkDeGroupby,
+            pseudobulkDeSourceCategory,
+            pseudobulkDeReferenceCategory,
+            getPseudobulkPanelModality()
+        );
         const entries = getPseudobulkDETableEntries(result);
         if (!entries.length) {{
             alert('No pseudobulk DE genes are available for this comparison.');
@@ -28794,7 +28846,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function downloadCurrentPathwayTable(method) {{
-        const result = getPairwisePseudobulkDEResult(pseudobulkDeGroupby, pseudobulkDeSourceCategory, pseudobulkDeReferenceCategory);
+        const result = getPairwisePseudobulkDEResult(
+            pseudobulkDeGroupby,
+            pseudobulkDeSourceCategory,
+            pseudobulkDeReferenceCategory,
+            getPseudobulkPanelModality()
+        );
         if (!result?.pathway_enrichment) {{
             alert('No pathway enrichment result is available for this comparison.');
             return;
@@ -29360,9 +29417,15 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return `<div class="pathway-analysis-empty">No ORA or GSEA pathways were retained for ${{escapeHtml(label)}}.</div>`;
     }}
 
-    function renderClusterPAResultSection(annotationCol, sourceCategory, referenceCategory) {{
-        const result = getPairwisePseudobulkDEResult(annotationCol, sourceCategory, referenceCategory);
-        if (!result?.pathway_enrichment) return '';
+    function renderClusterPAResultSection(annotationCol, sourceCategory, referenceCategory, modality = getPseudobulkPanelModality()) {{
+        const result = getPairwisePseudobulkDEResult(annotationCol, sourceCategory, referenceCategory, modality);
+        if (!result?.pathway_enrichment) {{
+            const settings = getPseudobulkPathwaySettingsForModality(modality);
+            if (settings.available === false && settings.reason) {{
+                return `<div class="pathway-analysis-empty">Pathway enrichment is unavailable for ${{escapeHtml(getModalityDisplayLabel(modality))}} (${{escapeHtml(String(settings.reason))}}).</div>`;
+            }}
+            return '';
+        }}
         const sourceColor = annotationCol && sourceCategory !== null ? getCategoryColorForValue(annotationCol, sourceCategory) : '#d94f4f';
         const referenceColor = annotationCol && referenceCategory !== null ? getCategoryColorForValue(annotationCol, referenceCategory) : '#4f82d9';
         const sourcePanel = renderPathwayAnnotationPanel(result, sourceCategory, referenceCategory, sourceColor, referenceColor, 'source');
@@ -29387,8 +29450,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         `;
     }}
 
-    function renderPseudobulkDEResultSection(annotationCol, sourceCategory, referenceCategory) {{
-        const result = getPairwisePseudobulkDEResult(annotationCol, sourceCategory, referenceCategory);
+    function renderPseudobulkDEResultSection(annotationCol, sourceCategory, referenceCategory, modality = getPseudobulkPanelModality()) {{
+        const result = getPairwisePseudobulkDEResult(annotationCol, sourceCategory, referenceCategory, modality);
         if (!result) {{
             return '';
         }}
@@ -29425,7 +29488,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const pctReference = Array.isArray(result.pct_reference) ? result.pct_reference : [];
         const baseMean = Array.isArray(result.base_mean) ? result.base_mean : [];
         const sampleInfo = getPseudobulkPairDiagnostics(
-            annotationCol, sourceCategory, referenceCategory, result
+            annotationCol, sourceCategory, referenceCategory, result, modality
         );
         const padjCutoff = Math.min(Math.max(normalizePositiveThreshold(result.padj_cutoff, 0.05), 0), 1);
         const log2fcCutoff = normalizePositiveThreshold(result.log2fc_cutoff, 0.5);
@@ -29450,7 +29513,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const scoreValue = scores[idx];
             const pctSourceValue = pctSource[idx];
             const pctReferenceValue = pctReference[idx];
-            const loadable = isViewerFeatureLoadable(gene);
+            const loadable = isViewerFeatureLoadable(gene, modality);
             const rowColor = Number.isFinite(log2fcValue)
                 ? (log2fcValue >= 0 ? sourceColor : referenceColor)
                 : '';
@@ -29493,7 +29556,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             `;
         const volcanoHtml = buildVolcanoPlot(
             genes, log2fc, pvalsAdj, pctSource, pctReference, minPctCutoff, padjCutoff, log2fcCutoff,
-            annotationCol, sourceCategory, referenceCategory
+            annotationCol, sourceCategory, referenceCategory, modality
         );
         const tableMoreButton = significantIndices.length > 20
             ? `<button type="button" class="pseudobulk-de-more-link" data-pseudobulk-de-table-more>${{clusterDETableExpanded ? 'Hide extra lines' : `Show more (${{(significantIndices.length - 20).toLocaleString()}})`}}</button>`
@@ -29512,7 +29575,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             </div>
         `;
         const genePanels = [
-            buildMAPlot(genes, baseMean, log2fc, pvals, pvalsAdj, pctSource, pctReference, minPctCutoff, padjCutoff, log2fcCutoff, annotationCol, sourceCategory, referenceCategory),
+            buildMAPlot(genes, baseMean, log2fc, pvals, pvalsAdj, pctSource, pctReference, minPctCutoff, padjCutoff, log2fcCutoff, annotationCol, sourceCategory, referenceCategory, modality),
             wrapPseudobulkDEVolcanoPlot(volcanoHtml),
         ].filter(Boolean).join('');
         const samplePanels = [
@@ -29554,10 +29617,21 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function syncPseudobulkDEControls() {{
+        const modalitySelect = document.getElementById('pseudobulk-de-modality-select');
         const annotationSelect = document.getElementById('pseudobulk-de-annotation');
         const sourceSelect = document.getElementById('pseudobulk-de-source');
         const referenceSelect = document.getElementById('pseudobulk-de-reference');
-        const availableGroupbys = getAvailableComparisonColors();
+        const availableModalities = getPseudobulkDEModalities();
+        const modality = ensurePseudobulkPanelModality();
+        const availableGroupbys = getAvailableComparisonColors(modality);
+
+        if (modalitySelect) {{
+            modalitySelect.innerHTML = availableModalities
+                .map((name) => `<option value="${{escapeHtml(name)}}"${{name === modality ? ' selected' : ''}}>${{escapeHtml(getModalityDisplayLabel(name))}}</option>`)
+                .join('');
+            modalitySelect.value = modality;
+            modalitySelect.disabled = availableModalities.length < 2;
+        }}
 
         if (annotationSelect) {{
             annotationSelect.innerHTML = availableGroupbys.length
@@ -29571,11 +29645,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             pseudobulkDeReferenceCategory = null;
             if (sourceSelect) sourceSelect.innerHTML = '';
             if (referenceSelect) referenceSelect.innerHTML = '';
-            return {{ availableGroupbys, categories: [] }};
+            return {{ availableGroupbys, categories: [], availableModalities, modality }};
         }}
 
         const activeAnnotation = String(explorationColorCol || '');
-        const activePseudobulkAnnotation = getPseudobulkDEColorKey(activeAnnotation);
+        const activePseudobulkAnnotation = getPseudobulkDEColorKey(activeAnnotation, modality);
         if (availableGroupbys.includes(activePseudobulkAnnotation)) {{
             if (pseudobulkDeGroupby !== activePseudobulkAnnotation) {{
                 pseudobulkDeGroupby = activePseudobulkAnnotation;
@@ -29587,7 +29661,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
         if (annotationSelect) annotationSelect.value = pseudobulkDeGroupby;
 
-        const categories = getPseudobulkDECategories(pseudobulkDeGroupby);
+        const categories = getPseudobulkDECategories(pseudobulkDeGroupby, modality);
         const options = categories.map(category => `<option value="${{escapeHtml(category)}}">${{escapeHtml(category)}}</option>`).join('');
         if (sourceSelect) sourceSelect.innerHTML = options;
         if (referenceSelect) referenceSelect.innerHTML = options;
@@ -29595,7 +29669,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!categories.length) {{
             pseudobulkDeSourceCategory = null;
             pseudobulkDeReferenceCategory = null;
-            return {{ availableGroupbys, categories }};
+            return {{ availableGroupbys, categories, availableModalities, modality }};
         }}
 
         if (!pseudobulkDeSourceCategory || !categories.includes(pseudobulkDeSourceCategory)) {{
@@ -29611,26 +29685,26 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             referenceSelect.disabled = categories.length < 2;
         }}
 
-        return {{ availableGroupbys, categories }};
+        return {{ availableGroupbys, categories, availableModalities, modality }};
     }}
 
     function renderPseudobulkDE() {{
         const container = document.getElementById('pseudobulk-de-results');
         if (!container) return;
 
-        const {{ availableGroupbys, categories }} = syncPseudobulkDEControls();
+        const {{ availableGroupbys, categories, availableModalities, modality }} = syncPseudobulkDEControls();
         const selectedAnnotation = pseudobulkDeGroupby && availableGroupbys.includes(pseudobulkDeGroupby)
             ? pseudobulkDeGroupby
             : null;
-        if (!selectedAnnotation || !hasPseudobulkDEForAnnotation(selectedAnnotation)) {{
-            const availableComparisons = getAvailablePseudobulkDEColors();
+        if (!selectedAnnotation || !hasPseudobulkDEForAnnotation(selectedAnnotation, modality)) {{
+            const availableComparisons = getAvailablePseudobulkDEColors(modality);
             const comparisonChips = availableComparisons.length
                 ? availableComparisons.map((color) => renderAggChip(
                     getAnnotationColumnLabel(color),
                     'color-mix(in srgb, #eab308 18%, var(--input-bg))'
                 )).join('')
                 : renderAggChip('none', 'color-mix(in srgb, #eab308 18%, var(--input-bg))');
-            container.innerHTML = `<div class="pseudobulk-comparison-warning"><strong>Pseudobulk warning.</strong> No pseudobulk DE result is available for this comparison.<br>Available comparison: ${{comparisonChips}}</div>`;
+            container.innerHTML = `<div class="pseudobulk-comparison-warning"><strong>Pseudobulk warning.</strong> No pseudobulk DE result is available for this comparison in ${{escapeHtml(getModalityDisplayLabel(modality))}}.<br>Available comparison: ${{comparisonChips}}</div>`;
             return;
         }}
         if (!pseudobulkDeGroupby) {{
@@ -29656,21 +29730,32 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const contrastResult = getPairwisePseudobulkDEResult(
             pseudobulkDeGroupby,
             pseudobulkDeSourceCategory,
-            pseudobulkDeReferenceCategory
+            pseudobulkDeReferenceCategory,
+            modality
         );
         const sourceColor = getCategoryColorForValue(pseudobulkDeGroupby, pseudobulkDeSourceCategory) || 'var(--accent-strong)';
         const referenceColor = getCategoryColorForValue(pseudobulkDeGroupby, pseudobulkDeReferenceCategory) || '#4cc9f0';
         const buildCategoryOptions = (otherCategory) => categories.map((category) => {{
             const label = formatCategoryLabel(pseudobulkDeGroupby, category);
-            const pairResult = getPairwisePseudobulkDEResult(pseudobulkDeGroupby, category, otherCategory);
+            const pairResult = getPairwisePseudobulkDEResult(pseudobulkDeGroupby, category, otherCategory, modality);
             const count = getPseudobulkContrastCellCount(pairResult, pseudobulkDeGroupby, category);
             const countLabel = Number.isFinite(count) ? count.toLocaleString() : '—';
             return `<option value="${{escapeHtml(category)}}">${{escapeHtml(label)}} (${{countLabel}} cells)</option>`;
         }}).join('');
         const sourceOptions = buildCategoryOptions(pseudobulkDeReferenceCategory);
         const referenceOptions = buildCategoryOptions(pseudobulkDeSourceCategory);
+        const modalityOptions = availableModalities.map((name) => `
+            <option value="${{escapeHtml(name)}}"${{name === modality ? ' selected' : ''}}>${{escapeHtml(getModalityDisplayLabel(name))}}</option>
+        `).join('');
+        const annotationOptions = availableGroupbys.map((col) => `
+            <option value="${{escapeHtml(col)}}"${{col === pseudobulkDeGroupby ? ' selected' : ''}}>${{escapeHtml(getAnnotationColumnLabel(col))}}</option>
+        `).join('');
         const controlsHtml = `
             <div class="pseudobulk-de-controls">
+                <div class="pseudobulk-de-select-row">
+                    <div><label>Feature namespace</label><select id="pseudobulk-de-modality-select" ${{availableModalities.length < 2 ? 'disabled' : ''}}>${{modalityOptions}}</select></div>
+                    <div><label>Annotation</label><select id="pseudobulk-de-annotation">${{annotationOptions}}</select></div>
+                </div>
                 <div class="pseudobulk-de-select-row comparison-pair-select-row">
                     <div><label>Annotation A</label><select id="pseudobulk-de-source" style="border-color:${{sourceColor}}">${{sourceOptions}}</select></div>
                     <div><label>Annotation B</label><select id="pseudobulk-de-reference" style="border-color:${{referenceColor}}">${{referenceOptions}}</select></div>
@@ -29736,7 +29821,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const markerSummary = renderComparisonMarkerSummary(
             pseudobulkDeGroupby,
             pseudobulkDeSourceCategory,
-            pseudobulkDeReferenceCategory
+            pseudobulkDeReferenceCategory,
+            modality
         );
         const markerSection = markerSummary
             ? `<div class="selection-summary-title">Pseudobulk Markers${{renderCalcInfoButton('de_genes')}}</div>${{markerSummary}}`
@@ -29744,20 +29830,46 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const pathwaySection = renderClusterPAResultSection(
             pseudobulkDeGroupby,
             pseudobulkDeSourceCategory,
-            pseudobulkDeReferenceCategory
+            pseudobulkDeReferenceCategory,
+            modality
         );
 
         container.innerHTML = `
             ${{controlsHtml}}
             ${{contrastInfo}}
             ${{markerSection}}
-            <div class="selection-summary-title" id="pseudobulk-de-section-title">Pseudobulk gene expression differential analysis${{renderCalcInfoButton('de_genes')}}${{getPseudobulkDEMethodBadge(pseudobulkDeGroupby)}}</div>
-            ${{renderPseudobulkDEResultSection(pseudobulkDeGroupby, pseudobulkDeSourceCategory, pseudobulkDeReferenceCategory)}}
+            <div class="selection-summary-title" id="pseudobulk-de-section-title">Pseudobulk gene expression differential analysis${{renderCalcInfoButton('de_genes')}}${{getPseudobulkDEMethodBadge(pseudobulkDeGroupby, modality)}}</div>
+            ${{renderPseudobulkDEResultSection(pseudobulkDeGroupby, pseudobulkDeSourceCategory, pseudobulkDeReferenceCategory, modality)}}
             ${{pathwaySection ? '<div class="selection-summary-title" id="pathway-enrichment-title">Pathway Enrichment' + renderCalcInfoButton('pathway_enrichment_section') + '</div>' + pathwaySection : ''}}
         `;
 
+        const modalitySelect = container.querySelector('#pseudobulk-de-modality-select');
+        const annotationSelect = container.querySelector('#pseudobulk-de-annotation');
         const sourceSelect = container.querySelector('#pseudobulk-de-source');
         const referenceSelect = container.querySelector('#pseudobulk-de-reference');
+        if (modalitySelect) {{
+            modalitySelect.value = modality;
+            modalitySelect.addEventListener('change', () => {{
+                setPseudobulkPanelModality(modalitySelect.value || DEFAULT_MODALITY_NAME);
+                pseudobulkDeGroupby = null;
+                pseudobulkDeSourceCategory = null;
+                pseudobulkDeReferenceCategory = null;
+                clusterDETableExpanded = false;
+                pathwayAnnotationSide = 'source';
+                renderPseudobulkDE();
+            }});
+        }}
+        if (annotationSelect) {{
+            annotationSelect.value = pseudobulkDeGroupby || '';
+            annotationSelect.addEventListener('change', () => {{
+                pseudobulkDeGroupby = annotationSelect.value || null;
+                pseudobulkDeSourceCategory = null;
+                pseudobulkDeReferenceCategory = null;
+                clusterDETableExpanded = false;
+                pathwayAnnotationSide = 'source';
+                renderPseudobulkDE();
+            }});
+        }}
         if (sourceSelect) {{
             sourceSelect.value = pseudobulkDeSourceCategory;
             sourceSelect.addEventListener('change', () => {{
@@ -29809,6 +29921,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             btn.addEventListener('click', async () => {{
                 const gene = btn.getAttribute('data-pseudobulk-de-gene') || '';
                 if (!gene) return;
+                if (modality && getVisualModality() !== modality && typeof setActiveModality === 'function') {{
+                    await setActiveModality(modality);
+                }}
                 const ok = await activateViewerGene(gene, {{ showErrors: true }});
                 if (ok) renderPseudobulkDE();
             }});

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -179,8 +179,7 @@ def _embed_section_images(data: dict, section_images: Dict[str, object], max_px:
     """Read image files, downsample if needed, and embed as base64 data URLs.
 
     Each section may carry one or more named overlay layers (e.g. DAPI + H&E),
-    embedded into ``section["he_images"]`` as ``[{"name", "url"}, ...]``. The
-    first layer is also mirrored to the legacy ``section["he_image"]`` field.
+    embedded into ``section["he_images"]`` as ``[{"name", "url"}, ...]``.
     """
     import io
     try:
@@ -219,7 +218,6 @@ def _embed_section_images(data: dict, section_images: Dict[str, object], max_px:
             )
         if embedded:
             section_by_id[section_id]["he_images"] = embedded
-            section_by_id[section_id]["he_image"] = embedded[0]["url"]
 
 
 FEATURE_SIDECAR_SHARD_SIZE = 256
@@ -328,11 +326,11 @@ def _binary_payload_kind_from_sections(section_entries: Mapping[str, dict]) -> i
 
 def _build_binary_feature_payload(
     *,
-    gene_entry: Mapping[str, object],
+    feature_entry: Mapping[str, object],
     section_order: List[str],
     section_cell_counts: Mapping[str, int],
 ) -> Tuple[int, bytes]:
-    section_entries = gene_entry.get("sections") or {}
+    section_entries = feature_entry.get("sections") or {}
     payload_kind = _binary_payload_kind_from_sections(section_entries)
     chunks: List[bytes] = [struct.pack("<I", len(section_order))]
 
@@ -399,15 +397,15 @@ def _write_binary_feature_shard(
     payload_blobs: List[Tuple[bytes, int, bytes]] = []
     index_size = 0
 
-    for gene in shard_features:
-        gene_name_bytes = str(gene).encode("utf-8")
+    for feature in shard_features:
+        feature_name_bytes = str(feature).encode("utf-8")
         payload_kind, payload_bytes = _build_binary_feature_payload(
-            gene_entry=features_payload.get(gene) or {},
+            feature_entry=features_payload.get(feature) or {},
             section_order=section_order,
             section_cell_counts=section_cell_counts,
         )
-        payload_blobs.append((gene_name_bytes, payload_kind, payload_bytes))
-        index_size += 2 + len(gene_name_bytes) + 1 + 1 + 8 + 8
+        payload_blobs.append((feature_name_bytes, payload_kind, payload_bytes))
+        index_size += 2 + len(feature_name_bytes) + 1 + 1 + 8 + 8
 
     header = struct.pack(
         "<4sHHII",
@@ -422,9 +420,9 @@ def _write_binary_feature_shard(
     out.extend(header)
 
     current_offset = payload_offset
-    for gene_name_bytes, payload_kind, payload_bytes in payload_blobs:
-        out.extend(struct.pack("<H", len(gene_name_bytes)))
-        out.extend(gene_name_bytes)
+    for feature_name_bytes, payload_kind, payload_bytes in payload_blobs:
+        out.extend(struct.pack("<H", len(feature_name_bytes)))
+        out.extend(feature_name_bytes)
         out.extend(struct.pack("<BBQQ", payload_kind, 0, current_offset, len(payload_bytes)))
         current_offset += len(payload_bytes)
 
@@ -551,16 +549,15 @@ def _write_karospace_package_loader(
 
 
 def _validate_feature_sidecar_manifest_payload(payload: dict, path: Union[str, Path]) -> None:
-    supported_formats = {
-        "karospace-feature-sidecar-manifest-v3",
-        "karospace-feature-sidecar-manifest-v4",
-    }
     manifest_format = payload.get("format") if isinstance(payload, dict) else None
-    if manifest_format not in supported_formats:
+    if manifest_format != "karospace-feature-sidecar-manifest-v4":
         raise ValueError(
             f"unsupported feature sidecar manifest format in {path}: "
-            f"{manifest_format!r}; expected one of {sorted(supported_formats)}"
+            f"{manifest_format!r}; expected 'karospace-feature-sidecar-manifest-v4'"
         )
+    modalities = payload.get("modalities") if isinstance(payload, dict) else None
+    if not isinstance(modalities, dict) or not modalities:
+        raise ValueError(f"feature sidecar manifest in {path} is missing modalities")
 
 
 def _extract_embedded_viewer_data(html_text: str) -> dict:
@@ -916,7 +913,7 @@ def _serialize_embedded_viewer_data(data: Mapping[str, object]) -> Tuple[str, st
                 append_fragment(section_index, key, value)
                 continue
             if isinstance(value, dict):
-                # Dense dictionaries (for example encoded annotations or genes)
+                # Dense dictionaries (for example encoded annotations or features)
                 # can themselves be large; split their entries as well.
                 append_fragment(section_index, key, {})
                 for child_key, child_value in value.items():
@@ -6940,7 +6937,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Zoom and rotate"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3a9 9 0 1 0 9 9"></path><path d="M21 3v6h-6"></path></svg></span></div><div class="button-help-text">Changes magnification, fits modal/network views, or rotates sections and overlays.</div></div>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Neighbors and image overlay"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true" data-icon="waypoints"><circle cx="12" cy="4.5" r="2.5"></circle><circle cx="4.5" cy="12" r="2.5"></circle><circle cx="19.5" cy="12" r="2.5"></circle><circle cx="12" cy="19.5" r="2.5"></circle><path d="m10.2 6.3-3.9 3.9"></path><path d="m13.8 6.3 3.9 3.9"></path><path d="M7 12h10"></path><path d="m10.2 17.7-3.9-3.9"></path><path d="m13.8 17.7 3.9-3.9"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect><circle cx="9" cy="9" r="2"></circle><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"></path></svg></span></div><div class="button-help-text">Toggles spatial neighbor graph tools or opens image overlay controls such as H&amp;E/DAPI.</div></div>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Annotations"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect width="18" height="18" x="3" y="3" rx="2"></rect><path d="M16 8.9V7H8l4 5-4 5h8v-1.9"></path></svg></span></div><div class="button-help-text">Creates, groups, imports, exports, loads, or deletes user-created spatial annotations and feature modules.</div></div>
-                            <div class="button-help-item"><div class="button-help-icons" aria-label="Plot and table modes"><span class="button-help-icon"><svg class="lucide lucide-chart-candlestick" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 5v4"></path><rect x="7" y="9" width="4" height="6" rx="1"></rect><path d="M9 15v2"></path><path d="M17 3v2"></path><rect x="15" y="5" width="4" height="8" rx="1"></rect><path d="M17 13v3"></path><path d="M3 3v16a2 2 0 0 0 2 2h16"></path></svg></span><span class="button-help-icon"><svg class="lucide lucide-list-sort-descending" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12H3"></path><path d="M3 5h18"></path><path d="M9 19H3"></path></svg></span></div><div class="button-help-text">Switches analysis sections between plot, graph, list, raw table, genes, samples, ORA, or GSEA views.</div></div>
+                            <div class="button-help-item"><div class="button-help-icons" aria-label="Plot and table modes"><span class="button-help-icon"><svg class="lucide lucide-chart-candlestick" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 5v4"></path><rect x="7" y="9" width="4" height="6" rx="1"></rect><path d="M9 15v2"></path><path d="M17 3v2"></path><rect x="15" y="5" width="4" height="8" rx="1"></rect><path d="M17 13v3"></path><path d="M3 3v16a2 2 0 0 0 2 2h16"></path></svg></span><span class="button-help-icon"><svg class="lucide lucide-list-sort-descending" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12H3"></path><path d="M3 5h18"></path><path d="M9 19H3"></path></svg></span></div><div class="button-help-text">Switches analysis sections between plot, graph, list, raw table, features, samples, ORA, or GSEA views.</div></div>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Calculation info"><span class="button-help-icon button-help-calc">!</span></div><div class="button-help-text">Explains how the displayed metric, plot, or analysis section was generated.</div></div>
                         </div>
                     </div>
@@ -6975,7 +6972,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         </div>
                     </div>
                 </div>
-                <button class="icon-btn" id="save-session-btn" type="button" title="Save current viewer state (rotations, annotation or gene view, hidden categories, spotlight, samples view) to a JSON file" aria-label="Save session">
+                <button class="icon-btn" id="save-session-btn" type="button" title="Save current viewer state (rotations, annotation or feature view, hidden categories, spotlight, samples view) to a JSON file" aria-label="Save session">
                     <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg>
                 </button>
                 <button class="icon-btn" id="load-session-btn" type="button" title="Load a previously saved session JSON file" aria-label="Load session">
@@ -7050,7 +7047,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 <select id="overview-blend-a-namespace" style="display:none;"></select>
                 <select id="overview-blend-a-annotation"></select>
                 <select id="overview-blend-a-category"></select>
-                <input type="text" id="overview-blend-a-gene" list="overview-blend-a-feature-list" placeholder="Gene symbol" style="display:none;">
+                <input type="text" id="overview-blend-a-gene" list="overview-blend-a-feature-list" placeholder="Feature" style="display:none;">
                 <datalist id="overview-blend-a-feature-list"></datalist>
             </div>
             <div class="overview-blend-row" id="overview-blend-row-b">
@@ -7059,7 +7056,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 <select id="overview-blend-b-namespace" style="display:none;"></select>
                 <select id="overview-blend-b-annotation"></select>
                 <select id="overview-blend-b-category"></select>
-                <input type="text" id="overview-blend-b-gene" list="overview-blend-b-feature-list" placeholder="Gene symbol" style="display:none;">
+                <input type="text" id="overview-blend-b-gene" list="overview-blend-b-feature-list" placeholder="Feature" style="display:none;">
                 <datalist id="overview-blend-b-feature-list"></datalist>
             </div>
             <div class="overview-blend-row" id="overview-blend-row-mix">
@@ -7402,9 +7399,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     <canvas class="modal-canvas" id="modal-canvas"></canvas>
                     <div class="modal-gene-panel" id="modal-gene-panel" aria-hidden="true">
                         <div class="modal-gene-panel-header">
-                            <div class="modal-gene-panel-title">Genes in selection</div>
+                            <div class="modal-gene-panel-title">Features in selection</div>
                             <div class="modal-gene-panel-count" id="modal-gene-panel-count">0 cells</div>
-                            <button class="modal-gene-panel-close" id="modal-gene-panel-close" type="button" aria-label="Dismiss selection genes">×</button>
+                            <button class="modal-gene-panel-close" id="modal-gene-panel-close" type="button" aria-label="Dismiss selection features">×</button>
                         </div>
                         <div class="modal-gene-panel-body" id="modal-gene-panel-body"></div>
                     </div>
@@ -7555,7 +7552,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     const METADATA_LABELS = {metadata_labels_json};
     const OUTLINE_BY = {outline_by_json};
     const VIEWER_INFO_HTML = {viewer_info_html_json};
-    // Modality registry — RNA-only datasets keep an empty registry so legacy paths run unchanged.
+    // Modality registry for feature namespaces.
     const MODALITY_DESCRIPTORS = Array.isArray(DATA.modalities) ? DATA.modalities : [];
     const FEATURES_BY_MODALITY = (DATA.features_by_modality && typeof DATA.features_by_modality === 'object')
         ? DATA.features_by_modality
@@ -7568,13 +7565,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         || (MODALITY_DESCRIPTORS[0]?.name)
         || 'rna';
     const MODULE_MODALITY_NAME = 'module';
-	    const PANEL_MODALITY_STATE = {{
-	        visual: DEFAULT_MODALITY_NAME,
-	        exploration: DEFAULT_MODALITY_NAME,
-	        module: DEFAULT_MODALITY_NAME,
-	        pseudobulk: DEFAULT_MODALITY_NAME,
-	        interactions: DEFAULT_MODALITY_NAME,
-	        split: {{
+    const PANEL_MODALITY_STATE = {{
+        visual: DEFAULT_MODALITY_NAME,
+        exploration: DEFAULT_MODALITY_NAME,
+        module: DEFAULT_MODALITY_NAME,
+        interactions: DEFAULT_MODALITY_NAME,
+        split: {{
             a: DEFAULT_MODALITY_NAME,
             b: DEFAULT_MODALITY_NAME,
         }},
@@ -7691,7 +7687,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function getModalityDisplayLabel(modality) {{
         if (isModuleModality(modality)) return 'Module';
         const modDesc = MODALITY_DESCRIPTORS.find(m => m.name === modality);
-        return modDesc?.label || (modality === 'gene' ? 'Gene' : String(modality || 'Gene'));
+        return modDesc?.label || String(modality || 'Feature');
     }}
     function getGeneInputFeatureList() {{
         return getFeatureDatalistValuesForModality(getVisualModality());
@@ -7744,20 +7740,17 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function getExplorationModality() {{
         return getPanelModality('exploration');
     }}
-	    function setExplorationModality(modality) {{
-	        return setPanelModality('exploration', modality);
-	    }}
-	    function getModuleBuilderModality() {{
-	        return getPanelModality('module');
-	    }}
-	    function setModuleBuilderModality(modality) {{
-	        return setPanelModality('module', modality);
-	    }}
-	    function getPseudobulkPanelModality() {{
-	        return getPanelModality('pseudobulk');
-	    }}
-    function setPseudobulkPanelModality(modality) {{
-        return setPanelModality('pseudobulk', modality);
+    function setExplorationModality(modality) {{
+        return setPanelModality('exploration', modality);
+    }}
+    function getModuleBuilderModality() {{
+        return getPanelModality('module');
+    }}
+    function setModuleBuilderModality(modality) {{
+        return setPanelModality('module', modality);
+    }}
+    function getPseudobulkPanelModality() {{
+        return getExplorationModality();
     }}
     function getInteractionsModality() {{
         return getPanelModality('interactions');
@@ -7803,14 +7796,6 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             .filter(Boolean);
         return uniqueSortedFeatures([...registryNames, ...Object.keys(root)])
             .filter((modality) => modalityHasPseudobulkDE(modality));
-    }}
-    function ensurePseudobulkPanelModality() {{
-        const available = getPseudobulkDEModalities();
-        const current = getPseudobulkPanelModality();
-        if (available.length && !available.includes(current)) {{
-            return setPseudobulkPanelModality(available[0]);
-        }}
-        return current;
     }}
     function getExplorationMarkerFeaturesPayload(modality = getExplorationModality()) {{
         return getModalityPayload('marker_features_by_modality', modality) || {{}};
@@ -7869,12 +7854,39 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }});
         return uniqueSortedFeatures(genes);
     }}
-    function getInsightsGeneSearchValues(modality = getExplorationModality()) {{
-        const embedded = getFeatureDatalistValuesForModality(modality);
+    function getPseudobulkMeanFeatureNames(annotationCol = explorationColorCol || currentAnnotation || '', modality = getExplorationModality()) {{
+        const pseudobulkKey = getPseudobulkDEColorKey(annotationCol, modality);
+        const summary = getExplorationPseudobulkDEPayload(modality)[pseudobulkKey]?._summary?.category_gene_means;
+        const summaryGenes = Array.isArray(summary?.genes) && summary?.means
+            ? summary.genes.map(gene => String(gene))
+            : [];
+        if (summaryGenes.length) return uniqueSortedFeatures(summaryGenes);
+        const data = getExplorationCategoryFeatureMeansPayload(modality);
+        const genes = Array.isArray(data?.genes) ? data.genes.map(gene => String(gene)) : [];
+        const column = data?.columns?.[annotationCol];
+        return genes.length && column?.means ? uniqueSortedFeatures(genes) : [];
+    }}
+    function getEmbeddedFeatureDatalistValuesForModality(modality = getExplorationModality()) {{
+        if (isModuleModality(modality)) return uniqueSortedFeatures(getGeneModuleDatalistValues());
+        const embeddedByModality = DATA.embedded_features_by_modality && typeof DATA.embedded_features_by_modality === 'object'
+            ? DATA.embedded_features_by_modality
+            : {{}};
+        const embedded = Array.isArray(embeddedByModality[modality])
+            ? embeddedByModality[modality]
+            : getLoadedFeaturesForModality(modality);
+        return uniqueSortedFeatures(embedded);
+    }}
+    function getInsightsGeneSearchValues(modality = getExplorationModality(), subtab = insightsGenesTab) {{
+        const embedded = getEmbeddedFeatureDatalistValuesForModality(modality);
+        if (subtab === 'distribution') return embedded;
         const embeddedSet = new Set(embedded);
-        const categoryVsRest = getCategoryVsRestGenes(explorationColorCol || currentAnnotation || '', modality)
-            .filter(gene => !embeddedSet.has(gene));
-        return uniqueSortedFeatures([...embedded, ...categoryVsRest]);
+        const extraFeatures = subtab === 'means'
+            ? getPseudobulkMeanFeatureNames(explorationColorCol || currentAnnotation || '', modality)
+            : getCategoryVsRestGenes(explorationColorCol || currentAnnotation || '', modality);
+        return uniqueSortedFeatures([
+            ...embedded,
+            ...extraFeatures.filter(feature => !embeddedSet.has(feature)),
+        ]);
     }}
     function renderInsightsGeneSearchDatalistOptions() {{
         const modality = getExplorationModality();
@@ -7892,7 +7904,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
     function getFeatureDatalistValuesForModality(modality = getVisualModality()) {{
         if (isModuleModality(modality)) return uniqueSortedFeatures(getGeneModuleDatalistValues());
-        const base = getFeatureCatalog(modality);
+        const base = DATA.feature_manifest_url
+            ? getFeatureCatalog(modality)
+            : getLoadedFeaturesForModality(modality);
         return uniqueSortedFeatures(base);
     }}
     function isActiveModalityIntensity() {{
@@ -7963,21 +7977,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             s.genes_sparse = payload.features_sparse || payload.genes_sparse || {{}};
         }});
     }}
-    function getActiveModalityManifestEntry(manifest) {{
-        if (!manifest) return null;
-        const map = manifest.modalities;
-        if (map && typeof map === 'object' && map[getVisualModality()]) return map[getVisualModality()];
-        // Legacy v2/v3 manifests have no modalities map; only valid for default modality.
-        if (getVisualModality() === DEFAULT_MODALITY_NAME) return manifest;
-        return null;
-    }}
     function getFeatureSidecarManifestEntryForModality(manifest, modality = getVisualModality()) {{
         if (!manifest) return null;
         const name = normalizeFeatureModalityName(modality);
         const map = manifest.modalities;
         if (map && typeof map === 'object' && map[name]) return map[name];
-        // Legacy v2/v3 manifests have no modalities map; only valid for default modality.
-        if (name === DEFAULT_MODALITY_NAME) return manifest;
         return null;
     }}
     async function setActiveModality(name) {{
@@ -8342,13 +8346,13 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             formula: 'count(category) = number of selected cells with category'
         }},
         selection_expression: {{
-            title: 'Selection expression',
-            body: 'Features are selected by a two-sided Welch test. The top positive and negative Welch T scores are displayed after the minimum-expression threshold. The value at the bar end is the mean feature value followed by the percentage of cells above zero. The factor is mean A divided by mean B.',
+            title: 'Selection feature values',
+            body: 'Features are selected by a two-sided Welch test. The top positive and negative Welch T scores are displayed after the minimum-detection threshold. The value at the bar end is the mean feature value followed by the percentage of cells above zero. The factor is mean A divided by mean B.',
             formula: 'Welch T = (mean A - mean B) / sqrt(variance A / n A + variance B / n B); the highest positive and lowest negative T scores are used; factor = mean A / mean B'
         }},
         region_expression: {{
-            title: 'Region expression',
-            body: 'Features are selected by a two-sided Welch test between Region A and Region B. The top positive and negative Welch T scores are retained after the minimum-expression threshold. Bar-end values show mean feature value and the percentage of cells above zero; the factor is mean A divided by mean B.',
+            title: 'Region feature values',
+            body: 'Features are selected by a two-sided Welch test between Region A and Region B. The top positive and negative Welch T scores are retained after the minimum-detection threshold. Bar-end values show mean feature value and the percentage of cells above zero; the factor is mean A divided by mean B.',
             formula: 'Welch T = (mean A - mean B) / sqrt(variance A / n A + variance B / n B); factor = mean A / mean B; log2FC = log2(mean A / mean B)'
         }},
         selection_compare: {{
@@ -8374,32 +8378,32 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         de_genes: {{
             title: 'Marker features',
             body: 'Differential analysis uses one shared fit model across replicate and annotation, while statistical tests are calculated category-versus-category. Features not detected in a minimal percentage of cells in at least one category are removed from reported DE results. Model and statistical tests are calculated using DESeq2 and multiple testing correction is applied to the retained result features using your method of choice. The table values report log2 fold-change, p-values, adjusted p-values, DESeq2 score and rank, base_mean, and percent detected. Marker features are ordered by adjusted pvalue then log2FC.',
-            formula: 'fit model: ~ replicate + annotation; reported gene filter: max(% expressed in A, % expressed in B) >= min_pct; statistical test: DESeq2 category A vs category B; padj: retained p-values adjusted with the selected correction method; marker order: padj ascending, then log2FC'
+            formula: 'fit model: ~ replicate + annotation; reported feature filter: max(% detected in A, % detected in B) >= min_pct; statistical test: DESeq2 category A vs category B; padj: retained p-values adjusted with the selected correction method; marker order: padj ascending, then log2FC'
         }},
         pseudobulk_simple_de_section: {{
             title: 'Pseudobulk differential analysis',
             body: 'This section is based on the selected Simple design category-vs-category pseudobulk DESeq2 contrast. Cells are grouped by biological replicate and annotation, raw counts are summed into pseudobulk samples, and a shared DESeq2 model is fit for the annotation. The selected Annotation A and Annotation B are then extracted as a pairwise contrast. Features shown as DE pass the minimum percent-detected result filter, then pass the adjusted p-value and absolute log2FC thresholds.',
-            formula: 'model = ~ replicate + annotation; retained genes: max(% expressing cells in A, B) >= min_pct after DESeq2 statistics; DE genes: padj < padj_cutoff and |log2FC| >= log2fc_cutoff'
+            formula: 'model = ~ replicate + annotation; retained features: max(% detected cells in A, B) >= min_pct after DESeq2 statistics; DE features: padj < padj_cutoff and |log2FC| >= log2fc_cutoff'
         }},
         pseudobulk_simple_de_table: {{
-            title: 'Differential expression table',
+            title: 'Differential feature table',
             body: 'The table lists features from the selected Annotation A versus Annotation B contrast that pass the current DE thresholds. Rows are sorted by adjusted p-value, then p-value and log2FC. Feature buttons are disabled only when that feature vector is not available in the HTML or sidecar.',
             formula: 'displayed rows: padj < padj_cutoff and |log2FC| >= log2fc_cutoff; row direction/color follows sign(log2FC)'
         }},
         pseudobulk_ma_plot: {{
             title: 'MA plot',
-            body: 'The MA plot uses every gene returned for the fitted pairwise contrast. The x-axis is DESeq2 baseMean and the y-axis is log2FC for Annotation A versus Annotation B. Red points have adjusted p-value below 0.1; grey points do not.',
+            body: 'The MA plot uses every feature returned for the fitted pairwise contrast. The x-axis is DESeq2 baseMean and the y-axis is log2FC for Annotation A versus Annotation B. Red points have adjusted p-value below 0.1; grey points do not.',
             formula: 'x = baseMean; y = log2FC(A/B); red if padj < 0.1, grey if padj >= 0.1'
         }},
         pseudobulk_volcano_plot: {{
             title: 'Volcano plot',
-            body: 'The volcano plot uses every gene returned for the fitted pairwise contrast. The x-axis is log2FC and the y-axis is -log10 adjusted p-value. Grey points fail either the adjusted p-value or log2FC threshold. Colored points pass both thresholds; positive log2FC is colored as Annotation A and negative log2FC as Annotation B.',
+            body: 'The volcano plot uses every feature returned for the fitted pairwise contrast. The x-axis is log2FC and the y-axis is -log10 adjusted p-value. Grey points fail either the adjusted p-value or log2FC threshold. Colored points pass both thresholds; positive log2FC is colored as Annotation A and negative log2FC is colored as Annotation B.',
             formula: 'x = log2FC(A/B); y = -log10(padj); colored if padj < padj_cutoff and |log2FC| >= log2fc_cutoff'
         }},
         pseudobulk_pca_plot: {{
             title: 'Pseudobulk PCA',
-            body: 'The PCA is a sample-level diagnostic. Each point is a pseudobulk sample built from one replicate and one annotation category. Coordinates are computed from log1p CPM values for variable genes retained for the pseudobulk diagnostic. Point color follows the selected annotation category.',
-            formula: 'pseudobulk sample = summed raw counts per replicate-category; PCA input = log1p(CPM) on diagnostic variable genes'
+            body: 'The PCA is a sample-level diagnostic. Each point is a pseudobulk sample built from one replicate and one annotation category. Coordinates are computed from log1p CPM values for variable features retained for the pseudobulk diagnostic. Point color follows the selected annotation category.',
+            formula: 'pseudobulk sample = summed raw counts per replicate-category; PCA input = log1p(CPM) on diagnostic variable features'
         }},
         pseudobulk_distance_matrix: {{
             title: 'Pseudobulk distance matrix',
@@ -8424,7 +8428,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         de_heatmap: {{
             title: 'DE heatmap',
             body: 'Tiles use aggregation of feature counts per category/replicate and calculate the mean of each category across replicates, then z-score against the full DE heatmap table before applying the visible feature filter. Features are selected if found DE versus the balanced rest. A star marks features found DE versus the balanced rest.',
-            formula: 'category mean = mean over replicates of (category gene counts / category cells); z = (category mean - full table mean) / full table SD'
+            formula: 'category mean = mean over replicates of (category feature counts / category cells); z = (category mean - full table mean) / full table SD'
         }},
         spatial_moran: {{
             title: 'Spatial Moran index',
@@ -8433,7 +8437,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }},
         distribution: {{
             title: 'Feature distribution',
-            body: 'List of values and figures are computed from per-cell expression values in each Exploration annotation category. Selection can be restricted to subcategories',
+            body: 'List of values and figures are computed from per-cell feature values in each Exploration annotation category. Selection can be restricted to subcategories',
             formula: 'mean = sum(values) / n; Q1/Q3 = 25th/75th percentile; % Expr = 100 * cells with value > 0 / n'
         }},
         means: {{
@@ -8442,7 +8446,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             formula: 'category mean = mean over samples of (sample category counts / sample category cells); background = mean over samples of (sample total counts / sample total cells); delta = category mean - background'
         }},
         group_de: {{
-            title: 'Annotation expression',
+            title: 'Annotation feature values',
             body: 'Features are selected by a two-sided Welch test between Annotation A and Annotation B. The top positive and negative Welch T scores are retained after the minimum-detection threshold. Bar-end values show mean feature value and the percentage of cells above zero; the factor is mean A divided by mean B.',
             formula: 'Welch T = (mean A - mean B) / sqrt(variance A / n A + variance B / n B); factor = mean A / mean B; log2FC = log2(mean A / mean B)'
         }},
@@ -8812,6 +8816,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     let selectionWelchRunRequested = false;
     let selectionWelchRunning = false;
     let selectionWelchButtonHidden = false;
+    let selectionWelchRunToken = 0;
+    let selectionWelchFullRun = null;
     const selectionWelchCache = new Map();
     let selectionComparisonLegendExpanded = false;
     const MAX_SELECTION_QUERY_MATCHES = 150000;
@@ -8929,11 +8935,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         img.src = url;
     }}
 
-    // Auto-load any images embedded at export time: a multi-layer `he_images`
-    // list ([{{name, url}}, ...]) or a single legacy `he_image` data URL.
+    // Auto-load any images embedded at export time as a multi-layer `he_images`
+    // list ([{{name, url}}, ...]).
     (DATA.sections || []).forEach((section) => {{
-        let imgs = Array.isArray(section.he_images) ? section.he_images : null;
-        if (!imgs && section.he_image) imgs = [{{ name: 'Image', url: section.he_image }}];
+        const imgs = Array.isArray(section.he_images) ? section.he_images : null;
         if (!imgs) return;
         imgs.forEach((entry, i) => {{
             const url = entry && (entry.url || entry.data);
@@ -8952,8 +8957,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function getOverlayLayerNames() {{
         const names = [], seen = new Set();
         (DATA.sections || []).forEach((section) => {{
-            let imgs = Array.isArray(section.he_images) ? section.he_images : null;
-            if (!imgs && section.he_image) imgs = [{{ name: 'Image' }}];
+            const imgs = Array.isArray(section.he_images) ? section.he_images : null;
             (imgs || []).forEach((entry, i) => {{
                 const name = (entry && entry.name) || `Image ${{i + 1}}`;
                 if (!seen.has(name)) {{ seen.add(name); names.push(name); }}
@@ -9375,7 +9379,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }};
         const rawSteps = [
             step('Welcome the KaroSpace', ['#grid-stage', '#grid', '.main-container'], [
-                'KaroSpace is a self-contained spatial viewer. The central grid is where you inspect sections, while the surrounding controls change color, expression, filters, and analysis panels. Click next or use your arrow keys to continue'
+                'KaroSpace is a self-contained spatial viewer. The central grid is where you inspect sections, while the surrounding controls change color, feature values, filters, and analysis panels. Click next or use your arrow keys to continue'
             ], {{ nextLabel: tryIt, scroll: false }}),
             step('Section filter bar', ['#filter-bar', '#visual-params-bar'], [
                 'The filter bar contains section-level metadata filters when they were exported.',
@@ -9395,7 +9399,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 'The theme button switches between light and dark mode.'
             ], {{ nextLabel: tryIt }}),
             step('Current viewer status', ['#stats-text', '.stats'], [
-                'The status text summarizes how many sections, cells and genes are currently visible.',
+                'The status text summarizes how many sections, cells and features are currently visible.',
                 'It updates when filters, hidden sections, or some display choices change.'
             ], {{ nextLabel: tryIt }}),
             step('Screenshot menu', ['#screenshot-menu-wrap', '#screenshot-btn'], [
@@ -9472,15 +9476,15 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ], {{ action: () => {{ if (typeof closeModal === 'function') closeModal(); if (typeof openInsightsMode === 'function') openInsightsMode('exploration'); }}, nextLabel: tryIt }}),
             step('Insights Selection mode', ['#insights-mode-selection', '#insights-selection-panel'], [
                 'Selection contains the compact summary for cells selected by lasso, UMAP lasso, or query.',
-                'It shows selected-cell composition and expression context before you open the full comparison tools.'
+                'It shows selected-cell composition and feature-value context before you open the full comparison tools.'
             ], {{ action: () => {{ if (typeof openInsightsMode === 'function') openInsightsMode('selection'); updateSelectionInfo?.(); }}, nextLabel: tryIt }}),
             step('Insights Region mode', ['#insights-mode-region', '#region-section'], [
                 'Region stores manual spatial annotations created from selections.',
                 'Use it to organize, group, compare, export, or reuse drawn regions.'
             ], {{ action: () => {{ if (typeof openInsightsMode === 'function') openInsightsMode('exploration'); if (typeof setInsightsMode === 'function') setInsightsMode('region'); }}, nextLabel: tryIt }}),
             step('Insights Module mode', ['#insights-mode-module', '#insights-module-panel'], [
-                'The module area combines feature values to visualize associated genes or pathways.',
-                'Use it for signatures, custom marker lists, or repeated gene-set review.'
+                'The module area combines feature values to visualize associated features or pathways.',
+                'Use it for signatures, custom marker lists, or repeated feature-set review.'
             ], {{ action: () => {{ if (typeof openInsightsMode === 'function') openInsightsMode('exploration'); if (typeof setInsightsMode === 'function') setInsightsMode('module'); }}, nextLabel: tryIt }}),
             step('Insights Exploration mode', ['#insights-mode-exploration', '#insights-exploration-panel'], [
                 'Exploration is the main navigation mode for built-in summaries.',
@@ -9552,6 +9556,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             step('Switch to Feature source', ['#default-source-feature', '#visual-feature-controls'], [
                 'Feature source changes the grid from categorical annotation colors to feature values.'
             ], {{ action: () => safeTutorialClick('#default-source-feature'), nextLabel: tryIt }}),
+            step('Modality selector', ['#visual-feature-namespace-control', '#visual-feature-namespace-select'], [
+                'If multiple modalities were exported, the modality selector switches the feature namespace.',
+                'For example, RNA genes and protein features can be searched separately.'
+            ], {{ condition: () => Array.isArray(MODALITY_DESCRIPTORS) && MODALITY_DESCRIPTORS.length > 1, action: () => safeTutorialClick('#default-source-feature'), nextLabel: tryIt }}),
             step('Feature discovery panel', '#feature-discovery-panel', [
                 'Feature discovery helps you search, activate features, and inspect related feature information.',
                 'Marker feature suggestions are displayed depending on the selected annotation.',
@@ -9563,10 +9571,6 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             step('Feature value scale', ['#gene-params-panel', '#gene-params-toggle'], [
                 'Modify the default scaling of a feature to highlight its values. Scaling can be propagated to the other feature in the Split setup to compare feature values.'
             ], {{ action: () => lockTutorialGeneParamsPanel(), positionTarget: '#gene-params-panel', placement: 'right', prepareDelay: 360, nextLabel: tryIt }}),
-            step('Modality selector', ['#visual-feature-namespace-control', '#visual-feature-namespace-select'], [
-                'If multiple modalities were exported, the modality selector switches the feature namespace.',
-                'For example, RNA genes and protein features can be searched separately.'
-            ], {{ condition: () => Array.isArray(MODALITY_DESCRIPTORS) && MODALITY_DESCRIPTORS.length > 1, action: () => safeTutorialClick('#default-source-feature'), task: 'Switch modality once, then switch back to the one you want.', nextLabel: tryIt }}),
             step('Open a section modal', ['.section-panel:not(.filtered-out)', '.section-panel', '#grid-stage', '#grid'], [
                 'Clicking a section opens a high-detail modal view for that section.'
             ], {{ action: () => {{ if (typeof closeModal === 'function') closeModal(); }}, task: 'Click the highlighted section to open the modal view.', requiresModalOpen: true, nextLabel: tryIt }}),
@@ -9605,7 +9609,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ], {{ action: () => {{ tutorialModuleCreateClicked = false; if (typeof setInsightsMode === 'function') setInsightsMode('module'); }}, task: 'The sum button will create the module list.', requiresModuleCreateClicked: true, targetAfterGateSatisfied: ['#gene-module-create', '.gene-module-card'], combineTargetsAfterGateSatisfied: true, positionTarget: '#insights-panel', placement: 'left', nextLabel: tryIt }}),
             step('Load module score', ['[data-gene-module-load]', '#insights-module-panel'], [
                 'The load button activates a module score in the spatial viewer.',
-	                'Module scores are computed from the selected module features and displayed like an expression layer.'
+	                'Module scores are computed from the selected module features and displayed like a feature layer.'
             ], {{ action: () => {{ if (typeof setInsightsMode === 'function') setInsightsMode('module'); }}, nextLabel: tryIt }}),
             step('Module export', '#gene-module-download', [
                 'Export downloads module definitions as a JSON file.'
@@ -9621,7 +9625,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ], {{ action: () => {{ if (typeof openInsightsMode === 'function') openInsightsMode('exploration'); }}, onNext: () => {{ const tree = document.querySelector('[data-insights-tree]'); if (!tree?.classList.contains('is-open')) safeTutorialClick('[data-insights-tree-root]'); }}, nextLabel: tryIt }}),
             step('Visualization menu options', ['.insights-tree-panel-content', '[data-insights-tree]'], [
                 'The menu options open Overview, Features, Compare, and Neighbors panels.',
-                'Overview summarizes section composition and metadata trends; Features focuses marker, spatial, distribution, and mean-expression feature views; Compare contains selection, region, annotation, pseudobulk, and relationship comparisons; Neighbors contains spatial adjacency, interaction, and dispersion analyses.'
+                'Overview summarizes section composition and metadata trends; Features focuses marker, spatial, distribution, and mean-value feature views; Compare contains selection, region, annotation, pseudobulk, and relationship comparisons; Neighbors contains spatial adjacency, interaction, and dispersion analyses.'
             ], {{ action: () => {{ if (typeof openInsightsMode === 'function') openInsightsMode('exploration'); const tree = document.querySelector('[data-insights-tree]'); if (!tree?.classList.contains('is-open')) safeTutorialClick('[data-insights-tree-root]'); }}, nextLabel: tryIt }}),
             step('Open Overview > Summary', '[data-insights-tree-leaf="summary"][data-insights-tree-parent="overview"]', [
                 'Open Visualization, then Overview, then Summary to inspect annotation composition across section metadata.',
@@ -9652,7 +9656,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ], {{ action: () => openTutorialVisualizationLeafMenu('genes', 'de-genes'), task: 'Click Markers in the Features options.', nextLabel: tryIt }}),
             step('Features Markers panel', ['#marker-genes', '#genes-tab-de-genes-content'], [
                 'The marker panel lists pseudobulk-derived marker features by category when available.',
-                'Features that were not embedded may be shown but disabled for direct expression viewing.'
+                'Features that were not embedded may be shown but disabled for direct feature-value viewing.'
             ], {{ action: () => openTutorialInsightsPanel('genes', 'de-genes'), nextLabel: tryIt }}),
             step('Features Markers view switch', '[data-gene-subtab-toggle="de-genes"]', [
                 'The marker view switch changes between a compact feature list and a heatmap.'
@@ -9675,7 +9679,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 'Enter or select a feature in the Search control.'
             ], {{ action: () => openTutorialInsightsPanel('genes', 'distribution'), task: 'Enter or select a feature in Search.', requiresInsightsGeneSelected: true, nextLabel: tryIt }}),
             step('Features Distribution per cell panel', ['#gene-distribution-panel', '#genes-tab-distribution-content'], [
-                'The distribution panel summarizes expression distributions across categories.'
+                'The distribution panel summarizes feature-value distributions across categories.'
             ], {{ action: () => {{ openTutorialInsightsPanel('genes', 'distribution'); ensureTutorialInsightsGeneSelected(); }}, nextLabel: tryIt }}),
             step('Features Distribution per cell controls', '#gene-distribution-panel .pseudobulk-de-controls', [
                 'These controls restrict the per-cell distribution to a selected annotation or sample-metadata group.'
@@ -9691,7 +9695,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 'Enter or select a feature in the Search control before inspecting the per-sample means panel.'
             ], {{ action: () => openTutorialInsightsPanel('genes', 'means'), task: 'Enter or select a feature in Search.', requiresInsightsGeneSelected: true, nextLabel: tryIt }}),
             step('Features Distribution per sample panel', ['#pseudobulk-gene-means', '#genes-tab-means-content'], [
-                'The means panel uses pseudobulk mean per category to compare expression across categories.'
+                'The means panel uses pseudobulk mean per category to compare feature values across categories.'
             ], {{ action: () => {{ openTutorialInsightsPanel('genes', 'means'); ensureTutorialInsightsGeneSelected(); }}, nextLabel: tryIt }}),
             step('Features Distribution per sample view switch', '.samples-view-toggle[data-gene-subtab-toggle="means"]', [
                 'The per-sample means view can switch between category means and a barplot.'
@@ -9756,11 +9760,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 'The Enrichment switch changes between table, network, and chord views.'
             ], {{ action: () => openTutorialInsightsPanel('neighbors', 'enrichment'), nextLabel: tryIt }}),
             step('Open Neighbors > Interactions', '[data-insights-tree-leaf="interactions"][data-insights-tree-parent="neighbors"]', [
-                'Open Visualization, then Neighbors, then Interactions to inspect contact-conditioned marker genes.'
+                'Open Visualization, then Neighbors, then Interactions to inspect contact-conditioned marker features.'
             ], {{ action: () => openTutorialVisualizationLeafMenu('neighbors', 'interactions'), task: 'Click Interactions in Neighbors.', nextLabel: tryIt }}),
             step('Neighbors Interactions panel', ['#neighbors-tab-interactions-content', '#interaction-browser'], [
                 'Interactions compares source cells based on which target categories they touch.',
-                'Use it to inspect marker genes associated with local neighborhood context when interaction markers were exported.'
+                'Use it to inspect marker features associated with local neighborhood context when interaction markers were exported.'
             ], {{ action: () => {{ openTutorialInsightsPanel('neighbors', 'interactions'); scrollTutorialInsightsPanelTop('#neighbors-tab-interactions-content'); }}, scroll: false, prepareDelay: 140, nextLabel: tryIt }}),
             step('Neighbors Interactions controls', ['#interaction-source', '#interaction-search'], [
                 'The Interactions controls choose the source category and filter target names.'
@@ -10069,10 +10073,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             : (randomArea?.polygon?.length ? randomArea.polygon : buildAnnotationPolygonFromSelectedCells(section, indices));
         if (options.regionB) {{
             selectedCellsB = cells;
-            selectionWelchRevision += 1;
-            selectionWelchCache.clear();
-            selectionWelchRunRequested = false;
-            selectionWelchButtonHidden = false;
+            resetSelectionWelchState();
             selectedAnnotationBId = null;
             selectedLassoPathB = source === 'umap' ? getTutorialUmapPolygon(section, indices) : [];
             selectedCellsBFromGridLasso = source === 'grid';
@@ -11595,9 +11596,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         else if (blocked && step?.requiresModalOpen) next.title = 'Click the highlighted section to open the modal view';
         else if (blocked && step?.requiresSelectionFindMoreClicked) next.title = 'Click Find More to continue';
         else if (blocked && step?.requiresSelectionMarkersClicked) next.title = 'Click the marker search icon to continue';
-        else if (blocked && step?.requiresModuleDraftGene) next.title = 'Select at least one gene to continue';
+        else if (blocked && step?.requiresModuleDraftGene) next.title = 'Select at least one feature to continue';
         else if (blocked && step?.requiresModuleCreateClicked) next.title = 'Click the module sum button to continue';
-        else if (blocked && step?.requiresInsightsGeneSelected) next.title = 'Enter or select a gene to continue';
+        else if (blocked && step?.requiresInsightsGeneSelected) next.title = 'Enter or select a feature to continue';
         else if (blocked && getTutorialInsightsLeafTarget(step)) next.title = 'Click the highlighted menu option to continue';
         else next.removeAttribute('title');
         if (!blocked && step?.autoNextWhenGateSatisfied && !step?.storyMode) {{
@@ -13924,12 +13925,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         
         const geneEntry = auxData?.features?.[gene];
         const manifest = featureSidecarManifest;
-        const map = manifest?.modalities;
-        const modalityEntry = (map && map[targetModality]) ? map[targetModality] : (targetModality === DEFAULT_MODALITY_NAME ? manifest : null);
+        const modalityEntry = getFeatureSidecarManifestEntryForModality(manifest, targetModality);
 
         const geneMeta = auxData?.features_meta?.[gene]
-            || modalityEntry?.features_meta?.[gene]
-            || manifest?.features_meta?.[gene];
+            || modalityEntry?.features_meta?.[gene];
         if (!geneEntry || !geneMeta) return false;
 
         const targetState = getFeatureState(targetModality);
@@ -13940,14 +13939,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
         targetManifest.features_meta[gene] = geneMeta;
         const encoding = auxData?.feature_encodings?.[gene]
-            || modalityEntry?.feature_encodings?.[gene]
-            || manifest?.feature_encodings?.[gene];
+            || modalityEntry?.feature_encodings?.[gene];
         if (encoding) {{
             targetManifest.feature_encodings[gene] = encoding;
         }}
         const valueEncoding = auxData?.feature_value_encodings?.[gene]
-            || modalityEntry?.feature_value_encodings?.[gene]
-            || manifest?.feature_value_encodings?.[gene];
+            || modalityEntry?.feature_value_encodings?.[gene];
         if (valueEncoding) {{
             targetManifest.feature_value_encodings[gene] = valueEncoding;
         }}
@@ -14139,7 +14136,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             throw new Error('Binary feature sidecar manifest is missing section_order');
         }}
         if (buffer.byteLength < 4) {{
-            throw new Error('Binary gene payload is truncated');
+            throw new Error('Binary feature payload is truncated');
         }}
         const view = new DataView(buffer);
         let offset = 0;
@@ -14148,7 +14145,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const sections = {{}};
         for (let i = 0; i < sectionCount; i++) {{
             if (offset + 16 > buffer.byteLength) {{
-                throw new Error('Binary gene payload section header is truncated');
+                throw new Error('Binary feature payload section header is truncated');
             }}
             const sectionIndex = view.getUint16(offset, true);
             offset += 2;
@@ -14163,7 +14160,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             offset += 4;
             const sectionId = sectionOrder[sectionIndex];
             if (!sectionId) {{
-                throw new Error(`Binary gene payload references unknown section index ${{sectionIndex}}`);
+                throw new Error(`Binary feature payload references unknown section index ${{sectionIndex}}`);
             }}
 
             if (sectionEncoding === 0) {{
@@ -14174,7 +14171,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             if (sectionEncoding === 1 || sectionEncoding === 3) {{
                 const valueBytes = sectionEncoding === 1 ? cellCount : cellCount * 2;
                 if (offset + valueBytes + (nanCount * 4) > buffer.byteLength) {{
-                    throw new Error('Binary dense gene payload is truncated');
+                    throw new Error('Binary dense feature payload is truncated');
                 }}
                 const valuesBuffer = buffer.slice(offset, offset + valueBytes);
                 offset += valueBytes;
@@ -14197,7 +14194,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 const valueBytes = sectionEncoding === 2 ? nnz : nnz * 2;
                 const totalBytes = indexBytes + valueBytes + (nanCount * 4);
                 if (offset + totalBytes > buffer.byteLength) {{
-                    throw new Error('Binary sparse gene payload is truncated');
+                    throw new Error('Binary sparse feature payload is truncated');
                 }}
                 const idxBuffer = buffer.slice(offset, offset + indexBytes);
                 const idxs = nnz ? new Uint32Array(idxBuffer) : new Uint32Array(0);
@@ -14224,10 +14221,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const isCurrent = targetModality === getVisualModality();
         
         const manifest = featureSidecarManifest;
-        const map = manifest?.modalities;
-        const modalityEntry = (map && map[targetModality]) ? map[targetModality] : (targetModality === DEFAULT_MODALITY_NAME ? manifest : null);
+        const modalityEntry = getFeatureSidecarManifestEntryForModality(manifest, targetModality);
         
-        const geneMeta = modalityEntry?.features_meta?.[gene] || manifest?.features_meta?.[gene];
+        const geneMeta = modalityEntry?.features_meta?.[gene];
         if (!geneEntry || !geneMeta) return false;
 
         const targetState = getFeatureState(targetModality);
@@ -14237,11 +14233,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         targetManifest.feature_value_encodings = targetManifest.feature_value_encodings || {{}};
 
         targetManifest.features_meta[gene] = geneMeta;
-        const encoding = modalityEntry?.feature_encodings?.[gene] || manifest?.feature_encodings?.[gene];
+        const encoding = modalityEntry?.feature_encodings?.[gene];
         if (encoding) {{
             targetManifest.feature_encodings[gene] = encoding;
         }}
-        const valueEncoding = modalityEntry?.feature_value_encodings?.[gene] || manifest?.feature_value_encodings?.[gene];
+        const valueEncoding = modalityEntry?.feature_value_encodings?.[gene];
         if (valueEncoding) {{
             targetManifest.feature_value_encodings[gene] = valueEncoding;
         }}
@@ -14278,12 +14274,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!DATA.feature_manifest_url) return null;
         if (window.location.protocol === 'file:' && !window.__karospacePackageMode) {{
             window.__karospaceShowStartupError?.(
-                'This viewer was exported with sidecar gene loading. Open it over HTTP(S) to load additional genes.'
+                'This viewer was exported with sidecar feature loading. Open it over HTTP(S) to load additional features.'
             );
             return null;
         }}
 
-        setGeneLoadingState(true, 'Loading gene manifest…');
+	        setGeneLoadingState(true, 'Loading feature manifest...');
         window.__karospaceShowLoadingWarning?.('Loading feature sidecar manifest…');
         featureSidecarManifestPromise = fetch(DATA.feature_manifest_url, {{ credentials: 'same-origin', cache: 'no-store' }})
             .then((response) => {{
@@ -14294,11 +14290,19 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }})
             .then((payload) => {{
                 const format = payload?.format;
-                if (!payload || (format !== 'karospace-feature-sidecar-manifest-v3' && format !== 'karospace-feature-sidecar-manifest-v4')) {{
+                if (!payload || format !== 'karospace-feature-sidecar-manifest-v4') {{
                     throw new Error('Unsupported feature sidecar manifest format');
                 }}
-                if (isBinaryFeatureSidecarFormat(getFeatureSidecarFormat(payload)) && !Array.isArray(payload.section_order)) {{
-                    throw new Error('Binary feature sidecar manifest is missing section_order');
+                const modalities = payload.modalities;
+                if (!modalities || typeof modalities !== 'object') {{
+                    throw new Error('Feature sidecar manifest is missing modalities');
+                }}
+                if (isBinaryFeatureSidecarFormat(getFeatureSidecarFormat(payload))) {{
+                    Object.entries(modalities).forEach(([name, entry]) => {{
+                        if (!Array.isArray(entry?.section_order)) {{
+                            throw new Error(`Binary feature sidecar manifest is missing section_order for modality ${{name}}`);
+                        }}
+                    }});
                 }}
                 featureSidecarManifest = payload;
                 return payload;
@@ -14306,7 +14310,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             .catch((error) => {{
                 console.error('Failed to load feature sidecar manifest:', error);
                 window.__karospaceShowStartupError?.(
-                    `Failed to load auxiliary gene data: ${{error?.message || 'Unknown error'}}`
+                    `Failed to load auxiliary feature data: ${{error?.message || 'Unknown error'}}`
                 );
                 featureSidecarManifestPromise = null;
                 return null;
@@ -14354,7 +14358,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             .catch((error) => {{
                 console.error('Failed to load feature shard:', error);
                 window.__karospaceShowStartupError?.(
-                    `Failed to load requested gene data: ${{error?.message || 'Unknown error'}}`
+                    `Failed to load requested feature data: ${{error?.message || 'Unknown error'}}`
                 );
                 featureSidecarShardPromises.delete(shardUrl);
                 return null;
@@ -14390,18 +14394,17 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const manifest = await loadFeatureSidecarManifest();
         if (!manifest) return false;
         
-        const map = manifest.modalities;
-        const modalityEntry = (map && map[targetModality]) ? map[targetModality] : (targetModality === DEFAULT_MODALITY_NAME ? manifest : null);
+        const modalityEntry = getFeatureSidecarManifestEntryForModality(manifest, targetModality);
         
-        const shardUrl = modalityEntry?.feature_to_shard?.[token] ?? manifest?.feature_to_shard?.[token];
+        const shardUrl = modalityEntry?.feature_to_shard?.[token];
         if (!shardUrl) {{
             if (showErrors) {{
                 alert(`Gene "${{token}}" is listed in the dataset but was not indexed in the auxiliary manifest.`);
             }}
             return false;
         }}
-        const sectionOrder = modalityEntry?.section_order || manifest.section_order || [];
-        const geneMeta = modalityEntry?.features_meta?.[token] ?? manifest?.features_meta?.[token] ?? null;
+        const sectionOrder = modalityEntry?.section_order || [];
+        const geneMeta = modalityEntry?.features_meta?.[token] ?? null;
         let hydrated = false;
         if (isBinaryFeatureSidecarFormat(getFeatureSidecarFormat(manifest))) {{
             try {{
@@ -14410,10 +14413,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 const geneEntry = parseBinaryFeaturePayload(payloadBuffer, sectionOrder, geneMeta);
                 hydrated = hydrateGeneFromBinary(token, geneEntry, targetModality);
             }} catch (error) {{
-                console.error('Failed to load binary gene payload:', error);
+                console.error('Failed to load binary feature payload:', error);
                 if (showErrors) {{
                     window.__karospaceShowStartupError?.(
-                        `Failed to load requested gene data: ${{error?.message || 'Unknown error'}}`
+                        `Failed to load requested feature data: ${{error?.message || 'Unknown error'}}`
                     );
                 }}
                 return false;
@@ -14827,18 +14830,17 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!spec) return 'annotation';
         if (spec.source === 'feature') return 'feature';
         if (spec.source === 'annotation') return 'annotation';
-        return spec.kind && spec.kind !== 'cell' ? 'feature' : 'annotation';
+        return 'annotation';
     }}
 
     function getOverviewBlendModality(spec, side = null) {{
         if (!spec) return side ? getPanelModality(`split.${{side}}`) : DEFAULT_MODALITY_NAME;
         const fallback = side ? getPanelModality(`split.${{side}}`) : DEFAULT_MODALITY_NAME;
-        const legacyKind = spec.kind && spec.kind !== 'cell' ? spec.kind : '';
-        return spec.modality || legacyKind || fallback || DEFAULT_MODALITY_NAME;
+        return spec.modality || fallback || DEFAULT_MODALITY_NAME;
     }}
 
     function getOverviewBlendFeature(spec) {{
-        return String(spec?.feature || spec?.gene || '').trim();
+        return String(spec?.feature || '').trim();
     }}
 
     function getOverviewSplitGeneTarget(side) {{
@@ -15656,11 +15658,18 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return selectedCells.size > 0 || selectedCellsB.size > 0;
     }}
 
-    function clearRegionBSelection() {{
-        selectionWelchRevision += 1;
+    function resetSelectionWelchState(options = {{}}) {{
+        if (options.bumpRevision !== false) selectionWelchRevision += 1;
+        selectionWelchRunToken += 1;
         selectionWelchCache.clear();
-        selectionWelchRunRequested = false;
-        selectionWelchButtonHidden = false;
+        selectionWelchRunRequested = !!options.keepRequested;
+        selectionWelchRunning = false;
+        selectionWelchButtonHidden = !!options.keepRequested;
+        selectionWelchFullRun = null;
+    }}
+
+    function clearRegionBSelection() {{
+        resetSelectionWelchState();
         selectedCellsB.clear();
         selectedLassoPathB = [];
         selectedCellsBFromGridLasso = false;
@@ -15829,19 +15838,37 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return value.toFixed(2);
     }}
 
-    function computeSelectionWelchExpression(groupA, groupB = null) {{
-        if (!groupA?.size) return [];
+    function getSelectionWelchCacheKey(groupB = null) {{
+        return `${{getExplorationModality()}}:${{groupB === null ? 'all' : 'region-b'}}:${{selectionRevision}}:${{selectionWelchRevision}}`;
+    }}
+
+    function normalizeSelectionWelchResult(result) {{
+        if (!result || !result.available) return null;
+        const modality = result.modality || getExplorationModality();
+        return {{
+            ...result,
+            modality,
+            results: (result.results || []).map((entry) => ({{
+                ...entry,
+                pctA: 100 * Number(entry.pctA || 0),
+                pctB: 100 * Number(entry.pctB || 0),
+                modality,
+            }})),
+        }};
+    }}
+
+    function computeSelectionWelchResult(groupA, groupB = null) {{
+        if (!groupA?.size) return null;
         const cellSetA = buildSelectionCellSetGroup(groupA, {{ key: 'selection-a', label: 'Selection A' }});
         const cellSetB = groupB === null
             ? buildSelectionCellSetGroup(null, {{ key: 'all-cells', label: 'All cells' }}, true)
             : buildSelectionCellSetGroup(groupB, {{ key: 'selection-b', label: 'Selection B' }});
         const result = computePooledWelchCellSetDE(cellSetA, cellSetB);
-        if (!result.available) return [];
-        return result.results.map((entry) => ({{
-            ...entry,
-            pctA: 100 * entry.pctA,
-            pctB: 100 * entry.pctB,
-        }}));
+        return normalizeSelectionWelchResult(result);
+    }}
+
+    function computeSelectionWelchExpression(groupA, groupB = null) {{
+        return computeSelectionWelchResult(groupA, groupB)?.results || [];
     }}
 
     // Compatibility helper for the annotation comparison view, which still plots means.
@@ -15854,14 +15881,103 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}));
     }}
 
-	    function getCachedSelectionWelchExpression(groupA, groupB = null) {{
-	        if (!selectionWelchRunRequested) return [];
-	        const key = `${{getExplorationModality()}}:${{groupB === null ? 'all' : 'region-b'}}:${{selectionRevision}}:${{selectionWelchRevision}}`;
-	        if (selectionWelchCache.has(key)) return selectionWelchCache.get(key);
-	        const result = computeSelectionWelchExpression(groupA, groupB);
-	        selectionWelchCache.set(key, result);
-	        return result;
-	    }}
+    function getCachedSelectionWelchResult(groupA, groupB = null) {{
+        if (!selectionWelchRunRequested) return null;
+        const key = getSelectionWelchCacheKey(groupB);
+        if (selectionWelchCache.has(key)) return selectionWelchCache.get(key);
+        if (selectionWelchRunning || shouldRunFullSidecarDE(getExplorationModality())) return null;
+        const result = computeSelectionWelchResult(groupA, groupB);
+        if (result) selectionWelchCache.set(key, result);
+        return result;
+    }}
+
+    function getCachedSelectionWelchExpression(groupA, groupB = null) {{
+        return getCachedSelectionWelchResult(groupA, groupB)?.results || [];
+    }}
+
+    async function runSelectionWelchComparison() {{
+        if (selectionWelchRunning || selectedCells.size === 0) return;
+        const compareAllCells = selectedCellsB.size === 0;
+        const groupASelection = new Set(selectedCells);
+        const groupBSelection = compareAllCells ? null : new Set(selectedCellsB);
+        const key = getSelectionWelchCacheKey(groupBSelection);
+        const targetModality = getExplorationModality();
+        const token = ++selectionWelchRunToken;
+        selectionWelchRunRequested = true;
+        selectionWelchRunning = true;
+        selectionWelchButtonHidden = true;
+        selectionWelchFullRun = null;
+        updateSelectionInfo();
+        await new Promise((resolve) => window.setTimeout(resolve, 30));
+
+        const cellSetA = buildSelectionCellSetGroup(groupASelection, {{ key: 'selection-a', label: 'Selection A' }});
+        const cellSetB = groupBSelection === null
+            ? buildSelectionCellSetGroup(null, {{ key: 'all-cells', label: 'All cells' }}, true)
+            : buildSelectionCellSetGroup(groupBSelection, {{ key: 'selection-b', label: 'Selection B' }});
+        const isStale = () => token !== selectionWelchRunToken || key !== getSelectionWelchCacheKey(groupBSelection);
+        if (isStale()) return;
+
+        if (shouldRunFullSidecarDE(targetModality)) {{
+            selectionWelchFullRun = {{
+                token,
+                key,
+                running: true,
+                completedShards: 0,
+                totalShards: 0,
+                completedGenes: 0,
+                totalGenes: 0,
+                modality: targetModality,
+                error: null,
+            }};
+            updateSelectionInfo();
+            try {{
+                const fullResult = await runFullCellSetDE(cellSetA, cellSetB, {{
+                    modality: targetModality,
+                    isCancelled: isStale,
+                    onProgress: (progress) => {{
+                        if (isStale()) return;
+                        selectionWelchFullRun = {{
+                            token,
+                            key,
+                            running: true,
+                            completedShards: Number(progress.completedShards || 0),
+                            totalShards: Number(progress.totalShards || 0),
+                            completedGenes: Number(progress.completedGenes || 0),
+                            totalGenes: Number(progress.totalGenes || 0),
+                            modality: targetModality,
+                            error: null,
+                        }};
+                        updateSelectionInfo();
+                    }},
+                }});
+                if (isStale() || !fullResult) return;
+                const normalized = normalizeSelectionWelchResult(fullResult);
+                if (normalized) selectionWelchCache.set(key, normalized);
+                selectionWelchFullRun = null;
+            }} catch (error) {{
+                if (isStale()) return;
+                selectionWelchFullRun = {{
+                    token,
+                    key,
+                    running: false,
+                    completedShards: Number(selectionWelchFullRun?.completedShards || 0),
+                    totalShards: Number(selectionWelchFullRun?.totalShards || 0),
+                    completedGenes: Number(selectionWelchFullRun?.completedGenes || 0),
+                    totalGenes: Number(selectionWelchFullRun?.totalGenes || 0),
+                    modality: targetModality,
+                    error: error?.message || 'Unknown error',
+                }};
+            }}
+        }} else {{
+            const quickResult = normalizeSelectionWelchResult(computePooledWelchCellSetDE(cellSetA, cellSetB));
+            if (isStale()) return;
+            if (quickResult) selectionWelchCache.set(key, quickResult);
+        }}
+
+        if (isStale()) return;
+        selectionWelchRunning = false;
+        updateSelectionInfo();
+    }}
 
     function selectWelchTopResults(results, topN, minPct = 0, pctScale = 100) {{
         const n = Math.max(1, Math.min(20, Number(topN) || 3));
@@ -15885,7 +16001,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function renderWelchTopNControl() {{
-        return `<div class="selection-summary-welch-controls"><div class="selection-summary-welch-control-row"><label>Top N per direction</label><input type="number" name="selection_welch_top_n" min="1" max="20" step="1" value="${{selectionWelchTopN}}" data-welch-top-n aria-label="Number of top positive and negative genes selected by Welch test"></div><div class="selection-summary-welch-control-row"><label>Min expressed %</label><input type="range" name="selection_welch_min_pct" min="0" max="100" step="1" value="${{selectionWelchMinPct}}" data-welch-min-pct aria-label="Minimum percentage of expressing cells in at least one group"><output data-welch-min-pct-value>${{selectionWelchMinPct}}%</output></div></div>`;
+        return `<div class="selection-summary-welch-controls"><div class="selection-summary-welch-control-row"><label>Top N per direction</label><input type="number" name="selection_welch_top_n" min="1" max="20" step="1" value="${{selectionWelchTopN}}" data-welch-top-n aria-label="Number of top positive and negative features selected by Welch test"></div><div class="selection-summary-welch-control-row"><label>Min detected %</label><input type="range" name="selection_welch_min_pct" min="0" max="100" step="1" value="${{selectionWelchMinPct}}" data-welch-min-pct aria-label="Minimum percentage of cells with positive values in at least one group"><output data-welch-min-pct-value>${{selectionWelchMinPct}}%</output></div></div>`;
     }}
 
     function renderFindMarkersButton() {{
@@ -16087,7 +16203,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const entries = Array.isArray(modalGenePanelEntries) ? modalGenePanelEntries : [];
         countEl.textContent = `${{count.toLocaleString()}} cells`;
         if (!entries.length) {{
-            body.innerHTML = `<div class="modal-gene-panel-empty">${{escapeHtml(modalGenePanelState.message || 'Load a gene first to rank by expression')}}</div>`;
+            body.innerHTML = `<div class="modal-gene-panel-empty">${{escapeHtml(modalGenePanelState.message || 'Load a feature first to rank by value')}}</div>`;
         }} else {{
             body.innerHTML = entries.map((entry) => {{
                 const scoreLabel = formatModalGeneDiscoveryEntryScore(entry);
@@ -16113,7 +16229,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                             </span>
                         </button>
                         ${{renderGeneGoogleSearchButton(entry.gene, {{
-                            title: 'Search Google for this selection gene',
+                            title: 'Search Google for this selection feature',
                         }})}}
                     </div>
                 `;
@@ -16151,7 +16267,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             cellCount: indices.length,
             message: markerEntries.length
                 ? ''
-                : (loadedGenes.length ? 'Ranking loaded genes…' : 'Load a gene first to rank by expression'),
+                : (loadedGenes.length ? 'Ranking loaded features...' : 'Load a feature first to rank by value'),
         }};
         modalGenePanelEntries = mergeModalGeneDiscoveryEntries(markerEntries, [], 30);
         renderModalGeneDiscoveryPanel();
@@ -16164,7 +16280,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             if (!modalGenePanelEntries.length && !markerEntries.length) {{
                 modalGenePanelState = {{
                     ...modalGenePanelState,
-                    message: 'No enriched genes found among loaded genes.',
+                    message: 'No enriched features found among loaded features.',
                 }};
             }}
             renderModalGeneDiscoveryPanel();
@@ -16554,62 +16670,6 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }};
     }}
 
-    function computeCellSetDE(groupA, groupB, options = {{}}) {{
-        const topN = Math.max(1, Number(options.topN) || groupDeTopN || 12);
-        if (!groupA || !groupB) {{
-            return {{ available: false, reason: 'missing_groups', results: [] }};
-        }}
-        if (groupA.key && groupA.key === groupB.key) {{
-            return {{ available: false, reason: 'same_group', nA: groupA.nCells || 0, nB: groupB.nCells || 0, results: [] }};
-        }}
-        if (!(groupA.nCells > 0) || !(groupB.nCells > 0)) {{
-            return {{
-                available: false,
-                reason: 'empty_group',
-                nA: Number(groupA.nCells || 0),
-                nB: Number(groupB.nCells || 0),
-                modality: getExplorationModality(),
-                results: [],
-            }};
-        }}
-
-        const activeModality = getExplorationModality();
-        const loadedGenes = getLoadedFeaturesForModality(activeModality);
-        const totalGenes = getFeatureCatalog(activeModality).length || loadedGenes.length;
-        if (!loadedGenes.length) {{
-            return {{
-                available: false,
-                reason: 'no_loaded_features',
-                nA: Number(groupA.nCells || 0),
-                nB: Number(groupB.nCells || 0),
-                modality: activeModality,
-                loadedGeneCount: 0,
-                totalGeneCount: totalGenes,
-                results: [],
-            }};
-        }}
-
-        const results = [];
-        loadedGenes.forEach((gene) => {{
-            const statsA = computeQuickStatsForGroupGene(groupA, gene, activeModality);
-            const statsB = computeQuickStatsForGroupGene(groupB, gene, activeModality);
-            const entry = buildDEEntryFromStats(gene, statsA, statsB, groupA.nCells, groupB.nCells);
-            if (entry) results.push(entry);
-        }});
-
-        sortCellSetDEResults(results);
-        return {{
-            available: true,
-            reason: null,
-            nA: Number(groupA.nCells || 0),
-            nB: Number(groupB.nCells || 0),
-            modality: activeModality,
-            loadedGeneCount: loadedGenes.length,
-            totalGeneCount: totalGenes,
-            results: selectTwoSidedTopN(results, topN),
-        }};
-    }}
-
     function cancelGroupDEFullRun() {{
         groupDeFullRunToken += 1;
         groupDeFullRun = null;
@@ -16651,7 +16711,6 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function computeCellSetDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB, modality = getExplorationModality()) {{
         const modalityEntry = getFeatureSidecarManifestEntryForModality(featureSidecarManifest, modality);
         const geneMeta = modalityEntry?.features_meta?.[gene]
-            || (modality === DEFAULT_MODALITY_NAME ? featureSidecarManifest?.features_meta?.[gene] : null)
             || getFeatureState(modality).features_meta?.[gene]
             || null;
         const statsA = computeGroupStatsFromSidecarGeneEntry(geneEntry, groupA, geneMeta);
@@ -16695,7 +16754,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         if (!payloadBuffer) continue;
                         const geneEntry = parseBinaryFeaturePayload(
                             payloadBuffer,
-                            modalityEntry.section_order || manifest.section_order || [],
+                            modalityEntry.section_order || [],
                             modalityEntry?.features_meta?.[gene] || null
                         );
                         const entry = computeCellSetDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB, targetModality);
@@ -16971,7 +17030,6 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function computeRegionAnnotationDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB, modality = getExplorationModality()) {{
         const modalityEntry = getFeatureSidecarManifestEntryForModality(featureSidecarManifest, modality);
         const geneMeta = modalityEntry?.features_meta?.[gene]
-            || (modality === DEFAULT_MODALITY_NAME ? featureSidecarManifest?.features_meta?.[gene] : null)
             || getFeatureState(modality).features_meta?.[gene]
             || null;
         const statsA = computeGroupStatsFromSidecarGeneEntry(geneEntry, groupA, geneMeta);
@@ -17057,7 +17115,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                             if (!payloadBuffer) continue;
                             const geneEntry = parseBinaryFeaturePayload(
                                 payloadBuffer,
-                                modalityEntry.section_order || manifest.section_order || [],
+                                modalityEntry.section_order || [],
                                 modalityEntry?.features_meta?.[gene] || null
                             );
                             const result = computeRegionAnnotationDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB, targetModality);
@@ -17432,7 +17490,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const examples = getSelectionQueryExamplePresets();
         const preview = getSelectionQueryPreviewText();
         const summaryHtml = expanded
-            ? 'Use a simple rule with annotations, genes, or section metadata.'
+            ? 'Use a simple rule with annotations, features, or section metadata.'
             : selectionQueryStatus
                 ? escapeHtml(selectionQueryStatus)
                 : preview
@@ -17569,6 +17627,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const labelB = compareAllCells ? 'All cells' : 'Region B';
         const colorA = 'var(--accent-strong)';
         const colorB = compareAllCells ? 'var(--muted-color)' : '#4cc9f0';
+        const selectionResultKey = getSelectionWelchCacheKey(compareAllCells ? null : selectedCellsB);
+        const selectionFullRun = selectionWelchFullRun?.key === selectionResultKey ? selectionWelchFullRun : null;
         let html = '';
 
         // Match the Region composition layout for the two lasso selections.
@@ -17614,16 +17674,30 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
 
         // Welch test for feature values A vs B.
-        const expr = getCachedSelectionWelchExpression(selectedCells, compareAllCells ? null : selectedCellsB);
+        const selectionWelchResult = getCachedSelectionWelchResult(selectedCells, compareAllCells ? null : selectedCellsB);
+        const expr = selectionWelchResult?.results || [];
+        const resultModality = selectionWelchResult?.modality || selectionFullRun?.modality || getExplorationModality();
         if (selectedCells.size > 0 && (compareAllCells || selectedCellsB.size > 0)) {{
             const top = getWelchTopResults(expr);
             html += '<div class="selection-summary-expr">';
-            html += `<div class="selection-summary-title-row"><div class="selection-summary-title">Gene expression — ${{labelA.toLowerCase()}} vs ${{labelB.toLowerCase()}}${{renderCalcInfoButton('selection_expression')}}</div>${{renderFindMarkersButton()}}</div>${{selectionWelchRunRequested && !selectionWelchRunning ? renderWelchTopNControl() : ''}}`;
+            html += `<div class="selection-summary-title-row"><div class="selection-summary-title">Feature values - ${{labelA.toLowerCase()}} vs ${{labelB.toLowerCase()}}${{renderCalcInfoButton('selection_expression')}}</div>${{renderFindMarkersButton()}}</div>${{selectionWelchRunRequested && !selectionWelchRunning ? renderWelchTopNControl() : ''}}`;
+            if (selectionFullRun?.running) {{
+                const maximum = Math.max(1, Number(selectionFullRun.totalGenes || selectionFullRun.totalShards || 1));
+                const value = Math.min(maximum, Number(selectionFullRun.completedGenes || selectionFullRun.completedShards || 0));
+                const progressPct = Math.round((value / maximum) * 100);
+                html += `<div class="agg-group-meta">Scanning all ${{getModalityDisplayLabel(resultModality)}} features from the sidecar.</div><progress value="${{value}}" max="${{maximum}}" style="width:100%;height:12px"></progress><div class="agg-group-meta">${{progressPct}}% complete · ${{Number(selectionFullRun.completedGenes || 0).toLocaleString()}} / ${{Number(selectionFullRun.totalGenes || 0).toLocaleString()}} features</div>`;
+            }} else if (selectionFullRun?.error) {{
+                html += `<div class="agg-group-meta">Full sidecar comparison failed: ${{escapeHtml(selectionFullRun.error)}}</div>`;
+            }} else if (selectionWelchResult?.mode === 'full-sidecar') {{
+                html += `<div class="agg-group-meta">Full sidecar comparison across ${{Number(selectionWelchResult.totalGeneCount || 0).toLocaleString()}} ${{getModalityDisplayLabel(resultModality)}} features.</div>`;
+            }} else if (selectionWelchResult && Number(selectionWelchResult.loadedGeneCount || 0) < Number(selectionWelchResult.totalGeneCount || 0)) {{
+                html += `<div class="agg-group-meta">Quick preview over ${{Number(selectionWelchResult.loadedGeneCount || 0).toLocaleString()}} of ${{Number(selectionWelchResult.totalGeneCount || 0).toLocaleString()}} features.</div>`;
+            }}
             top.forEach(({{gene, meanA, meanB, pctA, pctB}}) => {{
                 const vmax = Math.max(1e-12, meanA || 0, meanB || 0);
                 const factor = meanB > 0 ? (meanA / meanB).toFixed(1) + 'x' : '—';
                 html += `<div class="selection-summary-expr-row">
-                    <span class="selection-summary-expr-gene" data-gene-activate="${{escapeHtml(gene)}}" title="Load ${{escapeHtml(gene)}} into the viewer">${{escapeHtml(gene)}}</span>
+                    <span class="selection-summary-expr-gene" data-gene-activate="${{escapeHtml(gene)}}" data-gene-modality="${{escapeHtml(resultModality)}}" title="Load ${{escapeHtml(gene)}} into the viewer">${{escapeHtml(gene)}}</span>
                     <div class="selection-summary-expr-bars">
                         <div class="selection-summary-expr-bar sel" style="width:${{clampPercent(100 * meanA / vmax)}}%;" title="${{labelA}} mean: ${{formatCompactNumber(meanA)}}">${{formatCompactNumber(meanA)}} (${{pctA.toFixed(0)}}%)</div>
                         <div class="selection-summary-expr-bar ${{compareAllCells ? 'rest' : 'region-b'}}" style="width:${{clampPercent(100 * meanB / vmax)}}%;" title="${{labelB}} mean: ${{formatCompactNumber(meanB)}}">${{formatCompactNumber(meanB)}} (${{pctB.toFixed(0)}}%)</div>
@@ -17642,19 +17716,21 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         <div class="comparison-card-title comparison-de-card-title">
                             <div class="comparison-de-card-title-main">
                                 ${{renderGeneTokenButton(entry.gene, {{
+                                    allowUnknown: true,
                                     isActive: entry.gene === currentGene,
+                                    modality: resultModality,
                                     showMeta: false,
-                                    title: 'Load selection comparison gene into the viewer',
+                                    title: 'Load selection comparison feature into the viewer',
                                 }})}}
                                 ${{renderGeneGoogleSearchButton(entry.gene, {{
-                                    title: 'Search Google for this gene',
+                                    title: 'Search Google for this feature',
                                 }})}}
                             </div>
                             <div class="comparison-de-title-stats" style="border-color:${{Number(entry.score || 0) >= 0 ? colorA : colorB}}"><span>log2FC ${{formatScaleNumber(entry.log2fc)}}</span><span>Score ${{formatScaleNumber(entry.score)}}</span></div>
                         </div>
                         <div class="comparison-metric-grid">
-                            <span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorA, Number(entry.score || 0) >= 0 ? colorA : colorB)}};color:${{textColorA}}"><span>% expr ${{compareAllCells ? 'selected' : 'A'}}</span><strong>${{Number(entry.pctA || 0).toFixed(1)}}%</strong><span>Mean ${{compareAllCells ? 'selected' : 'A'}}</span><strong>${{formatScaleNumber(entry.meanA)}}</strong></span>
-                            <span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorB, Number(entry.score || 0) >= 0 ? colorA : colorB)}};color:${{textColorB}}"><span>% expr ${{compareAllCells ? 'all' : 'B'}}</span><strong>${{Number(entry.pctB || 0).toFixed(1)}}%</strong><span>Mean ${{compareAllCells ? 'all' : 'B'}}</span><strong>${{formatScaleNumber(entry.meanB)}}</strong></span>
+	                            <span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorA, Number(entry.score || 0) >= 0 ? colorA : colorB)}};color:${{textColorA}}"><span>% detected ${{compareAllCells ? 'selected' : 'A'}}</span><strong>${{Number(entry.pctA || 0).toFixed(1)}}%</strong><span>Mean ${{compareAllCells ? 'selected' : 'A'}}</span><strong>${{formatScaleNumber(entry.meanA)}}</strong></span>
+	                            <span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorB, Number(entry.score || 0) >= 0 ? colorA : colorB)}};color:${{textColorB}}"><span>% detected ${{compareAllCells ? 'all' : 'B'}}</span><strong>${{Number(entry.pctB || 0).toFixed(1)}}%</strong><span>Mean ${{compareAllCells ? 'all' : 'B'}}</span><strong>${{formatScaleNumber(entry.meanB)}}</strong></span>
                         </div>
                     </div>
                 `).join('');
@@ -17751,16 +17827,32 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             html += '<div class="selection-summary-meta">No categorical annotation is available for type counts.</div>';
         }}
 
-        const exprData = getCachedSelectionWelchExpression(selectedCells, null);
+        const selectionResultKey = getSelectionWelchCacheKey(null);
+        const selectionFullRun = selectionWelchFullRun?.key === selectionResultKey ? selectionWelchFullRun : null;
+        const selectionWelchResult = getCachedSelectionWelchResult(selectedCells, null);
+        const exprData = selectionWelchResult?.results || [];
+        const resultModality = selectionWelchResult?.modality || selectionFullRun?.modality || getExplorationModality();
         if (selectedCells.size > 0) {{
             const top = getWelchTopResults(exprData);
             html += '<div class="selection-summary-expr">';
-            html += `<div class="selection-summary-title-row"><div class="selection-summary-title">Gene expression — selected cells vs all cells${{renderCalcInfoButton('selection_expression')}}</div>${{renderFindMarkersButton()}}</div>${{selectionWelchRunRequested && !selectionWelchRunning ? renderWelchTopNControl() : ''}}`;
+            html += `<div class="selection-summary-title-row"><div class="selection-summary-title">Feature values - selected cells vs all cells${{renderCalcInfoButton('selection_expression')}}</div>${{renderFindMarkersButton()}}</div>${{selectionWelchRunRequested && !selectionWelchRunning ? renderWelchTopNControl() : ''}}`;
+            if (selectionFullRun?.running) {{
+                const maximum = Math.max(1, Number(selectionFullRun.totalGenes || selectionFullRun.totalShards || 1));
+                const value = Math.min(maximum, Number(selectionFullRun.completedGenes || selectionFullRun.completedShards || 0));
+                const progressPct = Math.round((value / maximum) * 100);
+                html += `<div class="agg-group-meta">Scanning all ${{getModalityDisplayLabel(resultModality)}} features from the sidecar.</div><progress value="${{value}}" max="${{maximum}}" style="width:100%;height:12px"></progress><div class="agg-group-meta">${{progressPct}}% complete · ${{Number(selectionFullRun.completedGenes || 0).toLocaleString()}} / ${{Number(selectionFullRun.totalGenes || 0).toLocaleString()}} features</div>`;
+            }} else if (selectionFullRun?.error) {{
+                html += `<div class="agg-group-meta">Full sidecar comparison failed: ${{escapeHtml(selectionFullRun.error)}}</div>`;
+            }} else if (selectionWelchResult?.mode === 'full-sidecar') {{
+                html += `<div class="agg-group-meta">Full sidecar comparison across ${{Number(selectionWelchResult.totalGeneCount || 0).toLocaleString()}} ${{getModalityDisplayLabel(resultModality)}} features.</div>`;
+            }} else if (selectionWelchResult && Number(selectionWelchResult.loadedGeneCount || 0) < Number(selectionWelchResult.totalGeneCount || 0)) {{
+                html += `<div class="agg-group-meta">Quick preview over ${{Number(selectionWelchResult.loadedGeneCount || 0).toLocaleString()}} of ${{Number(selectionWelchResult.totalGeneCount || 0).toLocaleString()}} features.</div>`;
+            }}
             top.forEach(({{gene, meanA, meanB, pctA, pctB}}) => {{
                 const vmax = Math.max(1e-12, meanA || 0, meanB || 0);
                 const factor = meanB > 0 ? (meanA / meanB).toFixed(1) + 'x' : '—';
                 html += `<div class="selection-summary-expr-row">
-                    <span class="selection-summary-expr-gene" data-gene-activate="${{escapeHtml(gene)}}" title="Load ${{escapeHtml(gene)}} into the viewer">${{escapeHtml(gene)}}</span>
+                    <span class="selection-summary-expr-gene" data-gene-activate="${{escapeHtml(gene)}}" data-gene-modality="${{escapeHtml(resultModality)}}" title="Load ${{escapeHtml(gene)}} into the viewer">${{escapeHtml(gene)}}</span>
                     <div class="selection-summary-expr-bars">
                         <div class="selection-summary-expr-bar sel" style="width:${{clampPercent(100 * meanA / vmax)}}%;" title="Selected mean: ${{formatCompactNumber(meanA)}}">${{formatCompactNumber(meanA)}} (${{pctA.toFixed(0)}}%)</div>
                         <div class="selection-summary-expr-bar rest" style="width:${{clampPercent(100 * meanB / vmax)}}%;" title="All cells mean: ${{formatCompactNumber(meanB)}}">${{formatCompactNumber(meanB)}} (${{pctB.toFixed(0)}}%)</div>
@@ -17780,7 +17872,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (options.allowGenePanel && modalSection && summary.total > 0) {{
             actionButtons.push(
                 `<button class="selection-summary-compare-btn" type="button" id="selection-show-genes-btn">${{
-                    modalGenePanelState ? 'Hide genes' : 'Genes in selection'
+                    modalGenePanelState ? 'Hide features' : 'Features in selection'
                 }}</button>`
             );
         }}
@@ -17814,10 +17906,18 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         container.querySelectorAll('[data-selection-de-export-csv]').forEach((button) => {{
             button.addEventListener('click', () => {{
                 const compareAllCells = selectedCellsB.size === 0;
-                const result = {{
-                    results: getCachedSelectionWelchExpression(selectedCells, compareAllCells ? null : selectedCellsB),
+                const cachedResult = getCachedSelectionWelchResult(selectedCells, compareAllCells ? null : selectedCellsB);
+                const result = cachedResult ? {{
+                    ...cachedResult,
+                    nA: Number(cachedResult.nA ?? selectedCells.size),
+                    nB: Number(cachedResult.nB ?? (compareAllCells ? buildAllCellsSelectionSummary().total : selectedCellsB.size)),
+                }} : {{
+                    results: [],
                     nA: selectedCells.size,
                     nB: compareAllCells ? buildAllCellsSelectionSummary().total : selectedCellsB.size,
+                    modality: getExplorationModality(),
+                    loadedGeneCount: 0,
+                    totalGeneCount: 0,
                 }};
                 exportComparisonDECsv(
                     compareAllCells ? 'selected cells' : 'region A',
@@ -17851,16 +17951,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 event.stopPropagation();
                 if (selectionWelchRunning || selectedCells.size === 0) return;
                 const advanceTutorialFromMarkerSearch = tutorialActive && tutorialSteps[tutorialStepIndex]?.requiresSelectionMarkersClicked;
-                if (tutorialActive && tutorialSteps[tutorialStepIndex]?.requiresSelectionMarkersClicked) {{
+                if (advanceTutorialFromMarkerSearch) {{
                     tutorialSelectionMarkersClicked = true;
                 }}
-                selectionWelchRunning = true;
-                selectionWelchButtonHidden = true;
-                updateSelectionInfo();
-                window.setTimeout(() => {{
-                    selectionWelchRunRequested = true;
-                    selectionWelchRunning = false;
-                    updateSelectionInfo();
+                runSelectionWelchComparison().finally(() => {{
                     if (advanceTutorialFromMarkerSearch) {{
                         window.setTimeout(() => {{
                             if (!tutorialActive) return;
@@ -17868,7 +17962,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                             document.getElementById('tutorial-next')?.click();
                         }}, 80);
                     }}
-                }}, 30);
+                }});
             }});
         }});
         container.querySelectorAll('[data-selection-find-more]').forEach((button) => {{
@@ -18328,10 +18422,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
         if (lassoModeB) {{
             selectedCellsB = newCells;
-            selectionWelchRevision += 1;
-            selectionWelchCache.clear();
-            selectionWelchRunRequested = false;
-            selectionWelchButtonHidden = false;
+            resetSelectionWelchState();
             selectedLassoPathB = completedLassoPath;
             selectedCellsBFromGridLasso = false;
             selectedGridLassoSectionIdB = null;
@@ -18429,10 +18520,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
         if (lassoModeB) {{
             selectedCellsB = newCells;
-            selectionWelchRevision += 1;
-            selectionWelchCache.clear();
-            selectionWelchRunRequested = false;
-            selectionWelchButtonHidden = false;
+            resetSelectionWelchState();
             selectedLassoPathB = [];
             selectedCellsBFromGridLasso = true;
             selectedGridLassoSectionIdB = section.id;
@@ -19525,7 +19613,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             if (downsampleWarning) warnings.push(downsampleWarning);
         }}
         if (insightsGenesTab === 'de-genes') {{
-            warnings.push('<div class="genes-warning"><strong>Double dipping warning.</strong> When unsupervised cell clustering is used as category, the genes contributing to that clustering are inherently likely to be identified as differentially expressed. False positive differentially expressed genes are expected, which could lead to false biological cell-type interpretation.</div>');
+            warnings.push('<div class="genes-warning"><strong>Double dipping warning.</strong> When unsupervised cell clustering is used as category, the features contributing to that clustering are inherently likely to be identified as differentially enriched. False positive differential features are expected, which could lead to false biological interpretation.</div>');
         }}
         container.innerHTML = warnings.join('');
     }}
@@ -20228,9 +20316,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function markPrimarySelectionChanged() {{
         selectionRevision += 1;
         annotationCreatedForSelectionRevision = null;
-        selectionWelchCache.clear();
-        selectionWelchRunRequested = false;
-        selectionWelchButtonHidden = false;
+        resetSelectionWelchState({{ bumpRevision: false }});
     }}
 
     function annotationAlreadyCreatedForCurrentSelection() {{
@@ -20499,10 +20585,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const annotation = getModalAnnotationById(annotationId);
         if (!annotation || !selectedCellsFromAnnotation || selectedAnnotationId === annotation.id || selectedCells.size === 0) return;
         selectedCellsB = getAnnotationCellSet(annotation);
-        selectionWelchRevision += 1;
-        selectionWelchCache.clear();
-        selectionWelchRunRequested = false;
-        selectionWelchButtonHidden = false;
+        resetSelectionWelchState();
         selectedLassoPathB = [];
         selectedCellsBFromGridLasso = false;
         selectedGridLassoSectionIdB = null;
@@ -21235,7 +21318,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 xChunks = [header, ...xChunks];
             }}
 
-            const varCsv = 'gene_name\\n' + genesToExport.map(csvEscape).join('\\n') + (nGenes ? '\\n' : '');
+            const varCsv = 'feature_name\\n' + genesToExport.map(csvEscape).join('\\n') + (nGenes ? '\\n' : '');
 
             const xFileName = useSparse ? 'X.mtx' : 'X.csv';
             const readmeLines = [
@@ -21248,7 +21331,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 '- var.csv      Feature list (' + nGenes.toLocaleString() + ' features)',
                 useSparse
                     ? '- X.mtx        Sparse expression matrix in Matrix Market coordinate format (' + nnz.toLocaleString() + ' non-zero entries)'
-                    : '- X.csv        Dense expression matrix (rows = cells, columns = genes)',
+                    : '- X.csv        Dense feature matrix (rows = cells, columns = features)',
                 '- spatial.csv  Per-cell spatial coordinates',
                 anyUMAP ? '- umap.csv     Per-cell UMAP coordinates' : '- umap.csv     (not produced \u2014 no UMAP in viewer)',
                 '',
@@ -21260,7 +21343,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 'import numpy as np',
                 '',
                 'obs = pd.read_csv("obs.csv").set_index("cell_id")',
-                'var = pd.read_csv("var.csv").set_index("gene_name")',
+                'var = pd.read_csv("var.csv").set_index("feature_name")',
             ];
             if (useSparse) {{
                 readmeLines.push(
@@ -21330,7 +21413,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             document.body.removeChild(a);
             setTimeout(() => URL.revokeObjectURL(url), 1000);
             setLabel(origLabel || 'Export data');
-            finalizeExportProgress(`Saved ${{totalCells.toLocaleString()}} cells \u00d7 ${{genesToExport.length.toLocaleString()}} genes`);
+            finalizeExportProgress(`Saved ${{totalCells.toLocaleString()}} cells x ${{genesToExport.length.toLocaleString()}} features`);
         }} catch (err) {{
             if (err && /cancelled/i.test(err.message)) {{
                 finalizeExportProgress('Export cancelled');
@@ -21836,10 +21919,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
         if (lassoModeB) {{
             selectedCellsB = newCells;
-            selectionWelchRevision += 1;
-            selectionWelchCache.clear();
-            selectionWelchRunRequested = false;
-            selectionWelchButtonHidden = false;
+            resetSelectionWelchState();
             selectedLassoPathB = [];
             selectedCellsBFromGridLasso = false;
             selectedGridLassoSectionIdB = null;
@@ -22014,7 +22094,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const downsampleWarningHtml = getOverviewDownsampleWarningHtml();
             if (summary.total === 0) {{
                 compareSelectionSummary.classList.remove('selection-expression-only');
-                compareSelectionSummary.innerHTML = downsampleWarningHtml + '<div class="agg-group-meta">Select cells with the lasso tool to compare their expression.</div>';
+                compareSelectionSummary.innerHTML = downsampleWarningHtml + '<div class="agg-group-meta">Select cells with the lasso tool to compare their feature values.</div>';
             }} else {{
                 compareSelectionSummary.classList.add('selection-expression-only');
                 compareSelectionSummary.innerHTML = downsampleWarningHtml + renderSelectionSummaryHtml(summary, {{
@@ -22926,12 +23006,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }});
 
         // Update stats
-        const loadedGenes = Number(DATA.loaded_features ?? Object.keys(DATA.features_meta || {{}}).length);
-        const genesStatsText = Number.isFinite(loadedGenes) && loadedGenes > 0
-            ? ` | ${{loadedGenes.toLocaleString()}} genes`
+        const loadedFeatures = Number(DATA.loaded_features ?? Object.keys(DATA.features_meta || {{}}).length);
+        const featuresStatsText = Number.isFinite(loadedFeatures) && loadedFeatures > 0
+            ? ` | ${{loadedFeatures.toLocaleString()}} features`
             : '';
         document.getElementById('stats-text').textContent =
-            `${{visibleCount}}/${{DATA.n_sections}} sections | ${{totalCells.toLocaleString()}} cells${{genesStatsText}}`;
+            `${{visibleCount}}/${{DATA.n_sections}} sections | ${{totalCells.toLocaleString()}} cells${{featuresStatsText}}`;
 
         // When filters collapse to a single visible sample, avoid full-width stretching.
         if (grid) {{
@@ -24685,6 +24765,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (insightsTopLevelTab === 'features') {{
             renderGenesDetailsWarnings();
             syncGenesDetailsContentVisibility();
+            refreshLoadedGeneFilterDropdowns();
             if (insightsGenesTab === 'de-genes') {{
                 renderMarkerGenes();
             }} else if (insightsGenesTab === 'spatial') {{
@@ -24788,7 +24869,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 : '');
 
         html += `
-            <div class="selection-summary-title">Gene expression — region A vs region B${{renderCalcInfoButton('region_expression')}}</div>
+            <div class="selection-summary-title">Feature values - region A vs region B${{renderCalcInfoButton('region_expression')}}</div>
             <div class="pseudobulk-de-controls">
                 <div class="pseudobulk-de-select-row comparison-pair-select-row">
                     <div>
@@ -24804,11 +24885,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     ${{hasCompletedCalculation ? `<div class="selection-summary-welch-controls">
                         <div class="selection-summary-welch-control-row">
                             <label>Top N per direction</label>
-                            <input id="region-de-topn" type="number" min="1" max="20" step="1" value="${{Math.max(1, Math.min(20, Number(annotationDeTopN) || ANNOTATION_DE_TOP_N))}}" aria-label="Number of top positive and negative genes selected by Welch test">
+	                            <input id="region-de-topn" type="number" min="1" max="20" step="1" value="${{Math.max(1, Math.min(20, Number(annotationDeTopN) || ANNOTATION_DE_TOP_N))}}" aria-label="Number of top positive and negative features selected by Welch test">
                         </div>
                         <div class="selection-summary-welch-control-row">
-                            <label>Min expressed %</label>
-                            <input id="region-de-min-pct" type="range" min="0" max="100" step="1" value="${{Math.max(0, Math.min(100, Number(annotationDeMinPct) || 0))}}" aria-label="Minimum percentage of expressing cells in at least one region">
+	                            <label>Min detected %</label>
+	                            <input id="region-de-min-pct" type="range" min="0" max="100" step="1" value="${{Math.max(0, Math.min(100, Number(annotationDeMinPct) || 0))}}" aria-label="Minimum percentage of cells with positive values in at least one region">
                             <output id="region-de-min-pct-value">${{Math.max(0, Math.min(100, Number(annotationDeMinPct) || 0))}}%</output>
                         </div>
                     </div>` : ''}}
@@ -24851,14 +24932,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                                     title: 'Load region DE feature into the viewer',
                                 }})}}
                                 ${{renderGeneGoogleSearchButton(entry.gene, {{
-                                    title: 'Search Google for this gene',
+                                    title: 'Search Google for this feature',
                                 }})}}
                             </div>
                             <div class="comparison-de-title-stats" style="border-color:${{Number(entry.score || 0) >= 0 ? colorA : colorB}}"><span>log2FC ${{formatScaleNumber(entry.log2fc)}}</span><span>Score ${{formatScaleNumber(entry.score)}}</span></div>
                         </div>
                         <div class="comparison-metric-grid">
-                            <span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorA, Number(entry.score || 0) >= 0 ? colorA : colorB)}};color:${{textColorA}}"><span>% expr A</span><strong>${{formatPseudobulkDEPct(entry.pctA)}}</strong><span>Mean A</span><strong>${{formatScaleNumber(entry.meanA)}}</strong></span>
-                            <span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorB, Number(entry.score || 0) >= 0 ? colorA : colorB)}};color:${{textColorB}}"><span>% expr B</span><strong>${{formatPseudobulkDEPct(entry.pctB)}}</strong><span>Mean B</span><strong>${{formatScaleNumber(entry.meanB)}}</strong></span>
+	                            <span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorA, Number(entry.score || 0) >= 0 ? colorA : colorB)}};color:${{textColorA}}"><span>% detected A</span><strong>${{formatPseudobulkDEPct(entry.pctA)}}</strong><span>Mean A</span><strong>${{formatScaleNumber(entry.meanA)}}</strong></span>
+	                            <span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorB, Number(entry.score || 0) >= 0 ? colorA : colorB)}};color:${{textColorB}}"><span>% detected B</span><strong>${{formatPseudobulkDEPct(entry.pctB)}}</strong><span>Mean B</span><strong>${{formatScaleNumber(entry.meanB)}}</strong></span>
                         </div>
                     </div>
                 `;
@@ -24876,7 +24957,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const quickSummaryHtml = (deResult.available && displayedQuickResults.length)
             ? `
                 ${{Number(deResult.loadedGeneCount || 0) < Number(deResult.totalGeneCount || 0)
-                    ? `<div class="agg-group-meta">Quick preview over ${{Number(deResult.loadedGeneCount || 0).toLocaleString()}} of ${{Number(deResult.totalGeneCount || 0).toLocaleString()}} genes — run the full sidecar DE for the complete result.</div>`
+	                    ? `<div class="agg-group-meta">Quick preview over ${{Number(deResult.loadedGeneCount || 0).toLocaleString()}} of ${{Number(deResult.totalGeneCount || 0).toLocaleString()}} features - run the full sidecar DE for the complete result.</div>`
                     : ''}}
                 ${{buildGroupVolcanoPlot(displayedQuickResults, volcanoExportButtonHtml, {{
                     positive: getAnnotationDisplayColor(source) || 'var(--accent-strong)',
@@ -24893,7 +24974,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 ? `
                     <div class="agg-group-meta">
                         Cached full sidecar DE${{cachedTimestamp ? ` from ${{cachedTimestamp}}` : ''}}
-                        across ${{Number(fullCached.totalGeneCount || 0).toLocaleString()}} genes.
+	                        across ${{Number(fullCached.totalGeneCount || 0).toLocaleString()}} features.
                     </div>
                     ${{buildGroupVolcanoPlot(displayedFullResults, volcanoExportButtonHtml, {{
                         positive: getAnnotationDisplayColor(source) || 'var(--accent-strong)',
@@ -24903,7 +24984,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 `
                 : `
                     <div class="agg-group-meta">
-                        Cached full sidecar DE${{cachedTimestamp ? ` from ${{cachedTimestamp}}` : ''}} found no enriched genes across ${{Number(fullCached.totalGeneCount || 0).toLocaleString()}} genes.
+	                        Cached full sidecar DE${{cachedTimestamp ? ` from ${{cachedTimestamp}}` : ''}} found no enriched features across ${{Number(fullCached.totalGeneCount || 0).toLocaleString()}} features.
                     </div>
                 `
             : '';
@@ -24913,17 +24994,17 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }} else if (fullRun?.running) {{
             const totalShards = Number(fullRun.totalShards || 0);
             const completedShards = Number(fullRun.completedShards || 0);
-            const totalGenes = Number(fullRun.totalGenes || 0);
-            const completedGenes = Number(fullRun.completedGenes || 0);
-            const progressMax = Math.max(1, totalGenes || totalShards || 1);
-            const progressValue = Math.min(progressMax, totalGenes ? completedGenes : completedShards);
+	            const totalFeatures = Number(fullRun.totalGenes || 0);
+	            const completedFeatures = Number(fullRun.completedGenes || 0);
+	            const progressMax = Math.max(1, totalFeatures || totalShards || 1);
+	            const progressValue = Math.min(progressMax, totalFeatures ? completedFeatures : completedShards);
             const progressPct = progressMax > 0 ? Math.round((progressValue / progressMax) * 100) : 0;
             resultHtml = `
                 <div class="agg-group-meta">Scanning the full sidecar in the background. The viewer stays interactive while this runs.</div>
                 <progress value="${{progressValue}}" max="${{progressMax}}" style="width:100%; height:12px;"></progress>
                 <div class="agg-group-meta">
                     ${{progressPct}}% complete
-                    · ${{completedGenes.toLocaleString()}} / ${{totalGenes.toLocaleString()}} genes
+	                    · ${{completedFeatures.toLocaleString()}} / ${{totalFeatures.toLocaleString()}} features
                     · ${{completedShards.toLocaleString()}} / ${{totalShards.toLocaleString()}} shards
                 </div>
                 <div style="display:flex; justify-content:flex-end;">
@@ -24941,7 +25022,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 resultHtml += '<div class="agg-group-meta">Showing the previous cached full result:</div>';
                 resultHtml += cachedSummaryHtml;
             }} else if (quickSummaryHtml) {{
-                resultHtml += '<div class="agg-group-meta">Quick DE preview from currently loaded genes:</div>';
+	                resultHtml += '<div class="agg-group-meta">Quick DE preview from currently loaded features:</div>';
                 resultHtml += quickSummaryHtml;
             }}
         }} else if (fullCached?.available) {{
@@ -24954,13 +25035,13 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }} else if (!deResult.available && deResult.reason === 'too_few_cells') {{
             resultHtml = '<div class="agg-group-meta">Each selected region or group needs at least two cells.</div>';
         }} else if (!deResult.available && deResult.reason === 'no_loaded_features' && sidecarAvailable) {{
-            const totalGenes = Number(deResult.totalGeneCount || 0).toLocaleString();
+            const totalFeatures = Number(deResult.totalGeneCount || 0).toLocaleString();
             resultHtml = `
                 <div class="agg-group-meta">
-                    Differential expression runs across ${{totalGenes !== '0' ? `all ${{totalGenes}} genes` : 'all genes'}} from the feature sidecar.
+                    Differential analysis runs across ${{totalFeatures !== '0' ? `all ${{totalFeatures}} features` : 'all features'}} from the feature sidecar.
                 </div>
                 <div style="display:flex; justify-content:flex-end;">
-                    <button class="legend-btn" id="region-de-run-full" type="button">Compute Region DE across all genes</button>
+                    <button class="legend-btn" id="region-de-run-full" type="button">Compute Region DE across all features</button>
                 </div>
             `;
         }} else if (!deResult.available && deResult.reason === 'no_loaded_features') {{
@@ -24970,13 +25051,13 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }} else if (!displayedQuickResults.length) {{
             if (sidecarAvailable && Number(deResult.loadedGeneCount || 0) < Number(deResult.totalGeneCount || 0)) {{
                 resultHtml = `
-                    <div class="agg-group-meta">No enriched genes were found among the currently loaded genes.</div>
+	                    <div class="agg-group-meta">No enriched features were found among the currently loaded features.</div>
                     <div style="display:flex; justify-content:flex-end;">
                         <button class="legend-btn" id="region-de-run-full" type="button">Run Full Region DE</button>
                     </div>
                 `;
             }} else {{
-                resultHtml = '<div class="agg-group-meta">No enriched genes were found among the genes currently loaded in the viewer.</div>';
+	                resultHtml = '<div class="agg-group-meta">No enriched features were found among the features currently loaded in the viewer.</div>';
             }}
         }} else {{
             resultHtml = quickSummaryHtml;
@@ -25080,7 +25161,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
 
             // Match the Selections expression layout while preserving each
-            // region's own colour for its mean-expression bar.
+                // region's own colour for its mean-value bar.
             const comparisonResult = annotationDeQuickResultKey === quickResultKey
                 ? annotationDeQuickResult
                 : annotationDeFullCache.get(pairKey);
@@ -25117,7 +25198,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
 
         container.innerHTML = html || '<div class="agg-group-meta">No data available.</div>';
-        // Keep the controls and expression summaries together, then place the
+        // Keep the controls and feature-value summaries together, then place the
         // detailed DE report after those summaries.
         const deResults = container.querySelector('#region-de-results');
         if (deResults) container.appendChild(deResults);
@@ -25783,11 +25864,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 // annotation, so a change discards their derived results.
                 invalidateAnnotationDEState(true);
                 invalidateGroupDEState(true);
-                selectionWelchRevision += 1;
-                selectionWelchCache.clear();
-                selectionWelchRunRequested = false;
-                selectionWelchRunning = false;
-                selectionWelchButtonHidden = false;
+                resetSelectionWelchState();
                 selectionComparisonLegendExpanded = false;
                 hoveredNeighborFocus = null;
                 selectedNeighborFocus = null;
@@ -25822,26 +25899,25 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             if (explorationFeatureModalitySection) {{
                 explorationFeatureModalitySection.style.display = modalityOptions.length > 1 ? '' : 'none';
             }}
-	            explorationFeatureModalitySelect.addEventListener('change', async () => {{
-	                const nextModality = explorationFeatureModalitySelect.value || DEFAULT_MODALITY_NAME;
-	                const shouldRerunSelectionComparison = selectionWelchRunRequested && selectedCells.size > 0;
-	                setExplorationModality(nextModality);
-	                invalidateAnnotationDEState(true);
-	                invalidateGroupDEState(true);
-	                selectionWelchRevision += 1;
-	                selectionWelchCache.clear();
-	                selectionWelchRunRequested = shouldRerunSelectionComparison;
-	                selectionWelchRunning = false;
-	                selectionWelchButtonHidden = shouldRerunSelectionComparison;
-	                const markerSearch = document.getElementById('marker-gene-search');
-	                if (markerSearch) {{
-	                    markerSearch.value = '';
-	                    refreshLoadedGeneFilterDropdowns();
-	                }}
-	                renderGeneDiscoveryPanel?.();
-	                updateSelectionInfo?.();
-	                renderActiveInsightsPanel();
-	            }});
+            explorationFeatureModalitySelect.addEventListener('change', async () => {{
+                const nextModality = explorationFeatureModalitySelect.value || DEFAULT_MODALITY_NAME;
+                const shouldRerunSelectionComparison = selectionWelchRunRequested && selectedCells.size > 0;
+                setExplorationModality(nextModality);
+                invalidateAnnotationDEState(true);
+                invalidateGroupDEState(true);
+                resetSelectionWelchState({{ keepRequested: shouldRerunSelectionComparison }});
+                const markerSearch = document.getElementById('marker-gene-search');
+                if (markerSearch) {{
+                    markerSearch.value = '';
+                    refreshLoadedGeneFilterDropdowns();
+                }}
+                renderGeneDiscoveryPanel?.();
+                updateSelectionInfo?.();
+                renderActiveInsightsPanel();
+                if (shouldRerunSelectionComparison) {{
+                    await runSelectionWelchComparison();
+                }}
+            }});
         }}
 
         const groupBy = document.getElementById('annotation-section-key');
@@ -25940,22 +26016,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }};
             const gene = getInsightsSelectedGene();
             if (!gene) {{
-                await activateViewerGene('', {{ showErrors: false }});
+                renderActiveInsightsPanel();
                 advanceTutorialIfReady();
                 return;
             }}
-            const modality = getExplorationModality();
-            if (isViewerFeatureLoadable(gene, modality)) {{
-                if (getVisualModality() !== modality && typeof setActiveModality === 'function') {{
-                    await setActiveModality(modality);
-                }}
-                await activateViewerGene(gene, {{ showErrors: true }});
-                advanceTutorialIfReady();
-                return;
-            }}
-            // Balanced-rest results remain searchable even when their
-            // expression vectors were intentionally omitted from the HTML.
-            // Keep the selected term as a panel filter, without trying to load it.
+            // Marker search filters Insights panels only. It must not mutate the
+            // visual feature namespace or feature input controls.
             renderActiveInsightsPanel();
             advanceTutorialIfReady();
         }};
@@ -25969,7 +26035,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const markerSearch = document.getElementById('marker-gene-search');
             if (!markerSearch) return;
             markerSearch.value = '';
-            await activateViewerGene('', {{ showErrors: false }});
+            renderActiveInsightsPanel();
         }});
         renderGenesDetailsWarnings();
 
@@ -26016,29 +26082,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             renderInteractionBrowser();
         }});
 
-        const pseudobulkDeModalitySelect = document.getElementById('pseudobulk-de-modality-select');
-        const pseudobulkDeGroupbySelect = document.getElementById('pseudobulk-de-annotation');
         const pseudobulkDeSourceSelect = document.getElementById('pseudobulk-de-source');
         const pseudobulkDeReferenceSelect = document.getElementById('pseudobulk-de-reference');
         const pseudobulkDeSwap = document.getElementById('pseudobulk-de-swap');
 
-        const catCols = getCategoricalColorColumns();
         syncPseudobulkDEControls();
-        pseudobulkDeModalitySelect?.addEventListener('change', () => {{
-            setPseudobulkPanelModality(pseudobulkDeModalitySelect.value || DEFAULT_MODALITY_NAME);
-            pseudobulkDeGroupby = null;
-            pseudobulkDeSourceCategory = null;
-            pseudobulkDeReferenceCategory = null;
-            clusterDETableExpanded = false;
-            pathwayAnnotationSide = 'source';
-            renderPseudobulkDE();
-        }});
-        pseudobulkDeGroupbySelect?.addEventListener('change', () => {{
-            pseudobulkDeGroupby = pseudobulkDeGroupbySelect.value || null;
-            pseudobulkDeSourceCategory = null;
-            pseudobulkDeReferenceCategory = null;
-            renderPseudobulkDE();
-        }});
         pseudobulkDeSourceSelect?.addEventListener('change', () => {{
             pseudobulkDeSourceCategory = pseudobulkDeSourceSelect.value || null;
             renderPseudobulkDE();
@@ -27075,13 +27123,13 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 const z = data.zscores[rowIdx]?.[colIdx];
                 const mean = data.means[rowIdx]?.[colIdx];
                 const star = data.deStars.has(`${{gene}}\u0000${{category}}`);
-                parts.push(`<rect x="${{x}}" y="${{y}}" width="${{cellW - 1}}" height="${{cellH - 1}}" fill="${{heatmapZColor(z)}}" stroke="var(--input-bg)" data-volcano-gene="${{escapeHtml(gene)}}" data-tooltip-title="${{escapeHtml(gene)}}" data-tooltip-line1="Category: ${{escapeHtml(formatCategoryLabel(annotationCol, category))}}" data-tooltip-line2="Mean expression: ${{escapeHtml(Number.isFinite(mean) ? formatScaleNumber(mean) : 'n/a')}}" data-tooltip-line3="Z-score: ${{escapeHtml(Number.isFinite(z) ? z.toFixed(3) : 'n/a')}}" data-tooltip-line4="${{star ? 'DE vs balanced rest' : 'Not DE vs balanced rest'}}"/>`);
+                parts.push(`<rect x="${{x}}" y="${{y}}" width="${{cellW - 1}}" height="${{cellH - 1}}" fill="${{heatmapZColor(z)}}" stroke="var(--input-bg)" data-volcano-gene="${{escapeHtml(gene)}}" data-tooltip-title="${{escapeHtml(gene)}}" data-tooltip-line1="Category: ${{escapeHtml(formatCategoryLabel(annotationCol, category))}}" data-tooltip-line2="Mean feature value: ${{escapeHtml(Number.isFinite(mean) ? formatScaleNumber(mean) : 'n/a')}}" data-tooltip-line3="Z-score: ${{escapeHtml(Number.isFinite(z) ? z.toFixed(3) : 'n/a')}}" data-tooltip-line4="${{star ? 'DE vs balanced rest' : 'Not DE vs balanced rest'}}"/>`);
                 if (star) {{
                     parts.push(`<text x="${{(x + cellW / 2).toFixed(1)}}" y="${{(y + cellH / 2 + 4).toFixed(1)}}" text-anchor="middle" font-size="11" fill="#111">*</text>`);
                 }}
             }});
         }});
-        parts.push(`<text class="volcano-axis-label" x="${{ml}}" y="${{H - 8}}" text-anchor="start">z-score of category mean expression: negative red, positive blue</text>`);
+        parts.push(`<text class="volcano-axis-label" x="${{ml}}" y="${{H - 8}}" text-anchor="start">z-score of category mean feature value: negative red, positive blue</text>`);
         parts.push('</svg>');
         return geneGraphPanel(parts.join(''));
     }}
@@ -27183,7 +27231,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             parts.push(`<line x1="${{x.toFixed(1)}}" y1="${{axisY - 4}}" x2="${{x.toFixed(1)}}" y2="${{axisY + 4}}" stroke="var(--border-color)"/>`);
             parts.push(`<text class="volcano-axis-label" x="${{x.toFixed(1)}}" y="${{H - 12}}" text-anchor="middle">${{formatScaleNumber(tick)}}</text>`);
         }});
-        parts.push(`<text class="volcano-axis-label" x="${{(ml + iw / 2).toFixed(1)}}" y="${{H - 1}}" text-anchor="middle">expression</text>`);
+        parts.push(`<text class="volcano-axis-label" x="${{(ml + iw / 2).toFixed(1)}}" y="${{H - 1}}" text-anchor="middle">feature value</text>`);
         parts.push('</svg>');
         return geneGraphPanel(parts.join(''));
     }}
@@ -27358,7 +27406,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         showMeta: false,
                         title: loadable
                             ? 'Load pseudobulk DE feature into the viewer'
-                            : 'This category-vs-balanced-rest feature is not available for expression viewing',
+                            : 'This category-vs-balanced-rest feature is not available for feature-value viewing',
                     }});
                 }}).join('')
                 : '<div class="marker-empty">No pseudobulk DE features found.</div>';
@@ -27808,7 +27856,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ? ` \u2014 restricted to ${{escapeHtml(formatMetadataLabel(restrictSpec.key))}} = <strong>${{escapeHtml(String(geneDistributionRestrictValue))}}</strong>`
             : '';
         const tableHtml = `
-            <div class="gene-distribution-summary">Expression of <strong>${{escapeHtml(selectedGene)}}</strong> in ${{escapeHtml(getModalityDisplayLabel(modality))}} across ${{escapeHtml(formatMetadataLabel(spec.key))}}${{restrictLabel}}</div>
+            <div class="gene-distribution-summary">Feature value of <strong>${{escapeHtml(selectedGene)}}</strong> in ${{escapeHtml(getModalityDisplayLabel(modality))}} across ${{escapeHtml(formatMetadataLabel(spec.key))}}${{restrictLabel}}</div>
             <table class="gene-distribution-table">
                 <thead>
                     <tr>
@@ -27824,7 +27872,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         `;
 
         const graphHtml = `
-            <div class="gene-distribution-summary">Expression of <strong>${{escapeHtml(selectedGene)}}</strong> in ${{escapeHtml(getModalityDisplayLabel(modality))}} across ${{escapeHtml(formatMetadataLabel(spec.key))}}${{restrictLabel}}</div>
+            <div class="gene-distribution-summary">Feature value of <strong>${{escapeHtml(selectedGene)}}</strong> in ${{escapeHtml(getModalityDisplayLabel(modality))}} across ${{escapeHtml(formatMetadataLabel(spec.key))}}${{restrictLabel}}</div>
             ${{buildGeneDistributionBoxplot(sorted, spec)}}
         `;
         container.innerHTML = toggleHtml + controlsHtml + (isGraphView ? graphHtml : tableHtml);
@@ -28130,9 +28178,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             return '';
         }}
         const genes = Array.isArray(result.genes) ? result.genes : [];
-        const log2fc = Array.isArray(result.log2foldchanges)
-            ? result.log2foldchanges
-            : (Array.isArray(result.logfoldchanges) ? result.logfoldchanges : []);
+        const log2fc = Array.isArray(result.log2foldchanges) ? result.log2foldchanges : [];
         const significantIndices = getPseudobulkDEColoredIndices(result);
         const sourceMarkerEntries = normalizeGeneEntries(
             significantIndices
@@ -28154,15 +28200,15 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const visibleEntries = expanded ? entries : entries.slice(0, 30);
             const remaining = Math.max(0, entries.length - visibleEntries.length);
             const link = entries.length > 30
-                ? `<button type="button" class="pseudobulk-de-more-link" data-pseudobulk-de-marker-more="${{escapeHtml(key)}}">${{expanded ? 'Hide extra genes' : `Show more (${{remaining.toLocaleString()}})`}}</button>`
+                ? `<button type="button" class="pseudobulk-de-more-link" data-pseudobulk-de-marker-more="${{escapeHtml(key)}}">${{expanded ? 'Hide extra features' : `Show more (${{remaining.toLocaleString()}})`}}</button>`
                 : '';
             return `
             <div class="agg-group">
                 <div class="agg-group-title">
                     <span class="agg-group-title-main">${{renderAggCategoryChip(annotationCol, enrichedCategory)}}</span>
-                    <span class="agg-group-title-actions"><span class="agg-chip agg-count-chip">${{entries.length.toLocaleString()}} genes</span></span>
+                    <span class="agg-group-title-actions"><span class="agg-chip agg-count-chip">${{entries.length.toLocaleString()}} features</span></span>
                 </div>
-                ${{renderComparisonGeneTokenGrid(visibleEntries, 'No genes pass the current adjusted p-value and log\u2082FC thresholds in this direction.', 'Load pseudobulk marker into the viewer', modality)}}
+                ${{renderComparisonGeneTokenGrid(visibleEntries, 'No features pass the current adjusted p-value and log\u2082FC thresholds in this direction.', 'Load pseudobulk marker into the viewer', modality)}}
                 ${{link ? `<div class="pseudobulk-de-table-actions">${{link}}</div>` : ''}}
             </div>
         `;
@@ -28206,7 +28252,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             return `
                 <div class="agg-group">
                     <div class="agg-group-title">Contact-Conditioned Markers</div>
-                    <div class="agg-group-meta">Interaction DE genes were not precomputed for this annotation.</div>
+                    <div class="agg-group-meta">Interaction DE features were not precomputed for this annotation.</div>
                 </div>
             `;
         }}
@@ -28244,9 +28290,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     function doesPseudobulkDEIndexPassThresholds(result, idx, direction = 'both') {{
         if (!result || result.available === false) return false;
-        const log2fc = Array.isArray(result.log2foldchanges)
-            ? result.log2foldchanges
-            : (Array.isArray(result.logfoldchanges) ? result.logfoldchanges : []);
+        const log2fc = Array.isArray(result.log2foldchanges) ? result.log2foldchanges : [];
         const pvalsAdj = Array.isArray(result.pvals_adj) ? result.pvals_adj : [];
         const padjCutoff = Math.min(Math.max(normalizePositiveThreshold(result.padj_cutoff, 0.05), 0), 1);
         const log2fcCutoff = normalizePositiveThreshold(result.log2fc_cutoff, 0.5);
@@ -28261,9 +28305,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     function getPseudobulkDESignificanceClass(result, idx) {{
         if (!doesPseudobulkDEIndexPassThresholds(result, idx)) return 'grey';
-        const log2fc = Array.isArray(result.log2foldchanges)
-            ? result.log2foldchanges
-            : (Array.isArray(result.logfoldchanges) ? result.logfoldchanges : []);
+        const log2fc = Array.isArray(result.log2foldchanges) ? result.log2foldchanges : [];
         const log2fcValue = Number(log2fc[idx]);
         return log2fcValue > 0 ? 'red' : 'blue';
     }}
@@ -28292,7 +28334,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const bg = color || 'var(--border-color)';
         const textColor = getTextColorForBackground(bg);
         const countValue = Number(count || 0);
-        const countLabel = countValue.toLocaleString() + (countValue === 1 ? ' gene' : ' genes');
+        const countLabel = countValue.toLocaleString() + (countValue === 1 ? ' feature' : ' features');
         const countHtml = count === null || count === undefined
             ? ''
             : '<span class="volcano-summary-count">' + countLabel + '</span>';
@@ -28378,8 +28420,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const baseDisplay = formatScaleNumber(xValues[i]);
             const color = dotClass === 'red' ? '#d94f4f' : 'var(--border-color)';
             const loadable = isViewerFeatureLoadable(gene, modality);
-            const pctLine = 'pct expr: ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(sourcePct) ? sourcePct : NaN)) + ' / ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(referencePct) ? referencePct : NaN));
-            const extraLine = loadable ? '' : '" data-tooltip-line6="Expression vector unavailable"';
+            const pctLine = 'pct detected: ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(sourcePct) ? sourcePct : NaN)) + ' / ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(referencePct) ? referencePct : NaN));
+            const extraLine = loadable ? '' : '" data-tooltip-line6="Feature vector unavailable"';
             dots.push({{ dotClass, html: '<circle class="volcano-dot" cx="' + xs(xValues[i]).toFixed(1) + '" cy="' + ys(fc).toFixed(1) + '" r="2.8" fill="' + color + '" fill-opacity="0.78" data-volcano-gene="' + escapeHtml(gene) + '" data-gene-loadable="' + (loadable ? 'true' : 'false') + '" data-volcano-fc="' + fc.toFixed(3) + '" data-volcano-p="' + rawPDisplay + '" data-volcano-padj="' + padjDisplay + '" data-tooltip-title="' + escapeHtml(gene) + '" data-tooltip-line1="baseMean: ' + escapeHtml(baseDisplay) + '" data-tooltip-line2="logFC: ' + escapeHtml(fc.toFixed(3)) + '" data-tooltip-line3="pvalue: ' + escapeHtml(rawPDisplay) + '" data-tooltip-line4="adj. p: ' + escapeHtml(padjDisplay) + '" data-tooltip-line5="' + pctLine + extraLine + '"/>' }});
         }});
         ['grey', 'red'].forEach((layer) => {{
@@ -28393,7 +28435,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             buildPseudobulkDESummaryItem('adj. p < 0.1', '#d94f4f', counts.red),
             '</div>',
         ].join('');
-        return wrapPseudobulkDEPlot('MA Plot', 'Mean expression vs log\u2082FC; adjusted p-value controls coloring', parts.join('') + summary, true, 'ma-plot', 'pseudobulk_ma_plot');
+        return wrapPseudobulkDEPlot('MA Plot', 'Mean feature value vs log\u2082FC; adjusted p-value controls coloring', parts.join('') + summary, true, 'ma-plot', 'pseudobulk_ma_plot');
     }}
 
     function buildPseudobulkPCAPlot(sampleInfo, annotationCol) {{
@@ -28444,7 +28486,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         parts.push('<text class="volcano-axis-label" x="8" y="' + (mt+ih/2).toFixed(1) + '" text-anchor="middle" transform="rotate(-90,8,' + (mt+ih/2).toFixed(1) + ')">' + escapeHtml(yLabel) + '</text>');
         const legend = uniqueGroups.slice(0, 6).map((group) => buildPseudobulkDESummaryItem(group, groupColor(group))).join('');
         parts.push('</svg>');
-        return wrapPseudobulkDEPlot('PCA', `Pseudobulk samples, ${{Number(sampleInfo.pca_features || 0).toLocaleString()}} variable genes`, parts.join('') + '<div class="volcano-summary">' + legend + '</div>', true, 'dotplot', 'pseudobulk_pca_plot');
+        return wrapPseudobulkDEPlot('PCA', `Pseudobulk samples, ${{Number(sampleInfo.pca_features || 0).toLocaleString()}} variable features`, parts.join('') + '<div class="volcano-summary">' + legend + '</div>', true, 'dotplot', 'pseudobulk_pca_plot');
     }}
 
     function buildPseudobulkDistanceHeatmap(sampleInfo, annotationCol) {{
@@ -28565,8 +28607,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const safePAdj = Number.isFinite(pvalAdj) ? pvalAdj : 1;
             const padjDisplay = formatAdjustedPValue(safePAdj);
             const loadable = isViewerFeatureLoadable(gene, modality);
-            const pctLine = 'pct expr: ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(sourcePct) ? sourcePct : NaN)) + ' / ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(referencePct) ? referencePct : NaN));
-            const extraLine = loadable ? '' : '" data-tooltip-line4="Expression vector unavailable"';
+            const pctLine = 'pct detected: ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(sourcePct) ? sourcePct : NaN)) + ' / ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(referencePct) ? referencePct : NaN));
+            const extraLine = loadable ? '' : '" data-tooltip-line4="Feature vector unavailable"';
             dots.push({{ dotClass, html: '<circle class="volcano-dot" cx="' + xs(fc).toFixed(1) + '" cy="' + ys(nlpi).toFixed(1) + '" r="3" fill="' + col + '" fill-opacity="0.82" data-volcano-class="' + dotClass + '" data-volcano-gene="' + escapeHtml(gene) + '" data-gene-loadable="' + (loadable ? 'true' : 'false') + '" data-volcano-fc="' + fc.toFixed(3) + '" data-volcano-padj="' + padjDisplay + '" data-tooltip-title="' + escapeHtml(gene) + '" data-tooltip-line1="log\u2082FC: ' + escapeHtml(fc.toFixed(3)) + '" data-tooltip-line2="adj. p: ' + escapeHtml(padjDisplay) + '" data-tooltip-line3="' + pctLine + extraLine + '"/>' }});
         }});
         ['grey', 'reference', 'source'].forEach((layer) => {{
@@ -28811,9 +28853,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const genes = Array.isArray(result.genes) ? result.genes : [];
         const pvalsAdj = Array.isArray(result.pvals_adj) ? result.pvals_adj : [];
         const pvals = Array.isArray(result.pvals) ? result.pvals : [];
-        const log2fc = Array.isArray(result.log2foldchanges)
-            ? result.log2foldchanges
-            : (Array.isArray(result.logfoldchanges) ? result.logfoldchanges : []);
+        const log2fc = Array.isArray(result.log2foldchanges) ? result.log2foldchanges : [];
         return genes.map((gene, idx) => idx)
             .filter((idx) => doesPseudobulkDEIndexPassThresholds(result, idx))
             .sort((a, b) => {{
@@ -28831,9 +28871,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function getPseudobulkDETableEntries(result, coloredOnly = false) {{
         if (!result || result.available === false) return [];
         const genes = Array.isArray(result.genes) ? result.genes : [];
-        const log2fc = Array.isArray(result.log2foldchanges)
-            ? result.log2foldchanges
-            : (Array.isArray(result.logfoldchanges) ? result.logfoldchanges : []);
+        const log2fc = Array.isArray(result.log2foldchanges) ? result.log2foldchanges : [];
         const pvals = Array.isArray(result.pvals) ? result.pvals : [];
         const pvalsAdj = Array.isArray(result.pvals_adj) ? result.pvals_adj : [];
         const scores = Array.isArray(result.scores) ? result.scores : [];
@@ -29558,9 +29596,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
 
         const genes = Array.isArray(result.genes) ? result.genes : [];
-        const log2fc = Array.isArray(result.log2foldchanges)
-            ? result.log2foldchanges
-            : (Array.isArray(result.logfoldchanges) ? result.logfoldchanges : []);
+        const log2fc = Array.isArray(result.log2foldchanges) ? result.log2foldchanges : [];
         const pvals = Array.isArray(result.pvals) ? result.pvals : [];
         const pvalsAdj = Array.isArray(result.pvals_adj) ? result.pvals_adj : [];
         const scores = Array.isArray(result.scores) ? result.scores : [];
@@ -29641,11 +29677,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const tableMoreButton = significantIndices.length > 20
             ? `<button type="button" class="pseudobulk-de-more-link" data-pseudobulk-de-table-more>${{clusterDETableExpanded ? 'Hide extra lines' : `Show more (${{(significantIndices.length - 20).toLocaleString()}})`}}</button>`
             : '';
-        const tableExportButton = `<button class="icon-btn pseudobulk-de-plot-export" type="button" data-pseudobulk-de-download-csv title="Download differential-expression table as CSV" aria-label="Download differential-expression table as CSV">${{LEGEND_EXPORT_ICON}}</button>`;
+        const tableExportButton = `<button class="icon-btn pseudobulk-de-plot-export" type="button" data-pseudobulk-de-download-csv title="Download differential feature table as CSV" aria-label="Download differential feature table as CSV">${{LEGEND_EXPORT_ICON}}</button>`;
         const tablePanel = `
             <div class="pseudobulk-de-plot-panel pseudobulk-de-table-panel">
                 <div class="pseudobulk-de-figure-title">
-                    <span>Differential Expression Table</span>${{renderCalcInfoButton('pseudobulk_simple_de_table')}}
+                    <span>Differential Feature Table</span>${{renderCalcInfoButton('pseudobulk_simple_de_table')}}
                 </div>
                 ${{tableHtml}}
                 <div class="pseudobulk-de-table-actions">
@@ -29697,27 +29733,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function syncPseudobulkDEControls() {{
-        const modalitySelect = document.getElementById('pseudobulk-de-modality-select');
-        const annotationSelect = document.getElementById('pseudobulk-de-annotation');
         const sourceSelect = document.getElementById('pseudobulk-de-source');
         const referenceSelect = document.getElementById('pseudobulk-de-reference');
-        const availableModalities = getPseudobulkDEModalities();
-        const modality = ensurePseudobulkPanelModality();
+        const modality = getExplorationModality();
         const availableGroupbys = getAvailableComparisonColors(modality);
-
-        if (modalitySelect) {{
-            modalitySelect.innerHTML = availableModalities
-                .map((name) => `<option value="${{escapeHtml(name)}}"${{name === modality ? ' selected' : ''}}>${{escapeHtml(getModalityDisplayLabel(name))}}</option>`)
-                .join('');
-            modalitySelect.value = modality;
-            modalitySelect.disabled = availableModalities.length < 2;
-        }}
-
-        if (annotationSelect) {{
-            annotationSelect.innerHTML = availableGroupbys.length
-                ? `<optgroup label="Cell annotations">${{availableGroupbys.map(col => `<option value="${{escapeHtml(col)}}">${{escapeHtml(getAnnotationColumnLabel(col))}}</option>`).join('')}}</optgroup>`
-                : '';
-        }}
 
         if (!availableGroupbys.length) {{
             pseudobulkDeGroupby = null;
@@ -29725,7 +29744,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             pseudobulkDeReferenceCategory = null;
             if (sourceSelect) sourceSelect.innerHTML = '';
             if (referenceSelect) referenceSelect.innerHTML = '';
-            return {{ availableGroupbys, categories: [], availableModalities, modality }};
+            return {{ availableGroupbys, categories: [], modality }};
         }}
 
         const activeAnnotation = String(explorationColorCol || '');
@@ -29736,10 +29755,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 pseudobulkDeSourceCategory = null;
                 pseudobulkDeReferenceCategory = null;
             }}
-        }} else if (!pseudobulkDeGroupby || !availableGroupbys.includes(pseudobulkDeGroupby)) {{
-            pseudobulkDeGroupby = availableGroupbys.includes(currentAnnotation) ? currentAnnotation : availableGroupbys[0];
+        }} else {{
+            pseudobulkDeGroupby = null;
+            pseudobulkDeSourceCategory = null;
+            pseudobulkDeReferenceCategory = null;
         }}
-        if (annotationSelect) annotationSelect.value = pseudobulkDeGroupby;
 
         const categories = getPseudobulkDECategories(pseudobulkDeGroupby, modality);
         const options = categories.map(category => `<option value="${{escapeHtml(category)}}">${{escapeHtml(category)}}</option>`).join('');
@@ -29749,7 +29769,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!categories.length) {{
             pseudobulkDeSourceCategory = null;
             pseudobulkDeReferenceCategory = null;
-            return {{ availableGroupbys, categories, availableModalities, modality }};
+            return {{ availableGroupbys, categories, modality }};
         }}
 
         if (!pseudobulkDeSourceCategory || !categories.includes(pseudobulkDeSourceCategory)) {{
@@ -29765,14 +29785,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             referenceSelect.disabled = categories.length < 2;
         }}
 
-        return {{ availableGroupbys, categories, availableModalities, modality }};
+        return {{ availableGroupbys, categories, modality }};
     }}
 
     function renderPseudobulkDE() {{
         const container = document.getElementById('pseudobulk-de-results');
         if (!container) return;
 
-        const {{ availableGroupbys, categories, availableModalities, modality }} = syncPseudobulkDEControls();
+        const {{ availableGroupbys, categories, modality }} = syncPseudobulkDEControls();
         const selectedAnnotation = pseudobulkDeGroupby && availableGroupbys.includes(pseudobulkDeGroupby)
             ? pseudobulkDeGroupby
             : null;
@@ -29824,18 +29844,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}).join('');
         const sourceOptions = buildCategoryOptions(pseudobulkDeReferenceCategory);
         const referenceOptions = buildCategoryOptions(pseudobulkDeSourceCategory);
-        const modalityOptions = availableModalities.map((name) => `
-            <option value="${{escapeHtml(name)}}"${{name === modality ? ' selected' : ''}}>${{escapeHtml(getModalityDisplayLabel(name))}}</option>
-        `).join('');
-        const annotationOptions = availableGroupbys.map((col) => `
-            <option value="${{escapeHtml(col)}}"${{col === pseudobulkDeGroupby ? ' selected' : ''}}>${{escapeHtml(getAnnotationColumnLabel(col))}}</option>
-        `).join('');
         const controlsHtml = `
             <div class="pseudobulk-de-controls">
-                <div class="pseudobulk-de-select-row">
-                    <div><label>Feature namespace</label><select id="pseudobulk-de-modality-select" ${{availableModalities.length < 2 ? 'disabled' : ''}}>${{modalityOptions}}</select></div>
-                    <div><label>Annotation</label><select id="pseudobulk-de-annotation">${{annotationOptions}}</select></div>
-                </div>
                 <div class="pseudobulk-de-select-row comparison-pair-select-row">
                     <div><label>Annotation A</label><select id="pseudobulk-de-source" style="border-color:${{sourceColor}}">${{sourceOptions}}</select></div>
                     <div><label>Annotation B</label><select id="pseudobulk-de-reference" style="border-color:${{referenceColor}}">${{referenceOptions}}</select></div>
@@ -29869,12 +29879,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const minPctRetainedGenes = Number(contrastResult?.min_pct_retained_gene_count);
         const minPctPrefilterGenes = Number(contrastResult?.min_pct_prefilter_gene_count);
         const minPctRemovalCountText = Number.isFinite(minPctRemovedGenes)
-            ? ` ${{minPctRemovedGenes.toLocaleString()}} gene${{minPctRemovedGenes === 1 ? '' : 's'}} ${{minPctRemovedGenes === 1 ? 'was' : 'were'}} removed${{
+            ? ` ${{minPctRemovedGenes.toLocaleString()}} feature${{minPctRemovedGenes === 1 ? '' : 's'}} ${{minPctRemovedGenes === 1 ? 'was' : 'were'}} removed${{
                 Number.isFinite(minPctRetainedGenes) && Number.isFinite(minPctPrefilterGenes)
-                    ? ` (${{minPctRetainedGenes.toLocaleString()}} of ${{minPctPrefilterGenes.toLocaleString()}} fitted genes retained)`
+                    ? ` (${{minPctRetainedGenes.toLocaleString()}} of ${{minPctPrefilterGenes.toLocaleString()}} fitted features retained)`
                     : ''
             }}.`
-            : ' Removed-gene count is unavailable for this export.';
+            : ' Removed-feature count is unavailable for this export.';
         const padjCutoff = Math.min(Math.max(normalizePositiveThreshold(
             contrastResult?.padj_cutoff ?? pseudobulkSettings.padj_cutoff,
             0.05
@@ -29895,7 +29905,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     <span><code>--pseudobulk-log2fc-cutoff</code> |log₂FC| ≥ ${{formatScaleNumber(log2fcCutoff)}}</span>
                 </div>
             </div>
-            ${{minPct > 0 ? `<div class="comparison-info-warning"><strong>Warning.</strong> Genes expressed in less than ${{formatScaleNumber(100 * minPct)}}% of cells in both selected annotations are removed before DESeq2 statistical testing.${{minPctRemovalCountText}}</div>` : ''}}
+            ${{minPct > 0 ? `<div class="comparison-info-warning"><strong>Warning.</strong> Features detected in less than ${{formatScaleNumber(100 * minPct)}}% of cells in both selected annotations are removed before DESeq2 statistical testing.${{minPctRemovalCountText}}</div>` : ''}}
         `;
 
         const markerSummary = renderComparisonMarkerSummary(
@@ -29923,33 +29933,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ${{pathwaySection ? '<div class="selection-summary-title" id="pathway-enrichment-title">Pathway Enrichment' + renderCalcInfoButton('pathway_enrichment_section') + '</div>' + pathwaySection : ''}}
         `;
 
-        const modalitySelect = container.querySelector('#pseudobulk-de-modality-select');
-        const annotationSelect = container.querySelector('#pseudobulk-de-annotation');
         const sourceSelect = container.querySelector('#pseudobulk-de-source');
         const referenceSelect = container.querySelector('#pseudobulk-de-reference');
-        if (modalitySelect) {{
-            modalitySelect.value = modality;
-            modalitySelect.addEventListener('change', () => {{
-                setPseudobulkPanelModality(modalitySelect.value || DEFAULT_MODALITY_NAME);
-                pseudobulkDeGroupby = null;
-                pseudobulkDeSourceCategory = null;
-                pseudobulkDeReferenceCategory = null;
-                clusterDETableExpanded = false;
-                pathwayAnnotationSide = 'source';
-                renderPseudobulkDE();
-            }});
-        }}
-        if (annotationSelect) {{
-            annotationSelect.value = pseudobulkDeGroupby || '';
-            annotationSelect.addEventListener('change', () => {{
-                pseudobulkDeGroupby = annotationSelect.value || null;
-                pseudobulkDeSourceCategory = null;
-                pseudobulkDeReferenceCategory = null;
-                clusterDETableExpanded = false;
-                pathwayAnnotationSide = 'source';
-                renderPseudobulkDE();
-            }});
-        }}
         if (sourceSelect) {{
             sourceSelect.value = pseudobulkDeSourceCategory;
             sourceSelect.addEventListener('change', () => {{
@@ -30362,539 +30347,6 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}, sections);
     }}
 
-    async function computeCellSetDEAsync(groupA, groupB, options = {{}}) {{
-        const topN = Math.max(1, Number(options.topN) || groupDeTopN || 12);
-        const isCancelled = typeof options.isCancelled === 'function' ? options.isCancelled : () => false;
-        if (!groupA || !groupB) {{
-            return {{ available: false, reason: 'missing_groups', results: [] }};
-        }}
-        if (groupA.key && groupA.key === groupB.key) {{
-            return {{ available: false, reason: 'same_group', nA: groupA.nCells || 0, nB: groupB.nCells || 0, results: [] }};
-        }}
-        if (!(groupA.nCells > 0) || !(groupB.nCells > 0)) {{
-            return {{
-                available: false,
-                reason: 'empty_group',
-                nA: Number(groupA.nCells || 0),
-                nB: Number(groupB.nCells || 0),
-                modality: getExplorationModality(),
-                results: [],
-            }};
-        }}
-
-        const activeModality = getExplorationModality();
-        const loadedGenes = getLoadedFeaturesForModality(activeModality);
-        const totalGenes = getFeatureCatalog(activeModality).length || loadedGenes.length;
-        if (!loadedGenes.length) {{
-            return {{
-                available: false,
-                reason: 'no_loaded_features',
-                nA: Number(groupA.nCells || 0),
-                nB: Number(groupB.nCells || 0),
-                modality: activeModality,
-                loadedGeneCount: 0,
-                totalGeneCount: totalGenes,
-                results: [],
-            }};
-        }}
-
-        const results = [];
-        const BATCH = 10;
-        for (let i = 0; i < loadedGenes.length; i += BATCH) {{
-            if (isCancelled()) return null;
-            const end = Math.min(i + BATCH, loadedGenes.length);
-            for (let j = i; j < end; j++) {{
-                const gene = loadedGenes[j];
-                const statsA = computeQuickStatsForGroupGene(groupA, gene, activeModality);
-                const statsB = computeQuickStatsForGroupGene(groupB, gene, activeModality);
-                const entry = buildDEEntryFromStats(gene, statsA, statsB, groupA.nCells, groupB.nCells);
-                if (entry) results.push(entry);
-            }}
-            if (end < loadedGenes.length) await new Promise((r) => setTimeout(r, 0));
-        }}
-        if (isCancelled()) return null;
-
-        sortCellSetDEResults(results);
-        return {{
-            available: true,
-            reason: null,
-            nA: Number(groupA.nCells || 0),
-            nB: Number(groupB.nCells || 0),
-            modality: activeModality,
-            loadedGeneCount: loadedGenes.length,
-            totalGeneCount: totalGenes,
-            results: selectTwoSidedTopN(results, topN),
-        }};
-    }}
-
-    // Retained for reference while saved sessions that contain the older group-DE
-    // controls remain readable. The visible Annotations panel is rendered below.
-    function renderLegacyGroupDE() {{
-        groupDeRenderDepth += 1;
-        if (groupDeRenderDepth > 3) {{
-            console.error('renderGroupDE re-entrant depth', groupDeRenderDepth);
-            groupDeRenderDepth -= 1;
-            return;
-        }}
-        try {{
-        const container = document.getElementById('group-de-panel');
-        if (!container) return;
-
-        const {{ sources, sourceSpec, groupValues, restrictSpec, restrictValues }} = syncGroupDEUiState();
-        if (!sources.length) {{
-            setCompareSectionSummary('group-de-summary', 'Needs section metadata or categorical annotations.');
-            container.innerHTML = '<div class="agg-group-meta">Group DE needs section metadata or categorical annotations to define the two groups.</div>';
-            return;
-        }}
-
-        const groupedSourceOptions = (kind) => sources
-            .filter((spec) => spec.kind === kind)
-            .map((spec) => {{
-                const encoded = encodeGroupDESourceSpec(spec);
-                const selected = encoded === groupDeSourceSpecValue ? ' selected' : '';
-                return `<option value="${{encoded}}"${{selected}}>${{escapeHtml(formatGroupDESourceSpecLabel(spec))}}</option>`;
-            }})
-            .join('');
-        const groupedRestrictionOptions = (kind) => sources
-            .filter((spec) => spec.kind === kind)
-            .map((spec) => {{
-                const encoded = encodeGroupDESourceSpec(spec);
-                const selected = encoded === groupDeRestrictSpecValue ? ' selected' : '';
-                return `<option value="${{encoded}}"${{selected}}>${{escapeHtml(formatGroupDESourceSpecLabel(spec))}}</option>`;
-            }})
-            .join('');
-        const renderValueOptions = (values, selectedValue) => values
-            .map((value) => {{
-                const text = String(value);
-                const selected = text === String(selectedValue ?? '') ? ' selected' : '';
-                return `<option value="${{escapeHtml(text)}}"${{selected}}>${{escapeHtml(text)}}</option>`;
-            }})
-            .join('');
-
-        let html = `
-            <div class="agg-group-meta">Exploratory DE between two arbitrary cell groups. Compare samples, section metadata groups, or annotation categories, and optionally restrict within a second annotation.</div>
-            <div class="pseudobulk-de-controls">
-                <div>
-                    <label>Compare By</label>
-                    <select id="group-de-source-spec">
-                        ${{groupedSourceOptions('metadata') ? `<optgroup label="Section metadata">${{groupedSourceOptions('metadata')}}</optgroup>` : ''}}
-                        ${{groupedSourceOptions('annotation') ? `<optgroup label="Cell annotations">${{groupedSourceOptions('annotation')}}</optgroup>` : ''}}
-                    </select>
-                </div>
-                <div class="pseudobulk-de-select-row">
-                    <div>
-                        <label>Group A</label>
-                        <select id="group-de-source-value">${{renderValueOptions(groupValues, groupDeSourceValue)}}</select>
-                    </div>
-                    <div>
-                        <label>Group B</label>
-                        <select id="group-de-reference-value">${{renderValueOptions(groupValues, groupDeReferenceValue)}}</select>
-                    </div>
-                    <div>
-                        <label>Top Genes</label>
-                        <input id="group-de-topn" type="number" min="3" max="100" step="1" value="${{Math.max(3, Number(groupDeTopN) || ANNOTATION_DE_TOP_N)}}">
-                    </div>
-                </div>
-                <div class="pseudobulk-de-select-row">
-                    <div>
-                        <label>Restrict Within</label>
-                        <select id="group-de-restrict-spec">
-                            <option value="">None</option>
-                            ${{groupedRestrictionOptions('metadata') ? `<optgroup label="Section metadata">${{groupedRestrictionOptions('metadata')}}</optgroup>` : ''}}
-                            ${{groupedRestrictionOptions('annotation') ? `<optgroup label="Cell annotations">${{groupedRestrictionOptions('annotation')}}</optgroup>` : ''}}
-                        </select>
-                    </div>
-                    <div>
-                        <label>Restrict Value</label>
-                        <select id="group-de-restrict-value" ${{restrictSpec ? '' : 'disabled'}}>${{renderValueOptions(restrictValues, groupDeRestrictValue)}}</select>
-                    </div>
-                    <div>
-                        <label>Scope</label>
-                        <select id="group-de-scope">
-                            <option value="all"${{groupDeScope === 'all' ? ' selected' : ''}}>All cells</option>
-                            <option value="visible"${{groupDeScope === 'visible' ? ' selected' : ''}}>Current filters</option>
-                        </select>
-                    </div>
-                </div>
-                <div style="display: flex; justify-content: flex-end;">
-                    <button class="legend-btn" id="group-de-swap" type="button">Swap A/B</button>
-                </div>
-            </div>
-        `;
-
-        if (!sourceSpec) {{
-            setCompareSectionSummary('group-de-summary', 'Choose a grouping field.');
-            container.innerHTML = html + '<div class="agg-group-meta">Choose a section metadata field or categorical annotation to define the two groups.</div>';
-            return;
-        }}
-        if (groupValues.length < 2) {{
-            setCompareSectionSummary('group-de-summary', `${{formatGroupDESourceSpecLabel(sourceSpec)}} needs at least two values.`);
-            container.innerHTML = html + '<div class="agg-group-meta">This grouping field needs at least two values.</div>';
-            return;
-        }}
-
-        // Render controls immediately, defer heavy DE computation
-        const token = ++groupDeRenderToken;
-        const summaryLabel = formatGroupDESourceSpecLabel(sourceSpec);
-        const restrictSummary = restrictSpec && groupDeRestrictValue
-            ? ` · within ${{formatGroupDESourceSpecLabel(restrictSpec)}}=${{groupDeRestrictValue}}`
-            : '';
-        setCompareSectionSummary(
-            'group-de-summary',
-            `${{summaryLabel}}: ${{String(groupDeSourceValue ?? 'A')}} vs ${{String(groupDeReferenceValue ?? 'B')}}${{restrictSummary}}`,
-        );
-        // Synchronous placeholder. Only show the indeterminate "Computing…" bar
-        // when a real quick compute (over already-loaded genes) is about to run.
-        // During a full sidecar run this function is re-invoked after every shard,
-        // so showing the indeterminate bar here would flicker against the
-        // determinate bar the async step renders. For sidecar-only datasets the
-        // async step renders the "Compute DE" button, so an empty placeholder
-        // avoids a misleading flash.
-        const groupDeHasLoadedGenes = Object.keys(DATA.features_meta || {{}}).length > 0;
-        html += (groupDeHasLoadedGenes && !(groupDeFullRun && groupDeFullRun.running))
-            ? '<div id="group-de-results"><progress style="width:100%; height:12px;"></progress>'
-                + '<div class="agg-group-meta">Computing differential expression…</div></div>'
-            : '<div id="group-de-results"></div>';
-        container.innerHTML = html;
-
-        const sourceSpecSelect = container.querySelector('#group-de-source-spec');
-        const sourceValueSelect = container.querySelector('#group-de-source-value');
-        const referenceValueSelect = container.querySelector('#group-de-reference-value');
-        const restrictSpecSelect = container.querySelector('#group-de-restrict-spec');
-        const restrictValueSelect = container.querySelector('#group-de-restrict-value');
-        const scopeSelect = container.querySelector('#group-de-scope');
-        const topNInput = container.querySelector('#group-de-topn');
-        const swapBtn = container.querySelector('#group-de-swap');
-        // Defer re-renders via requestAnimationFrame so select elements finish
-        // their event lifecycle before innerHTML replaces them (Safari crash fix).
-        const deferRender = () => requestAnimationFrame(() => renderGroupDE());
-        sourceSpecSelect?.addEventListener('change', () => {{
-            cancelGroupDEFullRun();
-            groupDeSourceSpecValue = sourceSpecSelect.value || '';
-            groupDeSourceValue = null;
-            groupDeReferenceValue = null;
-            deferRender();
-        }});
-        sourceValueSelect?.addEventListener('change', () => {{
-            cancelGroupDEFullRun();
-            groupDeSourceValue = sourceValueSelect.value || null;
-            deferRender();
-        }});
-        referenceValueSelect?.addEventListener('change', () => {{
-            cancelGroupDEFullRun();
-            groupDeReferenceValue = referenceValueSelect.value || null;
-            deferRender();
-        }});
-        restrictSpecSelect?.addEventListener('change', () => {{
-            cancelGroupDEFullRun();
-            groupDeRestrictSpecValue = restrictSpecSelect.value || '';
-            groupDeRestrictValue = null;
-            deferRender();
-        }});
-        restrictValueSelect?.addEventListener('change', () => {{
-            cancelGroupDEFullRun();
-            groupDeRestrictValue = restrictValueSelect.value || null;
-            deferRender();
-        }});
-        scopeSelect?.addEventListener('change', () => {{
-            cancelGroupDEFullRun();
-            groupDeScope = scopeSelect.value === 'visible' ? 'visible' : 'all';
-            deferRender();
-        }});
-        topNInput?.addEventListener('change', () => {{
-            groupDeTopN = Math.min(100, Math.max(3, Number(topNInput.value) || ANNOTATION_DE_TOP_N));
-            deferRender();
-        }});
-        swapBtn?.addEventListener('click', () => {{
-            cancelGroupDEFullRun();
-            const source = groupDeSourceValue;
-            groupDeSourceValue = groupDeReferenceValue;
-            groupDeReferenceValue = source;
-            renderGroupDE();
-        }});
-
-        // Snapshot current state for the deferred computation
-        const deferredSourceSpec = sourceSpec;
-        const deferredRestrictSpec = restrictSpec;
-        const deferredSourceValue = groupDeSourceValue;
-        const deferredReferenceValue = groupDeReferenceValue;
-        const deferredRestrictValue = groupDeRestrictValue;
-        const deferredScope = groupDeScope;
-        const deferredTopN = groupDeTopN;
-
-        // Defer heavy cell-set building + DE computation so browser can breathe
-        (async () => {{
-            await new Promise((r) => setTimeout(r, 0));
-            if (groupDeRenderToken !== token) return;
-            const resultsDiv = document.getElementById('group-de-results');
-            if (!resultsDiv) return;
-
-            const groupA = await buildGroupDECellSetAsync(deferredSourceSpec, deferredSourceValue, {{
-                restrictSpec: deferredRestrictSpec,
-                restrictValue: deferredRestrictValue,
-                scope: deferredScope,
-                isCancelled: () => groupDeRenderToken !== token,
-            }});
-            if (groupDeRenderToken !== token) return;
-            const groupB = await buildGroupDECellSetAsync(deferredSourceSpec, deferredReferenceValue, {{
-                restrictSpec: deferredRestrictSpec,
-                restrictValue: deferredRestrictValue,
-                scope: deferredScope,
-                isCancelled: () => groupDeRenderToken !== token,
-            }});
-            if (groupDeRenderToken !== token) return;
-
-            const quickResult = await computeCellSetDEAsync(groupA, groupB, {{
-                topN: deferredTopN,
-                isCancelled: () => groupDeRenderToken !== token,
-            }});
-            if (groupDeRenderToken !== token || !quickResult) return;
-
-            const exportState = getGroupDEExportState(groupA, groupB, quickResult);
-            const pairKey = getGroupDECacheKey(groupA, groupB);
-            const fullCached = pairKey ? groupDeFullCache.get(pairKey) : null;
-            const fullRun = (groupDeFullRun && groupDeFullRun.key === pairKey) ? groupDeFullRun : null;
-            const sidecarAvailable = !!DATA.feature_manifest_url;
-            const renderCards = (result) => {{
-                const resultModality = result?.modality || getExplorationModality();
-                const topN = Math.max(1, Number(deferredTopN) || ANNOTATION_DE_TOP_N);
-                return selectTwoSidedTopN(result.results || [], topN).map((entry) => {{
-                    return `
-                        <div class="comparison-card">
-                            <div class="comparison-card-title">
-                                ${{renderGeneTokenButton(entry.gene, {{
-                                    allowUnknown: true,
-                                    isActive: entry.gene === currentGene,
-                                    modality: resultModality,
-                                    showMeta: false,
-                                    title: 'Load group DE feature into the viewer',
-                                }})}}
-                                ${{renderGeneGoogleSearchButton(entry.gene, {{
-                                    title: 'Search Google for this gene',
-                                }})}}
-                            </div>
-                            <div class="comparison-metric-grid">
-                                <div class="comparison-metric">
-                                    <span class="comparison-metric-label">log2FC A/B</span>
-                                    <span class="comparison-metric-value">${{formatScaleNumber(entry.log2fc)}}</span>
-                                </div>
-                                <div class="comparison-metric">
-                                    <span class="comparison-metric-label">Score</span>
-                                    <span class="comparison-metric-value">${{formatScaleNumber(entry.score)}}</span>
-                                </div>
-                                <div class="comparison-metric">
-                                    <span class="comparison-metric-label">% expr A</span>
-                                    <span class="comparison-metric-value">${{formatPseudobulkDEPct(entry.pctA)}}</span>
-                                </div>
-                                <div class="comparison-metric">
-                                    <span class="comparison-metric-label">% expr B</span>
-                                    <span class="comparison-metric-value">${{formatPseudobulkDEPct(entry.pctB)}}</span>
-                                </div>
-                                <div class="comparison-metric">
-                                    <span class="comparison-metric-label">Mean A</span>
-                                    <span class="comparison-metric-value">${{formatScaleNumber(entry.meanA)}}</span>
-                                </div>
-                                <div class="comparison-metric">
-                                    <span class="comparison-metric-label">Mean B</span>
-                                    <span class="comparison-metric-value">${{formatScaleNumber(entry.meanB)}}</span>
-                                </div>
-                            </div>
-                        </div>
-                    `;
-                }}).join('');
-            }};
-            const sourceLabel = groupA ? escapeHtml(groupA.description) : '';
-            const referenceLabel = groupB ? escapeHtml(groupB.description) : '';
-            const sizeSummary = (groupA && groupB)
-                ? ` · ${{Number(groupA.nCells || 0).toLocaleString()}} vs ${{Number(groupB.nCells || 0).toLocaleString()}} cells`
-                : '';
-            setCompareSectionSummary(
-                'group-de-summary',
-                `${{summaryLabel}}: ${{String(deferredSourceValue ?? 'A')}} vs ${{String(deferredReferenceValue ?? 'B')}}${{restrictSummary}}${{sizeSummary}}`,
-            );
-            const topNLabel = Math.max(1, Number(deferredTopN) || ANNOTATION_DE_TOP_N).toLocaleString();
-            const quickSummaryHtml = (quickResult.available && quickResult.results.length)
-                ? `
-                    <div class="agg-group-meta">
-                        Group A: <strong>${{sourceLabel}}</strong> (${{Number(quickResult.nA || 0).toLocaleString()}} cells)
-                        vs Group B: <strong>${{referenceLabel}}</strong> (${{Number(quickResult.nB || 0).toLocaleString()}} cells).
-                    </div>
-                    <div class="agg-group-meta">
-                        ${{
-                            Number(quickResult.loadedGeneCount || 0) < Number(quickResult.totalGeneCount || 0)
-                                ? `Quick preview over ${{Number(quickResult.loadedGeneCount || 0).toLocaleString()}} of ${{Number(quickResult.totalGeneCount || 0).toLocaleString()}} genes — run the full sidecar DE for the complete result.`
-                                : ''
-                        }}
-                        Showing top ${{topNLabel}} genes in both directions — positive scores = enriched in Group A, negative = enriched in Group B.
-                    </div>
-                    ${{buildGroupVolcanoPlot(quickResult.results || [])}}
-                    <div class="comparison-stack">${{renderCards(quickResult)}}</div>
-                `
-                : '';
-            const cachedTimestamp = fullCached?.completedAt
-                ? new Date(fullCached.completedAt).toLocaleTimeString([], {{ hour: '2-digit', minute: '2-digit', second: '2-digit' }})
-                : '';
-            const cachedSummaryHtml = fullCached?.available
-                ? (fullCached.results || []).length
-                    ? `
-                        <div class="agg-group-meta">
-                            Group A: <strong>${{sourceLabel}}</strong> (${{Number(fullCached.nA || 0).toLocaleString()}} cells)
-                            vs Group B: <strong>${{referenceLabel}}</strong> (${{Number(fullCached.nB || 0).toLocaleString()}} cells).
-                        </div>
-                        <div class="agg-group-meta">
-                            Cached full sidecar DE${{cachedTimestamp ? ` from ${{cachedTimestamp}}` : ''}}
-                            across ${{Number(fullCached.totalGeneCount || 0).toLocaleString()}} genes.
-                            Showing top ${{topNLabel}} genes in both directions — positive scores = enriched in Group A, negative = enriched in Group B.
-                        </div>
-                        ${{buildGroupVolcanoPlot(fullCached.results || [])}}
-                        <div class="comparison-stack">${{renderCards(fullCached)}}</div>
-                    `
-                    : `
-                        <div class="agg-group-meta">
-                            Group A: <strong>${{sourceLabel}}</strong> (${{Number(fullCached.nA || 0).toLocaleString()}} cells)
-                            vs Group B: <strong>${{referenceLabel}}</strong> (${{Number(fullCached.nB || 0).toLocaleString()}} cells).
-                        </div>
-                        <div class="agg-group-meta">
-                            Cached full sidecar DE${{cachedTimestamp ? ` from ${{cachedTimestamp}}` : ''}} found no enriched genes across ${{Number(fullCached.totalGeneCount || 0).toLocaleString()}} genes.
-                        </div>
-                    `
-                : '';
-            let resultHtml = '';
-            if (!groupA || !groupB) {{
-                resultHtml = '<div class="agg-group-meta">Choose two different groups to compare.</div>';
-            }} else if (fullRun?.running) {{
-                const totalShards = Number(fullRun.totalShards || 0);
-                const completedShards = Number(fullRun.completedShards || 0);
-                const totalGenes = Number(fullRun.totalGenes || 0);
-                const completedGenes = Number(fullRun.completedGenes || 0);
-                const progressMax = Math.max(1, totalGenes || totalShards || 1);
-                const progressValue = Math.min(progressMax, totalGenes ? completedGenes : completedShards);
-                const progressPct = progressMax > 0 ? Math.round((progressValue / progressMax) * 100) : 0;
-                resultHtml = `
-                    <div class="agg-group-meta">Scanning the full sidecar in the background. The viewer stays interactive while this runs.</div>
-                    <progress value="${{progressValue}}" max="${{progressMax}}" style="width:100%; height:12px;"></progress>
-                    <div class="agg-group-meta">
-                        ${{progressPct}}% complete
-                        · ${{completedGenes.toLocaleString()}} / ${{totalGenes.toLocaleString()}} genes
-                        · ${{completedShards.toLocaleString()}} / ${{totalShards.toLocaleString()}} shards
-                    </div>
-                    <div style="display:flex; justify-content:flex-end;">
-                        <button class="legend-btn" id="group-de-cancel" type="button">Cancel Full DE</button>
-                    </div>
-                `;
-            }} else if (fullRun?.error) {{
-                resultHtml = `
-                    <div class="agg-group-meta">Full sidecar DE failed: ${{escapeHtml(fullRun.error)}}</div>
-                    <div style="display:flex; justify-content:flex-end;">
-                        <button class="legend-btn" id="group-de-run-full" type="button">Retry Full DE</button>
-                    </div>
-                `;
-                if (cachedSummaryHtml) {{
-                    resultHtml += '<div class="agg-group-meta">Showing the previous cached full result:</div>';
-                    resultHtml += cachedSummaryHtml;
-                }} else if (quickSummaryHtml) {{
-                    resultHtml += '<div class="agg-group-meta">Quick DE preview from currently loaded genes:</div>';
-                    resultHtml += quickSummaryHtml;
-                }}
-            }} else if (fullCached?.available) {{
-                resultHtml = cachedSummaryHtml;
-                resultHtml += '<div style="display:flex; justify-content:flex-end;"><button class="legend-btn" id="group-de-refresh-full" type="button">Refresh Full DE</button></div>';
-            }} else if (!quickResult.available && quickResult.reason === 'empty_group') {{
-                resultHtml = '<div class="agg-group-meta">One of the selected groups has no cells after applying the current restriction.</div>';
-            }} else if (!quickResult.available && quickResult.reason === 'no_loaded_features' && sidecarAvailable) {{
-                const totalGenes = Number(quickResult.totalGeneCount || 0).toLocaleString();
-                resultHtml = `
-                    <div class="agg-group-meta">
-                        Differential expression runs across ${{totalGenes !== '0' ? `all ${{totalGenes}} genes` : 'all genes'}} from the feature sidecar.
-                    </div>
-                    <div style="display:flex; justify-content:flex-end;">
-                        <button class="legend-btn" id="group-de-run-full" type="button">Compute DE across all genes</button>
-                    </div>
-                `;
-            }} else if (!quickResult.available && quickResult.reason === 'no_loaded_features') {{
-                resultHtml = '<div class="agg-group-meta">No features are currently loaded for group DE. Load features in the Features tab or click pseudobulk DE features first.</div>';
-            }} else if (!quickResult.available && quickResult.reason === 'same_group') {{
-                resultHtml = '<div class="agg-group-meta">Choose two different groups to compare.</div>';
-            }} else if (!quickResult.available) {{
-                resultHtml = '<div class="agg-group-meta">Choose two different groups to compare.</div>';
-            }} else if (!quickResult.results.length) {{
-                if (sidecarAvailable && Number(quickResult.loadedGeneCount || 0) < Number(quickResult.totalGeneCount || 0)) {{
-                    resultHtml = `
-                        <div class="agg-group-meta">No enriched genes were found among the currently loaded genes.</div>
-                        <div style="display:flex; justify-content:flex-end;">
-                            <button class="legend-btn" id="group-de-run-full" type="button">Run Full DE</button>
-                        </div>
-                    `;
-                }} else {{
-                    resultHtml = '<div class="agg-group-meta">No enriched genes were found among the genes currently loaded in the viewer.</div>';
-                }}
-            }} else {{
-                resultHtml = quickSummaryHtml;
-                if (sidecarAvailable && Number(quickResult.loadedGeneCount || 0) < Number(quickResult.totalGeneCount || 0)) {{
-                    resultHtml += '<div style="display:flex; justify-content:flex-end;"><button class="legend-btn" id="group-de-run-full" type="button">Run Full DE</button></div>';
-                }}
-            }}
-
-            if (exportState) {{
-                resultHtml += `
-                    <div style="display:flex; justify-content:flex-end; gap:6px; margin-top:6px;">
-                        <button class="legend-btn" id="group-de-export-json" type="button">Export JSON</button>
-                        <button class="legend-btn" id="group-de-export-csv" type="button">Export CSV</button>
-                    </div>
-                `;
-            }}
-
-            resultsDiv.innerHTML = `<div class="gene-distribution-summary">Group differential expression${{renderCalcInfoButton('group_de')}}</div>` + resultHtml;
-
-            const runFullBtn = resultsDiv.querySelector('#group-de-run-full');
-            if (runFullBtn && groupA && groupB) {{
-                runFullBtn.addEventListener('click', () => {{
-                    runFullGroupDE(groupA, groupB);
-                }});
-            }}
-            const refreshFullBtn = resultsDiv.querySelector('#group-de-refresh-full');
-            if (refreshFullBtn && groupA && groupB) {{
-                refreshFullBtn.addEventListener('click', () => {{
-                    runFullGroupDE(groupA, groupB);
-                }});
-            }}
-            const cancelBtn = resultsDiv.querySelector('#group-de-cancel');
-            if (cancelBtn) {{
-                cancelBtn.addEventListener('click', () => {{
-                    cancelGroupDEFullRun();
-                    renderGroupDE();
-                }});
-            }}
-            const exportJsonBtn = resultsDiv.querySelector('#group-de-export-json');
-            if (exportJsonBtn && groupA && groupB) {{
-                exportJsonBtn.addEventListener('click', () => {{
-                    exportGroupDEReport(groupA, groupB, exportState);
-                }});
-            }}
-            const exportCsvBtn = resultsDiv.querySelector('#group-de-export-csv');
-            if (exportCsvBtn && groupA && groupB) {{
-                exportCsvBtn.addEventListener('click', () => {{
-                    exportGroupDECsv(groupA, groupB, exportState);
-                }});
-            }}
-            bindVolcanoGroupInteraction(resultsDiv, renderGroupDE);
-            bindGeneActivateButtons(resultsDiv, renderGroupDE);
-            bindGeneGoogleSearchButtons(resultsDiv);
-        }})().catch((asyncErr) => {{
-            // Without this, a throw inside the async compute would leave the
-            // "Computing…" placeholder stuck on screen forever.
-            console.error('group DE async compute failed:', asyncErr);
-            if (groupDeRenderToken !== token) return;
-            const rd = document.getElementById('group-de-results');
-            if (rd) rd.innerHTML = '<div class="agg-group-meta">Differential expression could not be computed. Adjust the selection and try again.</div>';
-        }});
-        }} catch (err) {{
-            console.error('renderGroupDE crashed:', err);
-        }} finally {{
-            groupDeRenderDepth -= 1;
-        }}
-    }}
-
     function getActiveAnnotationGroupDESpec() {{
         const column = String(explorationColorCol || '');
         if (!column || column.startsWith(SECTION_METADATA_COLOR_PREFIX)) return null;
@@ -31038,7 +30490,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ? '<div class="selection-query-icon-btn selection-summary-find-markers loading" role="status" aria-label="Finding annotation markers"><span class="selection-summary-find-markers-spinner"></span></div>'
             : (!hasCompletedCalculation ? '<button class="selection-query-icon-btn" id="group-de-run" type="button" title="Find annotation markers" aria-label="Find annotation markers"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg></button>' : '');
         const controlsHtml = `
-            <div class="selection-summary-title">Gene expression — annotation A vs annotation B${{renderCalcInfoButton('group_de')}}</div>
+            <div class="selection-summary-title">Feature values - annotation A vs annotation B${{renderCalcInfoButton('group_de')}}</div>
             <div class="pseudobulk-de-controls insights-panel-section">
                 <div class="pseudobulk-de-select-row comparison-pair-select-row">
                     <div><label>Annotation A</label><select id="group-de-source-value" style="border-color:${{colorA}}">${{renderValues(groupValues, groupDeSourceValue)}}</select></div>
@@ -31053,7 +30505,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     <select id="group-de-restrict-value"${{restrictSpec ? '' : ' disabled'}}>${{renderRestrictionValues}}</select>
                 </div>
                 <div class="comparison-de-action-row">
-                    ${{hasCompletedCalculation ? `<div class="selection-summary-welch-controls"><div class="selection-summary-welch-control-row"><label>Top N per direction</label><input id="group-de-topn" type="number" min="1" max="20" step="1" value="${{groupDeTopN}}"></div><div class="selection-summary-welch-control-row"><label>Min expressed %</label><input id="group-de-min-pct" type="range" min="0" max="100" step="1" value="${{groupDeMinPct}}"><output id="group-de-min-pct-value">${{groupDeMinPct}}%</output></div></div>` : ''}}
+                    ${{hasCompletedCalculation ? `<div class="selection-summary-welch-controls"><div class="selection-summary-welch-control-row"><label>Top N per direction</label><input id="group-de-topn" type="number" min="1" max="20" step="1" value="${{groupDeTopN}}"></div><div class="selection-summary-welch-control-row"><label>Min detected %</label><input id="group-de-min-pct" type="range" min="0" max="100" step="1" value="${{groupDeMinPct}}"><output id="group-de-min-pct-value">${{groupDeMinPct}}%</output></div></div>` : ''}}
                     <div class="comparison-de-action-buttons"><button class="legend-btn icon-only" id="group-de-swap" type="button" title="Swap Annotation A and Annotation B" aria-label="Swap Annotation A and Annotation B"><svg class="lucide lucide-arrow-left-right" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3 4 7l4 4"></path><path d="M4 7h16"></path><path d="m16 21 4-4-4-4"></path><path d="M20 17H4"></path></svg></button>${{runButtonHtml}}</div>
                 </div>
             </div>`;
@@ -31091,11 +30543,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const volcanoToolbar = '<button class="icon-btn" type="button" data-group-de-export-volcano title="Download volcano plot as SVG" aria-label="Download volcano plot as SVG"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg></button>';
             html += `<div id="group-de-results">${{buildGroupVolcanoPlot(displayed, volcanoToolbar, {{ positive: colorA, negative: colorB }})}}<div class="comparison-stack">${{renderCards()}}</div><div style="display:flex;justify-content:flex-end;gap:6px;margin-top:6px;"><button class="icon-btn" type="button" data-group-de-export-csv title="Download all annotation comparison features as CSV" aria-label="Download all annotation comparison features as CSV"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg></button></div>${{DATA.feature_manifest_url && result === quickResult && Number(result.loadedGeneCount || 0) < Number(result.totalGeneCount || 0) ? '<div style="display:flex;justify-content:flex-end"><button class="legend-btn" id="group-de-run-full" type="button">Run Full DE</button></div>' : ''}}</div>`;
         }} else if (quickResult && !quickResult.available) {{
-            const noLoadedGenes = quickResult.reason === 'no_loaded_features' && !!DATA.feature_manifest_url;
-            const message = noLoadedGenes
-                ? 'No genes are currently loaded. Run the full sidecar comparison to scan all genes.'
+            const noLoadedFeatures = quickResult.reason === 'no_loaded_features' && !!DATA.feature_manifest_url;
+            const message = noLoadedFeatures
+                ? 'No features are currently loaded. Run the full sidecar comparison to scan all features.'
                 : (quickResult.reason === 'too_few_cells' ? 'Each annotation needs at least two cells.' : 'The selected annotations could not be compared.');
-            html += `<div id="group-de-results"><div class="agg-group-meta">${{message}}</div>${{noLoadedGenes ? '<div style="display:flex;justify-content:flex-end"><button class="legend-btn" id="group-de-run-full" type="button">Run Full DE</button></div>' : ''}}</div>`;
+            html += `<div id="group-de-results"><div class="agg-group-meta">${{message}}</div>${{noLoadedFeatures ? '<div style="display:flex;justify-content:flex-end"><button class="legend-btn" id="group-de-run-full" type="button">Run Full DE</button></div>' : ''}}</div>`;
         }} else {{
             html += '<div id="group-de-results"></div>';
         }}
@@ -33183,7 +32635,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const activateAttr = loadable ? ` data-gene-activate="${{escapeHtml(token)}}" data-gene-modality="${{escapeHtml(modality)}}"` : '';
             const title = loadable
                 ? `Load ${{g}} into the ${{getModalityDisplayLabel(modality)}} viewer`
-                : `${{g}} is shown in DE results but its expression vector is unavailable for ${{getModalityDisplayLabel(modality)}}`;
+                : `${{g}} is shown in DE results but its feature vector is unavailable for ${{getModalityDisplayLabel(modality)}}`;
             return `<span class="${{cls}}"${{activateAttr}} title="${{escapeHtml(title)}}">${{escapeHtml(g)}}</span>`;
         }}).join(', ');
         const sourceMarkerLabel = sourceMarkers.length ? renderInlineGeneLinks(sourceMarkers) : 'No pseudobulk DE features available.';
@@ -34417,14 +33869,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 overviewBlendSpec.b.modality = overviewBlendSpec.b.modality || defaultModality;
 
                 const normalize = (entry, side, preferSecond) => {{
-                    const legacyModality = entry.kind && entry.kind !== 'cell' ? entry.kind : '';
-                    if (!entry.source) entry.source = legacyModality ? 'feature' : (catCols.length ? 'annotation' : 'feature');
+                    if (!entry.source) entry.source = catCols.length ? 'annotation' : 'feature';
                     if (entry.source !== 'feature' && entry.source !== 'annotation') entry.source = 'annotation';
-                    if (!entry.modality) entry.modality = legacyModality || getPanelModality(`split.${{side}}`, defaultModality);
+                    if (!entry.modality) entry.modality = getPanelModality(`split.${{side}}`, defaultModality);
                     if (!namespaceSet.has(entry.modality)) entry.modality = defaultModality;
                     setPanelModality(`split.${{side}}`, entry.modality);
-                    if (!entry.feature && entry.gene) entry.feature = entry.gene;
-                    if (entry.geneCleared && entry.featureCleared === undefined) entry.featureCleared = true;
 
                     if (entry.source === 'annotation') {{
                         if (!catCols.length) {{
@@ -35257,63 +34706,6 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 '''
 
 
-def _legacy_export_kwargs_shim(func):
-    """Back-compat wrapper for pre-migration ``export_to_html`` keyword names.
-
-    The gene->feature / marker->pseudobulk API migration renamed or removed many
-    parameters; the bundled example scripts still call the old names. This shim
-    remaps the recoverable ones and warns-and-drops the rest so existing callers
-    keep working. It is intentionally lenient — remove it once callers migrate.
-    """
-    import functools
-    import inspect
-    import warnings as _warnings
-
-    _RENAMES = {
-        "color": "main_cell_annotation",
-        "additional_colors": "cell_annotations",
-        "genes": "features",
-        "gene_encoding": "feature_encoding",
-        "gene_value_encoding": "feature_value_encoding",
-        "gene_storage": "feature_storage",
-        "gene_aux_path": "feature_manifest_path",
-        "gene_manifest_path": "feature_manifest_path",
-        "gene_sidecar_shard_size": "feature_sidecar_shard_size",
-        "gene_sparse_zero_threshold": "feature_sparse_zero_threshold",
-        "neighbor_stats_groupby": "neighbor_stats_annotations",
-        "cluster_de_groupby": "pseudobulk_additional_annotations",
-        "pseudobulk_de_annotations": "pseudobulk_additional_annotations",
-        "marker_gene_annotations": "pseudobulk_additional_annotations",
-        "interaction_marker_annotations": "interaction_markers",
-    }
-    _accepted = set(inspect.signature(func).parameters)
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        out = {}
-        dropped = []
-        for key, value in kwargs.items():
-            if key in _accepted:
-                out.setdefault(key, value)
-                continue
-            new_key = _RENAMES.get(key)
-            if new_key and new_key in _accepted and new_key not in out:
-                out[new_key] = value
-            else:
-                dropped.append(key)
-        if dropped:
-            _warnings.warn(
-                "export_to_html: ignoring legacy keyword(s) removed in the "
-                "gene->feature/pseudobulk API migration: "
-                + ", ".join(sorted(dropped)),
-                stacklevel=2,
-            )
-        return func(*args, **out)
-
-    return wrapper
-
-
-@_legacy_export_kwargs_shim
 def export_to_html(
     dataset: SpatialDataset,
     output_path: str,
@@ -35388,7 +34780,7 @@ def export_to_html(
         Path for output HTML file, or a `.karospace` package when
         `feature_storage="sidecar"`.
     main_cell_annotation : str
-        Main cell annotation column or gene name shown first in the viewer
+        Main cell annotation column or feature name shown first in the viewer
     title : str
         Page title
     min_panel_size : int
@@ -35412,20 +34804,20 @@ def export_to_html(
     cell_annotations : list, optional
         Additional cell obs columns to include for annotation switching.
     features : list, optional
-        Feature names to include for expression visualization
+        Feature names to include for visualization
     features_list : str or Path, optional
-        Text file containing one feature/gene name per line. Values are
+        Text file containing one feature name per line. Values are
         appended to `features`, then deduplicated while preserving order.
     feature_encoding : str
         "dense", "sparse", or "auto" (default). "auto" uses sparse encoding for
-        zero-inflated genes to reduce HTML size.
+        zero-inflated feature matrices to reduce HTML size.
     feature_value_encoding : str
         Only used for sidecar/package features. "uint16" (default) and "uint8"
         store linearly quantized values using each feature's exported vmin/vmax range.
     feature_storage : str
         "embedded" (default) keeps requested/top DE feature vectors in
         the HTML. "sidecar" embeds no feature vectors in the HTML and
-        writes all default-modality features to sidecar shards for lazy loading.
+        writes all selected-modality features to sidecar shards for lazy loading.
         `.karospace` package export requires `"sidecar"`.
     feature_manifest_path : str, optional
         Output path for the sidecar feature JSON when feature_storage="sidecar".
@@ -35436,20 +34828,19 @@ def export_to_html(
         Only used when feature_encoding="auto". Use sparse encoding when the
         fraction of zeros is >= this threshold (default: 0.8).
     gene_correlation_top_n : int
-        Number of top correlated genes to show per embedded gene (default 5). Set to 0 to disable.
+        Number of top correlated features to show per embedded feature (default 5). Set to 0 to disable.
     category_means_n_genes : int
-        Maximum embedded pseudobulk-DE genes to expose in category mean summaries
-        (default 500). These means power the Genes -> Means tab and the lasso
+        Maximum embedded pseudobulk-DE features to expose in category mean summaries
+        (default 500). These means power the Features -> Means tab and the lasso
         selection summary. Set to 0 to disable.
     spatial_variable_genes_n : int
-        Number of top variable genes to score with Moran's I spatial autocorrelation
+        Number of top variable features to score with Moran's I spatial autocorrelation
         (default 20). Requires a spatial weight matrix in adata.obsp. Set to 0 to disable.
     pseudobulk : str, optional
         Category pseudobulk DE mode. Use "auto" to analyze the main cells annotation and
         pseudobulk_additional_annotations, or None/"None" to disable.
     pseudobulk_additional_annotations : list, optional
-        Additional annotation columns to analyze with category pseudobulk DE and
-        interaction pseudobulk DE when their modes are enabled.
+        Additional annotation columns to analyze with category pseudobulk DE.
     pseudobulk_replicate_annotation : str, optional
         Obs annotation used as the biological replicate for pseudobulk analyses.
         Defaults to the dataset section_key annotation.
@@ -35470,7 +34861,7 @@ def export_to_html(
         Exclude cells below this total raw-count threshold before pseudobulk
         aggregation. Zero disables filtering.
     pseudobulk_min_gene_counts : int
-        Exclude genes below this total raw pseudobulk-count threshold in the
+        Exclude features below this total raw pseudobulk-count threshold in the
         shared DESeq2 fit. Zero disables filtering.
     pseudobulk_min_cells_per_pseudobulk : int
         Minimum cells required in each replicate x annotation pseudobulk sample
@@ -35480,7 +34871,7 @@ def export_to_html(
         contrast.
         Pseudobulk DE always requires at least two replicates.
     pseudobulk_min_pct_expressed : float
-        Minimum fraction of cells expressing a gene required in at least one
+        Minimum fraction of cells with a positive feature value required in at least one
         compared group before DE results are reported. Values > 1 are interpreted as
         percentages.
     pseudobulk_p_adjust_method : str
@@ -35495,9 +34886,13 @@ def export_to_html(
         Number of CPU workers used for the shared PyDESeq2 fit and the maximum
         number of parallel shared-fit contrasts. Must be at least one.
     pseudobulk_embed_top_n_per_comparison : int
-        Maximum significant DE genes to auto-embed per category or contact
-        comparison in embedded mode. Ignored in sidecar mode, where all gene
-        expression vectors are written to the sidecar.
+        Maximum significant DE features to auto-embed per category or contact
+        comparison in embedded mode. Ignored in sidecar mode, where all feature
+        vectors are written to the sidecar.
+    modalities : list, optional
+        Feature modalities to expose in the viewer. By default, embedded storage
+        exports only the default modality; sidecar storage exports all detected
+        modalities. Explicit non-default modalities are skipped in embedded mode.
     pathway_gmt : str or list, optional
         GMT pathway file(s) used for ORA and preranked GSEA. When omitted,
         KaroSpace loads a bundled or cached default Reactome GMT when
@@ -35515,7 +34910,8 @@ def export_to_html(
         Pathway comparisons are processed sequentially.
     neighbor_stats_annotations : list, optional
         Obs columns to compute neighbor composition stats for (categorical only).
-        If None/empty, neighbor stats are not computed.
+        If None, the exporter computes them for the main cells annotation plus
+        cell_annotations. Empty disables unless needed by enabled interaction markers.
     neighbor_stats_permutations : int
         Number of permutations for neighbor enrichment z-scores (0 disables)
     neighbor_stats_seed : int
@@ -35523,7 +34919,7 @@ def export_to_html(
     interaction_markers_top_targets : int
         Number of target categories to evaluate per source.
     interaction_markers_top_genes : int
-        Number of top DE genes to keep per source-target interaction.
+        Number of top DE features to keep per source-target interaction.
     interaction_markers_min_cells : int
         Minimum cells required per replicate in both contact+ and contact-
         pseudobulk samples.
@@ -35531,7 +34927,7 @@ def export_to_html(
         Minimum target neighbors to classify source cells as contact+.
     interaction_markers : str, optional
         Contact-conditioned interaction marker mode. Use "auto" to analyze the
-        main cells annotation and pseudobulk_additional_annotations, or None/"None" to disable.
+        main cells annotation and cell_annotations, or None/"None" to disable.
     section_rotations : mapping, optional
         Optional mapping of section_id -> initial rotation angle in degrees.
         Angles are stored exactly (normalized modulo 360) for the interactive viewer.
@@ -35636,18 +35032,11 @@ def export_to_html(
     selected_modalities = _normalize_modality_selection(
         modalities,
         option_name="modalities",
-        default_to_all=True,
+        default_to_all=(feature_storage == "sidecar"),
     )
     if default_modality_name in available_modalities and default_modality_name not in selected_modalities:
         selected_modalities.insert(0, default_modality_name)
     extra_modalities = [m for m in selected_modalities if m != default_modality_name]
-    if extra_modalities and feature_storage != "sidecar":
-        log_warning(
-            f"extra modalities {extra_modalities} require feature_storage='sidecar'; "
-            "skipping them in embedded mode."
-        )
-        selected_modalities = [m for m in selected_modalities if m == default_modality_name]
-        extra_modalities = []
     requested_feature_modalities = list(selected_modalities)
 
     def _features_for_modality(modality_name: str) -> List[str]:
@@ -35687,7 +35076,12 @@ def export_to_html(
         requested_feature_modalities,
     )
     requested_features = list(requested_features_by_modality.get(default_modality_name, []))
-    embedded_features = [] if feature_storage == "sidecar" else list(requested_features)
+    requested_embedding_features = [
+        feature
+        for modality_features in requested_features_by_modality.values()
+        for feature in modality_features
+    ]
+    embedded_features = [] if feature_storage == "sidecar" else list(requested_embedding_features)
     effective_pseudobulk_embed_top_n_per_comparison = (
         0 if feature_storage == "sidecar" else int(pseudobulk_embed_top_n_per_comparison)
     )
@@ -35814,17 +35208,22 @@ def export_to_html(
         if col and col not in pseudobulk_analysis_annotations:
             pseudobulk_analysis_annotations.append(col)
     pseudobulk_de_annotations = list(pseudobulk_analysis_annotations) if pseudobulk_enabled else []
-    interaction_marker_annotations = list(pseudobulk_analysis_annotations) if interaction_markers_enabled else []
+    interaction_annotation_candidates = []
+    for col in [annotation, *(cell_annotations or [])]:
+        if col and col not in interaction_annotation_candidates:
+            interaction_annotation_candidates.append(col)
+    interaction_marker_annotations = (
+        list(interaction_annotation_candidates) if interaction_markers_enabled else []
+    )
     analytics_annotations = list(pseudobulk_de_annotations)
     analytics_annotations.extend(
         col for col in interaction_marker_annotations if col and col not in analytics_annotations
     )
     if neighbor_stats_annotations is None:
-        neighbor_stats_annotations = list(analytics_annotations)
-        if cell_annotations:
-            neighbor_stats_annotations.extend(
-                col for col in cell_annotations if col and col not in neighbor_stats_annotations
-            )
+        neighbor_stats_annotations = []
+        for col in [*interaction_annotation_candidates, *analytics_annotations]:
+            if col and col not in neighbor_stats_annotations:
+                neighbor_stats_annotations.append(col)
     else:
         neighbor_stats_annotations = list(neighbor_stats_annotations)
         neighbor_stats_annotations.extend(
@@ -35982,7 +35381,7 @@ def export_to_html(
             level=2,
         )
         log_detail(
-            "GSEA ranked genes: all retained genes per contrast after model and % expression filtering.",
+            "GSEA ranked genes: all retained genes per contrast after model and percent-detected filtering.",
             level=2,
         )
         log_detail(
@@ -36083,11 +35482,6 @@ def export_to_html(
                     "reason": "unsupported_modality",
                     "modality": pathway_modality_name,
                 }
-                log_detail(
-                    f"Skipping pathway enrichment for modality {pathway_modality_name} "
-                    "(not gene-compatible).",
-                    level=2,
-                )
                 continue
             log_detail(f"Pathway modality: {pathway_modality_name}.", level=2)
             pathway_settings_by_modality[pathway_modality_name] = add_pathway_enrichment_to_pseudobulk_de(
@@ -36105,6 +35499,8 @@ def export_to_html(
             settings = pathway_settings_by_modality.get(pathway_modality_name) or {}
             if not settings.get("available"):
                 reason = settings.get("reason") or "unavailable"
+                if reason == "unsupported_modality":
+                    continue
                 error = settings.get("error")
                 log_warning(
                     f"pathway enrichment unavailable for modality {pathway_modality_name} "
@@ -36115,7 +35511,7 @@ def export_to_html(
                     f"Stored pathway enrichment for modality {pathway_modality_name}: "
                     f"{int(settings.get('enriched_comparisons') or 0):,}/"
                     f"{int(settings.get('comparisons') or 0):,} pseudobulk comparisons.",
-                    level=2,
+                    level=1,
                 )
     except Exception as exc:
         pathway_settings_by_modality = dict(data.get("pathway_settings_by_modality") or {})
@@ -36424,15 +35820,22 @@ def export_to_html(
                     dynamic_ncols=True,
                 )
         manifest = {
-            "format": "karospace-feature-sidecar-manifest-v3",
+            "format": "karospace-feature-sidecar-manifest-v4",
             "feature_sidecar_format": FEATURE_SIDECAR_FORMAT_BINARY,
+            "feature_count": total_sidecar_features,
+            "modalities": {},
+        }
+        default_entry: Dict[str, Any] = {
             "shards": {},
             "features_meta": {},
             "feature_encodings": {},
             "feature_value_encodings": {},
             "feature_to_shard": {},
+            "value_kind": "counts",
+            "label": default_modality_name,
             "section_order": [section.section_id for section in dataset.sections],
         }
+        manifest["modalities"][default_modality_name] = default_entry
         output_parent = Path(output_path).resolve().parent
         section_cell_counts = {
             section_id: int(len(indices))
@@ -36464,20 +35867,20 @@ def export_to_html(
                 feature_value_encoding=feature_value_encoding,
                 feature_sparse_zero_threshold=feature_sparse_zero_threshold,
             )
-            manifest["shards"][shard_rel] = shard_features
+            default_entry["shards"][shard_rel] = shard_features
             for gene in shard_features:
-                manifest["feature_to_shard"][gene] = shard_rel
+                default_entry["feature_to_shard"][gene] = shard_rel
                 if gene in shard_data.get("features_meta", {}):
-                    manifest["features_meta"][gene] = shard_data["features_meta"][gene]
+                    default_entry["features_meta"][gene] = shard_data["features_meta"][gene]
                 if gene in shard_data.get("feature_encodings", {}):
-                    manifest["feature_encodings"][gene] = shard_data["feature_encodings"][gene]
+                    default_entry["feature_encodings"][gene] = shard_data["feature_encodings"][gene]
                 if gene in shard_data.get("feature_value_encodings", {}):
-                    manifest["feature_value_encodings"][gene] = shard_data["feature_value_encodings"][gene]
+                    default_entry["feature_value_encodings"][gene] = shard_data["feature_value_encodings"][gene]
             _write_binary_feature_shard(
                 shard_path=shard_path,
                 shard_features=shard_features,
                 shard_data=shard_data,
-                section_order=manifest["section_order"],
+                section_order=default_entry["section_order"],
                 section_cell_counts=section_cell_counts,
             )
             features_written += len(shard_features)
@@ -36496,19 +35899,6 @@ def export_to_html(
         if progress is not None:
             progress.close()
             progress = None
-        # Mirror RNA fields under manifest.modalities for forward-compat.
-        manifest["modalities"] = {
-            default_modality_name: {
-                "shards": dict(manifest["shards"]),
-                "features_meta": dict(manifest["features_meta"]),
-                "feature_encodings": dict(manifest["feature_encodings"]),
-                "feature_value_encodings": dict(manifest["feature_value_encodings"]),
-                "feature_to_shard": dict(manifest["feature_to_shard"]),
-                "value_kind": "counts",
-                "section_order": list(manifest["section_order"]),
-            }
-        }
-
         # Per-modality shard writes for non-default modalities.
         for mod_name in extra_modalities:
             mod = dataset.modalities[mod_name]
@@ -36568,10 +35958,6 @@ def export_to_html(
                 )
             manifest["modalities"][mod_name] = mod_entry
 
-        # Bump format only when extra modalities are actually present.
-        if extra_modalities:
-            manifest["format"] = "karospace-feature-sidecar-manifest-v4"
-
         with open(resolved_feature_manifest_path, "w", encoding="utf-8") as f:
             json.dump(manifest, f, separators=(",", ":"))
         if package_mode:
@@ -36624,23 +36010,37 @@ def export_to_html(
     else:
         log_detail(f"Spot size: {resolved_spot_size:.2f}.")
     log_detail(f"Annotation options: {len(data['available_annotations'])}")
-    if embedded_features:
-        default_feature_state = (
-            (data.get("feature_state_by_modality") or {}).get(default_modality_name)
-            or {}
-        )
-        log_detail(
-            "Features embedded in HTML "
-            f"({default_modality_name}): {len(default_feature_state.get('features_meta') or {})}"
-        )
-        enc = default_feature_state.get("feature_encodings") or {}
-        if enc:
-            n_sparse = sum(1 for v in enc.values() if v == "sparse")
-            n_dense = sum(1 for v in enc.values() if v == "dense")
+    feature_state_by_modality = data.get("feature_state_by_modality") or {}
+    embedded_feature_counts = []
+    embedded_feature_encodings = {}
+    for modality_name in selected_modalities:
+        state = feature_state_by_modality.get(modality_name) or {}
+        features_meta = state.get("features_meta") or {}
+        if not features_meta:
+            continue
+        embedded_feature_counts.append((modality_name, len(features_meta)))
+        embedded_feature_encodings.update(state.get("feature_encodings") or {})
+    if embedded_feature_counts:
+        total_embedded_features = sum(count for _modality_name, count in embedded_feature_counts)
+        if len(embedded_feature_counts) == 1:
+            modality_name, count = embedded_feature_counts[0]
+            log_detail(f"Features embedded in HTML ({modality_name}): {count:,}")
+        else:
+            count_text = ", ".join(
+                f"{modality_name}={count:,}"
+                for modality_name, count in embedded_feature_counts
+            )
+            log_detail(
+                f"Features embedded in HTML: {count_text} "
+                f"(total {total_embedded_features:,})."
+            )
+        if embedded_feature_encodings:
+            n_sparse = sum(1 for v in embedded_feature_encodings.values() if v == "sparse")
+            n_dense = sum(1 for v in embedded_feature_encodings.values() if v == "dense")
             log_detail(f"Embedded feature encoding: {n_sparse} sparse, {n_dense} dense.")
     if feature_manifest_url:
         if not embedded_features:
-            log_detail("Features embedded in HTML: 0; expression is sidecar-only.")
+            log_detail("Features embedded in HTML: 0; feature values are sidecar-only.")
         log_detail(f"Sidecar features available via: {feature_manifest_url}")
         log_detail("Sidecar viewers must be opened over HTTP(S) with the .features.json file and .features/ directory next to the HTML.")
         log_detail(f"Sidecar format: {FEATURE_SIDECAR_FORMAT_BINARY}")

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -35373,8 +35373,16 @@ def export_to_html(
         deconvolutions=deconvolutions,
     )
     data["scalebar_unit"] = str(scalebar_unit or "μm")
-    embedded_features = [] if feature_storage == "sidecar" else list(data.get("available_features") or embedded_features)
-    data["embedded_features"] = list(embedded_features)
+    embedded_features_by_modality = dict(data.get("embedded_features_by_modality") or {})
+    if feature_storage == "sidecar":
+        embedded_features = []
+    else:
+        embedded_features = list(
+            embedded_features_by_modality.get(default_modality_name)
+            or embedded_features
+        )
+    embedded_features_by_modality.setdefault(default_modality_name, list(embedded_features))
+    data["embedded_features_by_modality"] = embedded_features_by_modality
     if feature_storage == "sidecar":
         sidecar_features = list(dataset.var_names)
     original_total_cells = int(dataset.adata.n_obs)
@@ -35533,8 +35541,14 @@ def export_to_html(
                     level=2,
                 )
 
-        data["pathway_settings"] = add_pathway_enrichment_to_pseudobulk_de(
-            data.get("pseudobulk_de"),
+        pathway_modality_name = (
+            selected_pseudobulk_modalities[0]
+            if selected_pseudobulk_modalities
+            else default_modality_name
+        )
+        pathway_settings_by_modality = dict(data.get("pathway_settings_by_modality") or {})
+        pathway_settings_by_modality[pathway_modality_name] = add_pathway_enrichment_to_pseudobulk_de(
+            (data.get("pseudobulk_de_by_modality") or {}).get(pathway_modality_name),
             pathway_gmt=pathway_gmt,
             top_n=int(pathway_top_n),
             min_overlap=int(pathway_min_overlap),
@@ -35543,28 +35557,35 @@ def export_to_html(
             n_cpus=1,
             progress_callback=_log_pathway_progress,
         )
-        if not data["pathway_settings"].get("available"):
-            reason = data["pathway_settings"].get("reason") or "unavailable"
-            error = data["pathway_settings"].get("error")
+        data["pathway_settings_by_modality"] = pathway_settings_by_modality
+        if not pathway_settings_by_modality[pathway_modality_name].get("available"):
+            reason = pathway_settings_by_modality[pathway_modality_name].get("reason") or "unavailable"
+            error = pathway_settings_by_modality[pathway_modality_name].get("error")
             log_warning(f"pathway enrichment unavailable ({reason}{': ' + error if error else ''}).")
         else:
             log_detail(
                 f"Stored pathway enrichment for "
-                f"{int(data['pathway_settings'].get('enriched_comparisons') or 0):,}/"
-                f"{int(data['pathway_settings'].get('comparisons') or 0):,} pseudobulk comparisons.",
+                f"{int(pathway_settings_by_modality[pathway_modality_name].get('enriched_comparisons') or 0):,}/"
+                f"{int(pathway_settings_by_modality[pathway_modality_name].get('comparisons') or 0):,} pseudobulk comparisons.",
                 level=2,
             )
     except Exception as exc:
-        data["pathway_settings"] = {
+        pathway_modality_name = (
+            selected_pseudobulk_modalities[0]
+            if selected_pseudobulk_modalities
+            else default_modality_name
+        )
+        pathway_settings_by_modality = dict(data.get("pathway_settings_by_modality") or {})
+        pathway_settings_by_modality[pathway_modality_name] = {
             "available": False,
             "reason": "pathway_enrichment_failed",
             "error": str(exc),
         }
+        data["pathway_settings_by_modality"] = pathway_settings_by_modality
         log_warning(f"pathway enrichment failed ({exc}).")
 
     if feature_storage == "sidecar":
         assert resolved_feature_manifest_path is not None
-        data["available_features"] = list(dataset.var_names)
         data["feature_manifest_url"] = Path(
             os.path.relpath(resolved_feature_manifest_path, start=requested_output_path.resolve().parent)
         ).as_posix()
@@ -35590,6 +35611,10 @@ def export_to_html(
     data["features_by_modality"] = features_by_modality
     data["requested_features_by_modality"] = requested_features_by_modality
     data["default_modality"] = default_modality_name if modality_descriptors else None
+    data.setdefault("category_feature_means_by_modality", {})
+    data.setdefault("feature_correlations_by_modality", {})
+    data.setdefault("spatial_variable_features_by_modality", {})
+    data.setdefault("pathway_settings_by_modality", {})
 
     if int(spatial_variable_genes_n) > 0:
         log_step("Computing spatially variable genes")
@@ -35598,12 +35623,16 @@ def export_to_html(
             f"on the full input cell set ({int(dataset.adata.n_obs):,} cells); "
             "output feeds Insights > Exploration > Genes > Spatial."
         )
-        data["spatial_variable_genes"] = _compute_morans_i(
+        data["spatial_variable_features_by_modality"][default_modality_name] = _compute_morans_i(
             dataset.adata, list(dataset.var_names), n_genes=int(spatial_variable_genes_n)
         )
-        log_detail(f"Stored {len(data['spatial_variable_genes'])} spatially variable gene rows.")
+        log_detail(
+            "Stored "
+            f"{len(data['spatial_variable_features_by_modality'].get(default_modality_name) or [])} "
+            "spatially variable feature rows."
+        )
     else:
-        data["spatial_variable_genes"] = []
+        data["spatial_variable_features_by_modality"][default_modality_name] = []
 
     category_gene_means_for_correlations = None
     if int(category_means_n_genes) > 0 and embedded_features:
@@ -35613,20 +35642,20 @@ def export_to_html(
             "pseudobulk analysis; output feeds Insights > Exploration > "
             "Genes > Distribution > Per sample."
         )
-        data["category_gene_means"] = _category_gene_means_from_pseudobulk_de(
-            data.get("pseudobulk_de"),
+        data["category_feature_means_by_modality"][default_modality_name] = _category_gene_means_from_pseudobulk_de(
+            (data.get("pseudobulk_de_by_modality") or {}).get(default_modality_name),
             embedded_features,
             int(category_means_n_genes),
         )
-        category_gene_means_for_correlations = data["category_gene_means"]
+        category_gene_means_for_correlations = data["category_feature_means_by_modality"][default_modality_name]
         mean_rows = sum(
             len((col_data or {}).get("means") or {})
-            for col_data in ((data["category_gene_means"] or {}).get("columns") or {}).values()
+            for col_data in ((category_gene_means_for_correlations or {}).get("columns") or {}).values()
             if isinstance(col_data, dict)
         )
         log_detail(f"Stored category mean payload for {mean_rows} category entries.")
     else:
-        data["category_gene_means"] = None
+        data["category_feature_means_by_modality"][default_modality_name] = None
 
     if int(gene_correlation_top_n) > 0 and embedded_features:
         log_step("Computing gene correlations from category means")
@@ -35634,7 +35663,7 @@ def export_to_html(
         available_mean_count = len((category_gene_means_for_correlations or {}).get("genes") or [])
         if required_gene_count and available_mean_count < required_gene_count:
             category_gene_means_for_correlations = _category_gene_means_from_pseudobulk_de(
-                data.get("pseudobulk_de"),
+                (data.get("pseudobulk_de_by_modality") or {}).get(default_modality_name),
                 embedded_features,
                 required_gene_count,
             )
@@ -35647,14 +35676,17 @@ def export_to_html(
             "using pseudobulk-derived category means; output feeds gene discovery "
             "related-gene suggestions."
         )
-        data["gene_correlations"] = _compute_gene_correlations_from_category_means(
+        data["feature_correlations_by_modality"][default_modality_name] = _compute_gene_correlations_from_category_means(
             category_gene_means_for_correlations,
             embedded_features,
             top_n=int(gene_correlation_top_n),
         )
-        log_detail(f"Stored correlations for {len(data['gene_correlations'])} genes.")
+        log_detail(
+            "Stored correlations for "
+            f"{len(data['feature_correlations_by_modality'].get(default_modality_name) or {})} features."
+        )
     else:
-        data["gene_correlations"] = {}
+        data["feature_correlations_by_modality"][default_modality_name] = {}
 
     resolved_spot_size, used_auto_spot_size = _resolve_spot_size(
         dataset=dataset,
@@ -35793,10 +35825,16 @@ def export_to_html(
             "resolved": {
                 "output_path": str(final_output_path),
                 "feature_manifest_url": feature_manifest_url,
-                "embedded_features": list(embedded_features),
+                "embedded_features_by_modality": embedded_features_by_modality,
                 "requested_features_by_modality": requested_features_by_modality,
-                "embedded_feature_count": len(embedded_features),
-                "available_feature_count": len(data.get("available_features") or []),
+                "embedded_feature_count_by_modality": {
+                    modality_name: len(features or [])
+                    for modality_name, features in embedded_features_by_modality.items()
+                },
+                "available_feature_count_by_modality": {
+                    modality_name: len(features or [])
+                    for modality_name, features in (data.get("features_by_modality") or {}).items()
+                },
                 "available_annotations": list(data.get("available_annotations") or []),
                 "section_metadata": list(data.get("section_metadata") or []),
                 "section_metadata_extra": list(data.get("section_metadata_extra") or []),
@@ -35805,7 +35843,7 @@ def export_to_html(
                 "pseudobulk_modalities": list(selected_pseudobulk_modalities),
                 "pseudobulk_replicate_annotation": data.get("pseudobulk_replicate_annotation"),
                 "pseudobulk_settings": data.get("pseudobulk_settings"),
-                "pathway_settings": data.get("pathway_settings"),
+                "pathway_settings_by_modality": data.get("pathway_settings_by_modality"),
                 "neighbor_stats_annotations": list(neighbor_stats_annotations or []),
                 "interaction_marker_annotations": list(interaction_marker_annotations),
                 "downsample": data.get("downsample"),
@@ -36113,12 +36151,19 @@ def export_to_html(
         log_detail(f"Spot size: {resolved_spot_size:.2f}.")
     log_detail(f"Annotation options: {len(data['available_annotations'])}")
     if embedded_features:
-        log_detail(f"Genes embedded in HTML: {len(data['features_meta'])}")
-        enc = data.get("feature_encodings") or {}
+        default_feature_state = (
+            (data.get("feature_state_by_modality") or {}).get(default_modality_name)
+            or {}
+        )
+        log_detail(
+            "Features embedded in HTML "
+            f"({default_modality_name}): {len(default_feature_state.get('features_meta') or {})}"
+        )
+        enc = default_feature_state.get("feature_encodings") or {}
         if enc:
             n_sparse = sum(1 for v in enc.values() if v == "sparse")
             n_dense = sum(1 for v in enc.values() if v == "dense")
-            log_detail(f"Embedded gene encoding: {n_sparse} sparse, {n_dense} dense.")
+            log_detail(f"Embedded feature encoding: {n_sparse} sparse, {n_dense} dense.")
     if feature_manifest_url:
         if not embedded_features:
             log_detail("Features embedded in HTML: 0; expression is sidecar-only.")

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -7739,10 +7739,40 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         || (MODALITY_DESCRIPTORS[0]?.name)
         || 'rna';
     const MODULE_MODALITY_NAME = 'module';
-    let CURRENT_MODALITY = DEFAULT_MODALITY_NAME;
+    const PANEL_MODALITY_STATE = {{
+        visual: DEFAULT_MODALITY_NAME,
+        exploration: DEFAULT_MODALITY_NAME,
+        pseudobulk: DEFAULT_MODALITY_NAME,
+        interactions: DEFAULT_MODALITY_NAME,
+        split: {{
+            a: DEFAULT_MODALITY_NAME,
+            b: DEFAULT_MODALITY_NAME,
+        }},
+    }};
+    function getPanelModality(panelName, fallback = DEFAULT_MODALITY_NAME) {{
+        const key = String(panelName || '').trim();
+        if (!key) return fallback || DEFAULT_MODALITY_NAME || 'rna';
+        if (key === 'split.a') return PANEL_MODALITY_STATE.split?.a || fallback || DEFAULT_MODALITY_NAME || 'rna';
+        if (key === 'split.b') return PANEL_MODALITY_STATE.split?.b || fallback || DEFAULT_MODALITY_NAME || 'rna';
+        return PANEL_MODALITY_STATE[key] || fallback || DEFAULT_MODALITY_NAME || 'rna';
+    }}
+    function setPanelModality(panelName, modality) {{
+        const key = String(panelName || '').trim();
+        const value = String(modality || DEFAULT_MODALITY_NAME || 'rna').trim() || DEFAULT_MODALITY_NAME || 'rna';
+        if (key === 'split.a') PANEL_MODALITY_STATE.split.a = value;
+        else if (key === 'split.b') PANEL_MODALITY_STATE.split.b = value;
+        else if (key) PANEL_MODALITY_STATE[key] = value;
+        return value;
+    }}
+    function getVisualModality() {{
+        return getPanelModality('visual');
+    }}
+    function setVisualModality(modality) {{
+        return setPanelModality('visual', modality);
+    }}
 
     function getActiveModalityDescriptor() {{
-        return MODALITY_DESCRIPTORS.find(d => d && d.name === CURRENT_MODALITY) || null;
+        return MODALITY_DESCRIPTORS.find(d => d && d.name === getVisualModality()) || null;
     }}
     function uniqueSortedFeatures(features) {{
         const seen = new Set();
@@ -7764,11 +7794,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             sections: raw.sections && typeof raw.sections === 'object' ? raw.sections : {{}},
         }};
     }}
-    function normalizeFeatureModalityName(modality = CURRENT_MODALITY) {{
-        const name = String(modality || CURRENT_MODALITY || DEFAULT_MODALITY_NAME || 'rna').trim();
+    function normalizeFeatureModalityName(modality = getVisualModality()) {{
+        const name = String(modality || getVisualModality() || DEFAULT_MODALITY_NAME || 'rna').trim();
         return name || DEFAULT_MODALITY_NAME || 'rna';
     }}
-    function getFeatureState(modality = CURRENT_MODALITY) {{
+    function getFeatureState(modality = getVisualModality()) {{
         const name = normalizeFeatureModalityName(modality);
         if (!FEATURE_STATE_BY_MODALITY[name]) {{
             FEATURE_STATE_BY_MODALITY[name] = normalizeFeatureState(null);
@@ -7777,7 +7807,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
         return FEATURE_STATE_BY_MODALITY[name];
     }}
-    function getFeatureSectionPayload(sectionOrId, modality = CURRENT_MODALITY) {{
+    function getFeatureSectionPayload(sectionOrId, modality = getVisualModality()) {{
         const sectionId = typeof sectionOrId === 'string'
             ? sectionOrId
             : String(sectionOrId?.id || '');
@@ -7798,7 +7828,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             features_sparse: payload?.features_sparse || payload?.genes_sparse || {{}},
         }};
     }}
-    function getFeatureSectionList(modality = CURRENT_MODALITY) {{
+    function getFeatureSectionList(modality = getVisualModality()) {{
         return (DATA.sections || []).map((section) => {{
             const payload = getFeatureSectionPayload(section, modality);
             return Object.assign({{}}, section, {{
@@ -7807,11 +7837,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }});
         }});
     }}
-    function getLoadedFeaturesForModality(modality = CURRENT_MODALITY) {{
+    function getLoadedFeaturesForModality(modality = getVisualModality()) {{
         const state = getFeatureState(modality);
         return Object.keys(state.features_meta || {{}}).sort((a, b) => a.localeCompare(b));
     }}
-    function getFeatureCatalog(modality = CURRENT_MODALITY) {{
+    function getFeatureCatalog(modality = getVisualModality()) {{
         if (isModuleModality(modality)) return uniqueSortedFeatures(getGeneModuleDatalistValues());
         const modalityFeatures = FEATURES_BY_MODALITY?.[modality];
         if (Array.isArray(modalityFeatures) && modalityFeatures.length) {{
@@ -7819,11 +7849,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
         return getLoadedFeaturesForModality(modality);
     }}
-    function getAvailableFeaturesForModality(modality = CURRENT_MODALITY) {{
+    function getAvailableFeaturesForModality(modality = getVisualModality()) {{
         return getFeatureCatalog(modality);
     }}
     function getActiveFeatureList() {{
-        return getFeatureCatalog(CURRENT_MODALITY);
+        return getFeatureCatalog(getVisualModality());
     }}
     function isModuleModality(modality) {{
         return String(modality || '').trim().toLowerCase() === MODULE_MODALITY_NAME;
@@ -7834,7 +7864,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return modDesc?.label || (modality === 'gene' ? 'Gene' : String(modality || 'Gene'));
     }}
     function getGeneInputFeatureList() {{
-        return uniqueSortedFeatures(getLoadedFeaturesForModality(CURRENT_MODALITY));
+        return uniqueSortedFeatures(getLoadedFeaturesForModality(getVisualModality()));
     }}
     function populateGeneInputDatalist() {{
         const geneListEl = document.getElementById('gene-list');
@@ -7848,7 +7878,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         geneListEl.replaceChildren(fragment);
         refreshLoadedGeneFilterDropdowns();
     }}
-    function getEmbeddedFeatureSet(modality = CURRENT_MODALITY) {{
+    function getEmbeddedFeatureSet(modality = getVisualModality()) {{
         const embeddedByModality = DATA.embedded_features_by_modality && typeof DATA.embedded_features_by_modality === 'object'
             ? DATA.embedded_features_by_modality
             : {{}};
@@ -7857,14 +7887,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             : getLoadedFeaturesForModality(modality);
         return new Set(embedded.map(feature => String(feature)));
     }}
-    function isEmbeddedViewerFeature(feature, modality = CURRENT_MODALITY) {{
+    function isEmbeddedViewerFeature(feature, modality = getVisualModality()) {{
         const raw = String(feature || '').trim();
         if (!raw) return false;
         const canonical = resolveCanonicalFeatureName(raw, modality);
         const embedded = getEmbeddedFeatureSet(modality);
         return embedded.has(raw) || (!!canonical && embedded.has(canonical));
     }}
-    function isSidecarViewerFeature(feature, modality = CURRENT_MODALITY) {{
+    function isSidecarViewerFeature(feature, modality = getVisualModality()) {{
         if (!DATA.feature_manifest_url) return false;
         const raw = String(feature || '').trim();
         if (!raw) return false;
@@ -7872,7 +7902,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const available = new Set(getFeatureCatalog(modality).map(g => String(g)));
         return available.has(raw) || (!!canonical && available.has(canonical));
     }}
-    function isViewerFeatureLoadable(feature, modality = CURRENT_MODALITY) {{
+    function isViewerFeatureLoadable(feature, modality = getVisualModality()) {{
         return isEmbeddedViewerFeature(feature, modality) || isSidecarViewerFeature(feature, modality);
     }}
     function getCategoryVsRestGenes(annotationCol = explorationColorCol || currentAnnotation || '') {{
@@ -7931,7 +7961,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const value = String(document.getElementById('marker-gene-search')?.value || '').trim();
         return value ? (resolveCanonicalFeatureName(value) || value) : '';
     }}
-    function getFeatureDatalistValuesForModality(modality = CURRENT_MODALITY) {{
+    function getFeatureDatalistValuesForModality(modality = getVisualModality()) {{
         if (isModuleModality(modality)) return uniqueSortedFeatures(getGeneModuleDatalistValues());
         const base = getLoadedFeaturesForModality(modality);
         return uniqueSortedFeatures(base);
@@ -7942,7 +7972,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     const FEATURE_INDEX_BY_MODALITY = new Map();
-    function buildFeatureIndex(modality = CURRENT_MODALITY) {{
+    function buildFeatureIndex(modality = getVisualModality()) {{
         const name = normalizeFeatureModalityName(modality);
         const catalog = getFeatureCatalog(name);
         return {{
@@ -7950,7 +7980,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             byLower: new Map(catalog.map(feature => [String(feature).toLowerCase(), feature])),
         }};
     }}
-    function getFeatureIndex(modality = CURRENT_MODALITY) {{
+    function getFeatureIndex(modality = getVisualModality()) {{
         const name = normalizeFeatureModalityName(modality);
         if (!FEATURE_INDEX_BY_MODALITY.has(name)) {{
             FEATURE_INDEX_BY_MODALITY.set(name, buildFeatureIndex(name));
@@ -7965,10 +7995,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
     }}
     function rebuildActiveFeatureIndex() {{
-        rebuildFeatureIndex(CURRENT_MODALITY);
+        rebuildFeatureIndex(getVisualModality());
     }}
     function getActiveFeatureSet() {{
-        return getFeatureIndex(CURRENT_MODALITY).exact;
+        return getFeatureIndex(getVisualModality()).exact;
     }}
 
     function _snapshotModalityFeatureState(name) {{
@@ -8007,20 +8037,20 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function getActiveModalityManifestEntry(manifest) {{
         if (!manifest) return null;
         const map = manifest.modalities;
-        if (map && typeof map === 'object' && map[CURRENT_MODALITY]) return map[CURRENT_MODALITY];
+        if (map && typeof map === 'object' && map[getVisualModality()]) return map[getVisualModality()];
         // Legacy v2/v3 manifests have no modalities map; only valid for default modality.
-        if (CURRENT_MODALITY === DEFAULT_MODALITY_NAME) return manifest;
+        if (getVisualModality() === DEFAULT_MODALITY_NAME) return manifest;
         return null;
     }}
     async function setActiveModality(name) {{
-        if (!name || name === CURRENT_MODALITY) return;
+        if (!name || name === getVisualModality()) return;
         if (!FEATURES_BY_MODALITY[name] && name !== DEFAULT_MODALITY_NAME) {{
             console.warn('Unknown modality:', name);
             return;
         }}
-        _snapshotModalityFeatureState(CURRENT_MODALITY);
-        CURRENT_MODALITY = name;
-        _restoreModalityFeatureState(CURRENT_MODALITY);
+        _snapshotModalityFeatureState(getVisualModality());
+        setVisualModality(name);
+        _restoreModalityFeatureState(getVisualModality());
         rebuildActiveFeatureIndex();
         populateGeneInputDatalist();
         // Clear any active gene selection so cells don't render with a feature
@@ -8032,7 +8062,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             try {{ renderGeneDiscoveryPanel(); }} catch (e) {{}}
         }}
     }}
-    _restoreModalityFeatureState(CURRENT_MODALITY);
+    _restoreModalityFeatureState(getVisualModality());
 
     const USER_AGENT = navigator.userAgent || '';
     const IS_SAFARI = /Safari/i.test(USER_AGENT) &&
@@ -10316,7 +10346,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (typeof openInsightsMode === 'function') openInsightsMode('exploration');
         if (typeof setInsightsMode === 'function') setInsightsMode('module');
         if (!geneModuleDraftGenes.length) {{
-            const genes = (typeof getGeneInputFeatureList === 'function' ? getGeneInputFeatureList() : getFeatureDatalistValuesForModality(CURRENT_MODALITY))
+            const genes = (typeof getGeneInputFeatureList === 'function' ? getGeneInputFeatureList() : getFeatureDatalistValuesForModality(getVisualModality()))
                 .map(gene => resolveCanonicalFeatureName(gene) || gene)
                 .filter(Boolean);
             geneModuleDraftGenes = [...new Set(genes)].slice(0, 2);
@@ -10686,7 +10716,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             overviewBlendGeneScaleOverrides = {{ a: null, b: null }};
             safeTutorialClick('#overview-mode-default');
 
-            if (CURRENT_MODALITY !== DEFAULT_MODALITY_NAME && typeof setActiveModality === 'function') {{
+            if (getVisualModality() !== DEFAULT_MODALITY_NAME && typeof setActiveModality === 'function') {{
                 setActiveModality(DEFAULT_MODALITY_NAME).catch(error => console.warn('Tutorial modality reset failed', error));
             }}
 
@@ -10891,7 +10921,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const modalityNames = MODALITY_DESCRIPTORS.map(m => m.name).filter(Boolean);
         if (!modalityNames.length && getLoadedFeaturesForModality('gene').length) return 'gene';
         const preferred = [
-            CURRENT_MODALITY,
+            getVisualModality(),
             DEFAULT_MODALITY_NAME,
             ...modalityNames.filter(name => String(name).toLowerCase() === 'rna'),
             ...modalityNames,
@@ -10963,7 +10993,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function ensureTutorialFirstGeneSelected() {{
-        const features = getFeatureDatalistValuesForModality(CURRENT_MODALITY);
+        const features = getFeatureDatalistValuesForModality(getVisualModality());
         const firstGene = features[0];
         if (!firstGene) return;
         const geneInput = document.getElementById('gene-input');
@@ -13224,7 +13254,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
             return {{ vmin, vmax }};
         }}
-        const targetModality = modality || CURRENT_MODALITY;
+        const targetModality = modality || getVisualModality();
         const base = getFeatureState(targetModality).features_meta?.[gene] || {{}};
         
         const autoScale = geneScaleAuto[gene];
@@ -13340,8 +13370,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     function computeGenePercentiles(gene, pmin = GENE_SCALE_PMIN, pmax = GENE_SCALE_PMAX, modality = null) {{
         if (getGeneModuleByToken(gene)) return {{ vmin: 0, vmax: 1, pmin, pmax }};
-        const targetModality = modality || CURRENT_MODALITY;
-        const isCurrent = targetModality === CURRENT_MODALITY;
+        const targetModality = modality || getVisualModality();
+        const isCurrent = targetModality === getVisualModality();
         
         let sectionsSource = isCurrent ? (DATA.sections || []) : getFeatureSectionList(targetModality);
 
@@ -13810,9 +13840,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const out = new Float32Array(n);
             const counts = new Uint16Array(n);
             module.genes.forEach((moduleGene) => {{
-                const vals = getSectionGeneValues(section, moduleGene, CURRENT_MODALITY);
+                const vals = getSectionGeneValues(section, moduleGene, getVisualModality());
                 if (!vals) return;
-                const scale = getGeneScaleRange(moduleGene, CURRENT_MODALITY);
+                const scale = getGeneScaleRange(moduleGene, getVisualModality());
                 const denom = Math.max(1e-12, scale.vmax - scale.vmin);
                 const m = Math.min(n, vals.length);
                 for (let i = 0; i < m; i++) {{
@@ -13828,8 +13858,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             geneDenseCache.set(key, out);
             return out;
         }}
-        const targetModality = modality || CURRENT_MODALITY;
-        const isCurrent = targetModality === CURRENT_MODALITY;
+        const targetModality = modality || getVisualModality();
+        const isCurrent = targetModality === getVisualModality();
         
         const sectionPayload = getFeatureSectionPayload(section, targetModality);
         const sectionSource = isCurrent
@@ -13946,8 +13976,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function hydrateGeneFromFeatureSidecar(gene, auxData, modality = null) {{
-        const targetModality = modality || CURRENT_MODALITY;
-        const isCurrent = targetModality === CURRENT_MODALITY;
+        const targetModality = modality || getVisualModality();
+        const isCurrent = targetModality === getVisualModality();
         
         const geneEntry = auxData?.features?.[gene];
         const manifest = featureSidecarManifest;
@@ -14247,8 +14277,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function hydrateGeneFromBinary(gene, geneEntry, modality = null) {{
-        const targetModality = modality || CURRENT_MODALITY;
-        const isCurrent = targetModality === CURRENT_MODALITY;
+        const targetModality = modality || getVisualModality();
+        const isCurrent = targetModality === getVisualModality();
         
         const manifest = featureSidecarManifest;
         const map = manifest?.modalities;
@@ -14397,8 +14427,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     async function ensureFeatureAvailable(feature, options = {{}}) {{
         const token = String(feature || '').trim();
         const showErrors = options.showErrors !== false;
-        const targetModality = options.modality || CURRENT_MODALITY;
-        const isCurrent = targetModality === CURRENT_MODALITY;
+        const targetModality = options.modality || getVisualModality();
+        const isCurrent = targetModality === getVisualModality();
 
         if (!token) return false;
         const module = getGeneModuleByToken(token);
@@ -14882,7 +14912,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!currentGene) return null;
         return {{
             gene: currentGene,
-            modality: getGeneModuleByToken(currentGene) ? MODULE_MODALITY_NAME : CURRENT_MODALITY,
+            modality: getGeneModuleByToken(currentGene) ? MODULE_MODALITY_NAME : getVisualModality(),
             side: null,
         }};
     }}
@@ -15289,7 +15319,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return {{ a, b }};
     }}
 
-    function requestOverviewBlendGene(gene, modality = CURRENT_MODALITY) {{
+    function requestOverviewBlendGene(gene, modality = getVisualModality()) {{
         const token = String(gene || '').trim();
         const key = `${{modality}}::${{token}}`;
         if (!token || isModuleModality(modality) || isFeatureLoadedForModality(token, modality) || overviewBlendGeneLoads.has(key)) return;
@@ -18427,15 +18457,15 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
     }}
 
-    function resolveCanonicalFeatureName(token, modality = CURRENT_MODALITY) {{
+    function resolveCanonicalFeatureName(token, modality = getVisualModality()) {{
         const text = String(token || '').trim();
         if (!text) return '';
-        const index = getFeatureIndex(typeof modality === 'string' ? modality : CURRENT_MODALITY);
+        const index = getFeatureIndex(typeof modality === 'string' ? modality : getVisualModality());
         if (index.exact.has(text)) return text;
         return index.byLower.get(text.toLowerCase()) || '';
     }}
 
-    function resolveFeatureTokenForModality(value, modality = CURRENT_MODALITY) {{
+    function resolveFeatureTokenForModality(value, modality = getVisualModality()) {{
         if (isModuleModality(modality)) return resolveGeneModuleToken(value);
         return resolveCanonicalFeatureName(value, modality);
     }}
@@ -18449,7 +18479,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return resolveCanonicalFeatureName(text);
     }}
 
-    function isFeatureLoadedForModality(feature, modality = CURRENT_MODALITY) {{
+    function isFeatureLoadedForModality(feature, modality = getVisualModality()) {{
         const token = String(feature || '').trim();
         if (!token) return false;
         if (isModuleModality(modality)) return !!getGeneModuleByToken(token);
@@ -33799,7 +33829,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 const opt = document.createElement('option');
                 opt.value = desc.name;
                 opt.textContent = desc.label || desc.name;
-                if (desc.name === CURRENT_MODALITY) opt.selected = true;
+                if (desc.name === getVisualModality()) opt.selected = true;
                 modalitySelect.appendChild(opt);
             }}
             modalityControl.style.display = '';

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -6939,7 +6939,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Clear and delete"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg></span></div><div class="button-help-text">Clears the current filter, selection, highlight, module, annotation, or panel-specific focus.</div></div>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Zoom and rotate"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14"></path><path d="M12 5v14"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3a9 9 0 1 0 9 9"></path><path d="M21 3v6h-6"></path></svg></span></div><div class="button-help-text">Changes magnification, fits modal/network views, or rotates sections and overlays.</div></div>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Neighbors and image overlay"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true" data-icon="waypoints"><circle cx="12" cy="4.5" r="2.5"></circle><circle cx="4.5" cy="12" r="2.5"></circle><circle cx="19.5" cy="12" r="2.5"></circle><circle cx="12" cy="19.5" r="2.5"></circle><path d="m10.2 6.3-3.9 3.9"></path><path d="m13.8 6.3 3.9 3.9"></path><path d="M7 12h10"></path><path d="m10.2 17.7-3.9-3.9"></path><path d="m13.8 17.7 3.9-3.9"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect><circle cx="9" cy="9" r="2"></circle><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"></path></svg></span></div><div class="button-help-text">Toggles spatial neighbor graph tools or opens image overlay controls such as H&amp;E/DAPI.</div></div>
-                            <div class="button-help-item"><div class="button-help-icons" aria-label="Annotations"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect width="18" height="18" x="3" y="3" rx="2"></rect><path d="M16 8.9V7H8l4 5-4 5h8v-1.9"></path></svg></span></div><div class="button-help-text">Creates, groups, imports, exports, loads, or deletes user-created spatial annotations and gene modules.</div></div>
+                            <div class="button-help-item"><div class="button-help-icons" aria-label="Annotations"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><rect width="18" height="18" x="3" y="3" rx="2"></rect><path d="M16 8.9V7H8l4 5-4 5h8v-1.9"></path></svg></span></div><div class="button-help-text">Creates, groups, imports, exports, loads, or deletes user-created spatial annotations and feature modules.</div></div>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Plot and table modes"><span class="button-help-icon"><svg class="lucide lucide-chart-candlestick" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 5v4"></path><rect x="7" y="9" width="4" height="6" rx="1"></rect><path d="M9 15v2"></path><path d="M17 3v2"></path><rect x="15" y="5" width="4" height="8" rx="1"></rect><path d="M17 13v3"></path><path d="M3 3v16a2 2 0 0 0 2 2h16"></path></svg></span><span class="button-help-icon"><svg class="lucide lucide-list-sort-descending" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 12H3"></path><path d="M3 5h18"></path><path d="M9 19H3"></path></svg></span></div><div class="button-help-text">Switches analysis sections between plot, graph, list, raw table, genes, samples, ORA, or GSEA views.</div></div>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Calculation info"><span class="button-help-icon button-help-calc">!</span></div><div class="button-help-text">Explains how the displayed metric, plot, or analysis section was generated.</div></div>
                         </div>
@@ -7568,12 +7568,13 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         || (MODALITY_DESCRIPTORS[0]?.name)
         || 'rna';
     const MODULE_MODALITY_NAME = 'module';
-    const PANEL_MODALITY_STATE = {{
-        visual: DEFAULT_MODALITY_NAME,
-        exploration: DEFAULT_MODALITY_NAME,
-        pseudobulk: DEFAULT_MODALITY_NAME,
-        interactions: DEFAULT_MODALITY_NAME,
-        split: {{
+	    const PANEL_MODALITY_STATE = {{
+	        visual: DEFAULT_MODALITY_NAME,
+	        exploration: DEFAULT_MODALITY_NAME,
+	        module: DEFAULT_MODALITY_NAME,
+	        pseudobulk: DEFAULT_MODALITY_NAME,
+	        interactions: DEFAULT_MODALITY_NAME,
+	        split: {{
             a: DEFAULT_MODALITY_NAME,
             b: DEFAULT_MODALITY_NAME,
         }},
@@ -7693,7 +7694,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return modDesc?.label || (modality === 'gene' ? 'Gene' : String(modality || 'Gene'));
     }}
     function getGeneInputFeatureList() {{
-        return uniqueSortedFeatures(getLoadedFeaturesForModality(getVisualModality()));
+        return getFeatureDatalistValuesForModality(getVisualModality());
     }}
     function populateGeneInputDatalist() {{
         const geneListEl = document.getElementById('feature-list');
@@ -7734,15 +7735,27 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function isViewerFeatureLoadable(feature, modality = getVisualModality()) {{
         return isEmbeddedViewerFeature(feature, modality) || isSidecarViewerFeature(feature, modality);
     }}
+    function shouldRunFullSidecarDE(modality = getExplorationModality()) {{
+        if (!DATA.feature_manifest_url || isModuleModality(modality)) return false;
+        const totalFeatures = getFeatureCatalog(modality).length;
+        const loadedFeatures = getLoadedFeaturesForModality(modality).length;
+        return totalFeatures > 0 && totalFeatures > loadedFeatures;
+    }}
     function getExplorationModality() {{
         return getPanelModality('exploration');
     }}
-    function setExplorationModality(modality) {{
-        return setPanelModality('exploration', modality);
-    }}
-    function getPseudobulkPanelModality() {{
-        return getPanelModality('pseudobulk');
-    }}
+	    function setExplorationModality(modality) {{
+	        return setPanelModality('exploration', modality);
+	    }}
+	    function getModuleBuilderModality() {{
+	        return getPanelModality('module');
+	    }}
+	    function setModuleBuilderModality(modality) {{
+	        return setPanelModality('module', modality);
+	    }}
+	    function getPseudobulkPanelModality() {{
+	        return getPanelModality('pseudobulk');
+	    }}
     function setPseudobulkPanelModality(modality) {{
         return setPanelModality('pseudobulk', modality);
     }}
@@ -7856,43 +7869,22 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }});
         return uniqueSortedFeatures(genes);
     }}
-    function renderInsightsGeneSearchOptions(selected = '', placeholder = 'All features') {{
-        const modality = getExplorationModality();
-        const selectedValue = String(selected || '');
+    function getInsightsGeneSearchValues(modality = getExplorationModality()) {{
         const embedded = getFeatureDatalistValuesForModality(modality);
         const embeddedSet = new Set(embedded);
         const categoryVsRest = getCategoryVsRestGenes(explorationColorCol || currentAnnotation || '', modality)
             .filter(gene => !embeddedSet.has(gene));
-        const allFeatures = new Set([...embedded, ...categoryVsRest]);
-        const current = allFeatures.has(selectedValue) ? selectedValue : '';
-        const emptySelected = current ? '' : ' selected';
-        const options = [`<option value=""${{emptySelected}}>${{escapeHtml(placeholder)}}</option>`];
-        if (embedded.length) {{
-            options.push(`<optgroup label="${{escapeHtml(getModalityDisplayLabel(modality))}} features">`);
-            embedded.forEach((gene) => {{
-                const isSelected = gene === current ? ' selected' : '';
-                options.push(`<option value="${{escapeHtml(gene)}}"${{isSelected}}>${{escapeHtml(gene)}}</option>`);
-            }});
-            options.push('</optgroup>');
-        }}
-        if (categoryVsRest.length) {{
-            options.push('<optgroup label="Balanced-rest features (not embedded)">');
-            categoryVsRest.forEach((gene) => {{
-                const isSelected = gene === current ? ' selected' : '';
-                options.push(`<option value="${{escapeHtml(gene)}}"${{isSelected}}>${{escapeHtml(gene)}}</option>`);
-            }});
-            options.push('</optgroup>');
-        }}
-        return options.join('');
+        return uniqueSortedFeatures([...embedded, ...categoryVsRest]);
+    }}
+    function renderInsightsGeneSearchDatalistOptions() {{
+        const modality = getExplorationModality();
+        return getInsightsGeneSearchValues(modality)
+            .map(gene => `<option value="${{escapeHtml(gene)}}"></option>`)
+            .join('');
     }}
     function refreshLoadedGeneFilterDropdowns() {{
-        [
-            ['marker-gene-search', 'All features'],
-        ].forEach(([id, placeholder]) => {{
-            const select = document.getElementById(id);
-            if (!select) return;
-            select.innerHTML = renderInsightsGeneSearchOptions(select.value, placeholder);
-        }});
+        const datalist = document.getElementById('marker-gene-search-list');
+        if (datalist) datalist.innerHTML = renderInsightsGeneSearchDatalistOptions();
     }}
     function getInsightsSelectedGene() {{
         const value = String(document.getElementById('marker-gene-search')?.value || '').trim();
@@ -7900,7 +7892,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
     function getFeatureDatalistValuesForModality(modality = getVisualModality()) {{
         if (isModuleModality(modality)) return uniqueSortedFeatures(getGeneModuleDatalistValues());
-        const base = getLoadedFeaturesForModality(modality);
+        const base = getFeatureCatalog(modality);
         return uniqueSortedFeatures(base);
     }}
     function isActiveModalityIntensity() {{
@@ -7979,6 +7971,15 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (getVisualModality() === DEFAULT_MODALITY_NAME) return manifest;
         return null;
     }}
+    function getFeatureSidecarManifestEntryForModality(manifest, modality = getVisualModality()) {{
+        if (!manifest) return null;
+        const name = normalizeFeatureModalityName(modality);
+        const map = manifest.modalities;
+        if (map && typeof map === 'object' && map[name]) return map[name];
+        // Legacy v2/v3 manifests have no modalities map; only valid for default modality.
+        if (name === DEFAULT_MODALITY_NAME) return manifest;
+        return null;
+    }}
     async function setActiveModality(name) {{
         if (!name || name === getVisualModality()) return;
         if (!isModuleModality(name) && !FEATURES_BY_MODALITY[name] && name !== DEFAULT_MODALITY_NAME) {{
@@ -7987,9 +7988,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
         _snapshotModalityFeatureState(getVisualModality());
         setVisualModality(name);
-        _restoreModalityFeatureState(getVisualModality());
-        rebuildActiveFeatureIndex();
-        populateGeneInputDatalist();
+	        _restoreModalityFeatureState(getVisualModality());
+	        rebuildActiveFeatureIndex();
+	        populateGeneInputDatalist();
+	        if (typeof syncVisualFeatureNamespaceSelect === 'function') syncVisualFeatureNamespaceSelect();
+	        recentGenes = loadRecentGenes(getVisualModality());
+	        savedGenePanels = loadSavedGenePanels(getVisualModality());
         // Clear any active gene selection so cells don't render with a feature
         // that doesn't exist in the new modality.
         if (typeof activateViewerGene === 'function') {{
@@ -8453,9 +8457,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             formula: 'NNI = observed mean nearest same-category distance / expected same-category distance from the all-cell kNN baseline; NNI < 0.9 clustered, NNI > 1.1 dispersed'
         }},
         module: {{
-            title: 'Gene module score',
-            body: 'Each gene expression is scaled from 0 to 1 across cells before module aggregation.',
-            formula: 'module score = mean(scaled expression of selected genes)'
+	            title: 'Feature module score',
+	            body: 'Each selected feature is scaled from 0 to 1 across cells in the focused modality before module aggregation.',
+	            formula: 'module score = mean(scaled value of selected features)'
         }}
     }};
 
@@ -9398,7 +9402,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 'The screenshot menu exports the current grid view.'
             ], {{ nextLabel: tryIt }}),
             step('Save the viewer session', ['#save-session-btn'], [
-                'Session export saves interactive state JSON file containing annotations, hidden categories, gene modules and current views.'
+	                'Session export saves an interactive state JSON file containing annotations, hidden categories, feature modules and current views.'
             ], {{ nextLabel: tryIt }}),
             step('Load a previous session', ['#load-session-btn'], [
                 'Session import restores a JSON session that was previously exported from the viewer.'
@@ -9593,15 +9597,15 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             step('Import regions', ['#regions-import', '#region-section'], [
                 'Region import uploads a regions JSON file and restores saved regions in the viewer.'
             ], {{ action: () => {{ if (typeof setInsightsMode === 'function') setInsightsMode('region'); }}, nextLabel: tryIt }}),
-            step('Module gene picker', ['#gene-module-gene-picker', '#gene-module-draft-genes', '#insights-module-panel'], [
-                'The gene picker dropdown shows which genes will be saved into the next module.'
-            ], {{ action: () => {{ if (typeof closeModal === 'function') closeModal(); if (typeof openInsightsMode === 'function') openInsightsMode('exploration'); if (typeof setInsightsMode === 'function') setInsightsMode('module'); }}, task: 'Use the gene picker to add genes into the module list.', requiresModuleDraftGene: true, nextLabel: tryIt }}),
+	            step('Module feature picker', ['#gene-module-modality-select', '#gene-module-gene-picker', '#gene-module-draft-genes', '#insights-module-panel'], [
+	                'The focused modality controls which feature namespace is used for the next module.'
+	            ], {{ action: () => {{ if (typeof closeModal === 'function') closeModal(); if (typeof openInsightsMode === 'function') openInsightsMode('exploration'); if (typeof setInsightsMode === 'function') setInsightsMode('module'); }}, task: 'Use the feature picker to add features into the module list.', requiresModuleDraftGene: true, nextLabel: tryIt }}),
             step('Create module', ['#gene-module-create', '#insights-module-panel'], [
-                'Each gene in the module will get a scaled expression and the average expression will be calculated.'
+	                'Each feature in the module will be scaled within the focused modality and averaged.'
             ], {{ action: () => {{ tutorialModuleCreateClicked = false; if (typeof setInsightsMode === 'function') setInsightsMode('module'); }}, task: 'The sum button will create the module list.', requiresModuleCreateClicked: true, targetAfterGateSatisfied: ['#gene-module-create', '.gene-module-card'], combineTargetsAfterGateSatisfied: true, positionTarget: '#insights-panel', placement: 'left', nextLabel: tryIt }}),
             step('Load module score', ['[data-gene-module-load]', '#insights-module-panel'], [
                 'The load button activates a module score in the spatial viewer.',
-                'Module scores are computed from the selected module genes and displayed like an expression layer.'
+	                'Module scores are computed from the selected module features and displayed like an expression layer.'
             ], {{ action: () => {{ if (typeof setInsightsMode === 'function') setInsightsMode('module'); }}, nextLabel: tryIt }}),
             step('Module export', '#gene-module-download', [
                 'Export downloads module definitions as a JSON file.'
@@ -9806,9 +9810,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             rawSteps.splice(insertBeforeUmapIndex, 0, ...legendSteps);
         }}
         const regionStartIndex = rawSteps.findIndex(item => item.title === 'Insights Region');
-        const regionEndIndex = rawSteps.findIndex(item => item.title === 'Module gene picker') >= 0
-            ? rawSteps.findIndex(item => item.title === 'Module gene picker')
-            : rawSteps.findIndex(item => item.title === 'Exploration annotation selector');
+	        const regionEndIndex = rawSteps.findIndex(item => item.title === 'Module feature picker') >= 0
+	            ? rawSteps.findIndex(item => item.title === 'Module feature picker')
+	            : rawSteps.findIndex(item => item.title === 'Exploration annotation selector');
         const umapRegionAnchorTitle = rawSteps.findIndex(item => item.title === 'Selection feature comparison') >= 0
             ? 'Selection feature comparison'
             : (rawSteps.findIndex(item => item.title === 'Selection Find More') >= 0
@@ -9835,7 +9839,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ['Legend panel toggle', 'Legend'],
             ['Open a section modal', 'Modal View'],
             ['Insights Region', 'Region'],
-            ['Module gene picker', 'Module'],
+	            ['Module feature picker', 'Module'],
             ['Exploration annotation selector', 'Exploration'],
             ['Open Overview > Summary', 'Exploration > Overview'],
             ['Open Features > Markers', 'Exploration > Features'],
@@ -10280,23 +10284,25 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         scheduleTutorialReposition?.();
     }}
 
-    function ensureTutorialModuleDraft() {{
-        if (typeof openInsightsMode === 'function') openInsightsMode('exploration');
-        if (typeof setInsightsMode === 'function') setInsightsMode('module');
-        if (!geneModuleDraftGenes.length) {{
-            const genes = (typeof getGeneInputFeatureList === 'function' ? getGeneInputFeatureList() : getFeatureDatalistValuesForModality(getVisualModality()))
-                .map(gene => resolveCanonicalFeatureName(gene) || gene)
-                .filter(Boolean);
-            geneModuleDraftGenes = [...new Set(genes)].slice(0, 2);
-        }}
+	    function ensureTutorialModuleDraft() {{
+	        if (typeof openInsightsMode === 'function') openInsightsMode('exploration');
+	        if (typeof setInsightsMode === 'function') setInsightsMode('module');
+	        if (!geneModuleDraftGenes.length) {{
+	            const moduleFocusedModality = typeof getModuleBuilderModality === 'function' ? getModuleBuilderModality() : getVisualModality();
+	            const genes = getFeatureDatalistValuesForModality(moduleFocusedModality)
+	                .map(gene => resolveCanonicalFeatureName(gene, moduleFocusedModality) || gene)
+	                .filter(Boolean);
+	            geneModuleDraftGenes = [...new Set(genes)].slice(0, 2);
+	        }}
         renderGeneModulePanel?.();
         updateTutorialStepGate?.();
     }}
 
-    function ensureTutorialModuleCreated() {{
-        ensureTutorialModuleDraft();
-        if (geneModuleDraftGenes.length) {{
-            const module = createGeneModule?.('', geneModuleDraftGenes.slice());
+	    function ensureTutorialModuleCreated() {{
+	        ensureTutorialModuleDraft();
+	        if (geneModuleDraftGenes.length) {{
+	            const moduleFocusedModality = typeof getModuleBuilderModality === 'function' ? getModuleBuilderModality() : getVisualModality();
+	            const module = createGeneModule?.('', geneModuleDraftGenes.slice(), moduleFocusedModality);
             if (module) {{
                 geneModuleDraftGenes = [];
                 refreshAfterGeneModuleChange?.();
@@ -10419,7 +10425,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ensureTutorialQuerySelection();
         }} else if (title === 'Open a section modal') {{
             ensureTutorialModalOpen();
-        }} else if (title === 'Module gene picker') {{
+	        }} else if (title === 'Module feature picker') {{
             ensureTutorialModuleDraft();
         }} else if (title === 'Create module') {{
             ensureTutorialModuleCreated();
@@ -13766,21 +13772,22 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return any ? mask : null;
     }}
 
-    function getSectionGeneValues(section, gene, modality = null) {{
-        const module = getGeneModuleByToken(gene);
-        if (module) {{
-            const key = `${{section.id}}::module::${{module.id}}::${{module.genes.join('|')}}`;
-            const cached = geneDenseCache.get(key);
-            if (cached) return cached;
-            const n = section.n_cells ?? section.x?.length ?? 0;
-            const out = new Float32Array(n);
-            const counts = new Uint16Array(n);
-            module.genes.forEach((moduleGene) => {{
-                const vals = getSectionGeneValues(section, moduleGene, getVisualModality());
-                if (!vals) return;
-                const scale = getGeneScaleRange(moduleGene, getVisualModality());
-                const denom = Math.max(1e-12, scale.vmax - scale.vmin);
-                const m = Math.min(n, vals.length);
+	    function getSectionGeneValues(section, gene, modality = null) {{
+	        const module = getGeneModuleByToken(gene);
+	        if (module) {{
+	            const sourceModality = getGeneModuleModality(module);
+	            const key = `${{section.id}}::module::${{sourceModality}}::${{module.id}}::${{module.genes.join('|')}}`;
+	            const cached = geneDenseCache.get(key);
+	            if (cached) return cached;
+	            const n = section.n_cells ?? section.x?.length ?? 0;
+	            const out = new Float32Array(n);
+	            const counts = new Uint16Array(n);
+	            module.genes.forEach((moduleGene) => {{
+	                const vals = getSectionGeneValues(section, moduleGene, sourceModality);
+	                if (!vals) return;
+	                const scale = getGeneScaleRange(moduleGene, sourceModality);
+	                const denom = Math.max(1e-12, scale.vmax - scale.vmin);
+	                const m = Math.min(n, vals.length);
                 for (let i = 0; i < m; i++) {{
                     const raw = vals[i];
                     if (!Number.isFinite(raw)) continue;
@@ -14469,10 +14476,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (options.isSearchActive) classes.push('search-active');
         if (!canActivate) classes.push('disabled');
         else if (!module && !isFeatureLoadedForModality(token, tokenModality || getVisualModality())) classes.push('unloaded');
-        const showMeta = options.showMeta !== false;
-        const metaLabel = options.metaLabel !== undefined
-            ? options.metaLabel
-            : (!canActivate ? 'not embedded' : (module ? `${{module.genes.length}} genes` : (isFeatureLoadedForModality(token, tokenModality || getVisualModality()) ? 'loaded' : 'sidecar')));
+	        const showMeta = options.showMeta !== false;
+	        const metaLabel = options.metaLabel !== undefined
+	            ? options.metaLabel
+	            : (!canActivate ? 'not embedded' : (module ? `${{getModalityDisplayLabel(getGeneModuleModality(module))}} · ${{module.genes.length}} features` : (isFeatureLoadedForModality(token, tokenModality || getVisualModality()) ? 'loaded' : 'sidecar')));
         const metaHtml = showMeta && metaLabel
             ? `<span class="gene-token-meta">${{escapeHtml(metaLabel)}}</span>`
             : '';
@@ -14540,6 +14547,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const input = document.getElementById('feature-input');
         if (!content || !input) return;
 
+        const discoveryModality = getVisualModality();
+        const discoveryModalityLabel = getModalityDisplayLabel(discoveryModality);
         const query = String(input.value || '').trim();
         geneDiscoveryResults = getGeneSearchResults(query);
         if (!geneDiscoveryResults.length) {{
@@ -14554,9 +14563,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 ? `<div class="gene-token-grid">${{geneDiscoveryResults.map((gene, idx) => renderGeneTokenButton(gene, {{
                     isActive: gene === currentGene,
                     isSearchActive: idx === geneDiscoveryActiveIndex,
-                    title: 'Load gene into the viewer',
+                    modality: discoveryModality,
+                    title: `Load ${{gene}} into the ${{discoveryModalityLabel}} viewer`,
                 }})).join('')}}</div>`
-                : `<div class="gene-discovery-empty">No genes matched "${{escapeHtml(query)}}". Try a shorter token or browse suggestions.</div>`;
+                : `<div class="gene-discovery-empty">No features matched "${{escapeHtml(query)}}". Try a shorter token or browse suggestions.</div>`;
             sections.push(`
                 <div class="gene-discovery-section">
                     <div class="gene-discovery-label">Search results</div>
@@ -14565,7 +14575,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             `);
         }}
 
-        if (geneModules.length) {{
+        if (isModuleModality(discoveryModality) && geneModules.length) {{
             const moduleMatches = query
                 ? geneModules.filter((module) => {{
                     const haystack = `${{getGeneModuleDisplayValue(module)}} ${{module.name}} ${{module.genes.join(' ')}}`.toLowerCase();
@@ -14576,38 +14586,40 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 sections.push(`
                     <div class="gene-discovery-section">
                         <div class="gene-discovery-label">Module results</div>
-                        <div class="gene-token-grid">${{moduleMatches.map((module) => renderGeneTokenButton(getGeneModuleToken(module), {{
-                            isActive: currentGene === getGeneModuleToken(module),
-                            metaLabel: `${{module.genes.length}} genes`,
-                            title: 'Load module assay',
-                        }})).join('')}}</div>
+	                        <div class="gene-token-grid">${{moduleMatches.map((module) => renderGeneTokenButton(getGeneModuleToken(module), {{
+	                            isActive: currentGene === getGeneModuleToken(module),
+	                            modality: discoveryModality,
+	                            metaLabel: `${{getModalityDisplayLabel(getGeneModuleModality(module))}} · ${{module.genes.length}} features`,
+	                            title: 'Load module assay',
+	                        }})).join('')}}</div>
                     </div>
                 `);
             }}
         }}
 
-        const recentRows = recentGenes.length
-            ? `<div class="gene-token-grid">${{recentGenes.map((gene) => renderGeneTokenButton(gene, {{
+        const visibleRecentGenes = getFeatureTokensForModality(recentGenes, discoveryModality);
+        const recentRows = visibleRecentGenes.length
+            ? `<div class="gene-token-grid">${{visibleRecentGenes.map((gene) => renderGeneTokenButton(gene, {{
                 isActive: gene === currentGene,
-                title: 'Recently viewed gene',
+                modality: discoveryModality,
+                title: `Recently viewed ${{discoveryModalityLabel}} feature`,
             }})).join('')}}</div>`
-            : '<div class="gene-discovery-empty">Recent genes will appear here after you load them.</div>';
+            : `<div class="gene-discovery-empty">Recent ${{escapeHtml(discoveryModalityLabel)}} features will appear here after you load them.</div>`;
         sections.push(`
             <div class="gene-discovery-section">
-                <div class="gene-discovery-label">Recent genes</div>
+                <div class="gene-discovery-label">Recent features</div>
                 ${{recentRows}}
             </div>
         `);
 
         const currentGeneModule = getGeneModuleByToken(currentGene);
-        const explorationModality = getExplorationModality();
-        const featureCorrelations = getExplorationFeatureCorrelationsPayload(explorationModality);
+        const featureCorrelations = getExplorationFeatureCorrelationsPayload(discoveryModality);
         if (currentGene && !currentGeneModule && featureCorrelations?.[currentGene]?.length) {{
             const corrData = featureCorrelations[currentGene];
             const corrRows = `<div class="gene-token-grid">${{corrData.map(({{gene, r}}) =>
                 renderGeneTokenButton(gene, {{
                     isActive: gene === currentGene,
-                    modality: explorationModality,
+                    modality: discoveryModality,
                     metaLabel: `r=${{r.toFixed(2)}}`,
                     title: `Pearson r = ${{r.toFixed(2)}} with ${{escapeHtml(currentGene)}}`,
                 }})
@@ -14619,7 +14631,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 </div>
             `);
         }} else if (currentGene && !currentGeneModule && !featureCorrelations?.[currentGene]?.length) {{
-            const originallyEmbedded = getEmbeddedFeatureSet(explorationModality).has(currentGene);
+            const originallyEmbedded = getEmbeddedFeatureSet(discoveryModality).has(currentGene);
             const emptyText = DATA.feature_manifest_url && !originallyEmbedded
                 ? 'No precomputed correlations for this sidecar-loaded feature.'
                 : 'No positive precomputed correlations for this feature among the embedded features.';
@@ -14631,13 +14643,13 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             `);
         }}
 
-        const spatialFeatures = getExplorationSpatialVariableFeaturesPayload(explorationModality);
+        const spatialFeatures = getExplorationSpatialVariableFeaturesPayload(discoveryModality);
         if (spatialFeatures.length) {{
             const topSVG = spatialFeatures.slice(0, 12);
             const svgRows = `<div class="gene-token-grid">${{topSVG.map((item) =>
                 renderGeneTokenButton(item.gene, {{
                     isActive: item.gene === currentGene,
-                    modality: explorationModality,
+                    modality: discoveryModality,
                     metaLabel: `I=${{item.I.toFixed(2)}}`,
                     title: `Moran's I = ${{item.I.toFixed(4)}}`,
                 }})
@@ -14650,7 +14662,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             `);
         }}
 
-        const suggestionInfo = getGeneSuggestionGroups();
+        const suggestionInfo = getGeneSuggestionGroups(discoveryModality);
         const suggestionRows = suggestionInfo.groups.length
             ? suggestionInfo.groups.map(group => `
                 <div class="gene-suggestion-group">
@@ -14658,7 +14670,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     <div class="gene-token-grid">
                         ${{group.genes.map((gene) => renderGeneTokenButton(gene, {{
                             isActive: gene === currentGene,
-                            title: `Suggested DE gene for ${{group.category}}`,
+                            modality: discoveryModality,
+                            title: `Suggested DE feature for ${{group.category}}`,
                         }})).join('')}}
                     </div>
                 </div>
@@ -14675,27 +14688,32 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             </div>
         `);
 
-        if (geneModules.length) {{
-            const moduleRows = `<div class="gene-token-grid">${{geneModules.map((module) => renderGeneTokenButton(getGeneModuleToken(module), {{
-                isActive: currentGene === getGeneModuleToken(module),
-                metaLabel: `${{module.genes.length}} genes`,
-                title: 'Load module assay',
-            }})).join('')}}</div>`;
-            sections.push(`
-                <div class="gene-discovery-section">
-                    <div class="gene-discovery-label">Gene modules</div>
-                    ${{moduleRows}}
-                </div>
+        if (isModuleModality(discoveryModality) && geneModules.length) {{
+	            const moduleRows = `<div class="gene-token-grid">${{geneModules.map((module) => renderGeneTokenButton(getGeneModuleToken(module), {{
+	                isActive: currentGene === getGeneModuleToken(module),
+	                modality: discoveryModality,
+	                metaLabel: `${{getModalityDisplayLabel(getGeneModuleModality(module))}} · ${{module.genes.length}} features`,
+	                title: 'Load module assay',
+	            }})).join('')}}</div>`;
+	            sections.push(`
+	                <div class="gene-discovery-section">
+	                    <div class="gene-discovery-label">Feature modules</div>
+	                    ${{moduleRows}}
+	                </div>
             `);
         }}
 
-        const panelRows = savedGenePanels.length
-            ? savedGenePanels.map((panel) => `
+        const visibleSavedGenePanels = (Array.isArray(savedGenePanels) ? savedGenePanels : []).map((panel) => ({{
+            ...panel,
+            genes: getFeatureTokensForModality(panel?.genes || [], discoveryModality),
+        }}));
+        const panelRows = visibleSavedGenePanels.length
+            ? visibleSavedGenePanels.map((panel) => `
                 <div class="gene-panel-card">
                     <div class="gene-panel-header">
                         <div class="gene-panel-name">${{escapeHtml(panel.name)}}</div>
                         <div class="gene-panel-actions">
-                            <button type="button" class="gene-panel-btn" data-gene-panel-add="${{escapeHtml(panel.name)}}" title="Add the current gene to this panel">+ current</button>
+                            <button type="button" class="gene-panel-btn" data-gene-panel-add="${{escapeHtml(panel.name)}}" title="Add the current feature to this panel">+ current</button>
                             <button type="button" class="gene-panel-btn" data-gene-panel-delete="${{escapeHtml(panel.name)}}" title="Delete this panel">Delete</button>
                         </div>
                     </div>
@@ -14703,14 +14721,15 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         ${{panel.genes.length
                             ? panel.genes.map((gene) => renderGeneTokenButton(gene, {{
                                 isActive: gene === currentGene,
+                                modality: discoveryModality,
                                 title: `Load ${{gene}} from ${{panel.name}}`,
                             }})).join('')
-                            : '<div class="gene-discovery-empty">Panel is empty. Use + current to add a gene.</div>'
+                            : `<div class="gene-discovery-empty">Panel has no ${{escapeHtml(discoveryModalityLabel)}} features. Use + current to add one.</div>`
                         }}
                     </div>
                 </div>
             `).join('')
-            : '<div class="gene-discovery-empty">No saved panels yet. Create one from the current active gene or an exact gene in the input.</div>';
+            : '<div class="gene-discovery-empty">No saved panels yet. Create one from the current active feature or an exact feature in the input.</div>';
         sections.push(`
             <div class="gene-discovery-section">
                 <div class="gene-discovery-label">Saved panels</div>
@@ -15053,21 +15072,42 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         ];
     }}
 
-    function getFeatureNamespaceOptions() {{
-        const options = MODALITY_DESCRIPTORS.map(desc => ({{
-            value: desc.name,
-            label: desc.label || desc.name,
-        }}));
+	    function getFeatureNamespaceOptions() {{
+	        const options = MODALITY_DESCRIPTORS.map(desc => ({{
+	            value: desc.name,
+	            label: desc.label || desc.name,
+	        }}));
         if (!options.length) {{
             options.push({{ value: DEFAULT_MODALITY_NAME, label: getModalityDisplayLabel(DEFAULT_MODALITY_NAME) }});
         }}
         if (Array.isArray(geneModules) && geneModules.length) {{
             options.push({{ value: MODULE_MODALITY_NAME, label: 'Module' }});
-        }}
-        return options;
-    }}
+	        }}
+	        return options;
+	    }}
 
-    function getCategoriesForColorColumn(annotationCol) {{
+	    function syncVisualFeatureNamespaceSelect() {{
+	        const options = getFeatureNamespaceOptions();
+	        const modalityControl = document.getElementById('visual-feature-namespace-control');
+	        const modalitySelect = document.getElementById('visual-feature-namespace-select');
+	        if (modalitySelect) {{
+	            const active = getVisualModality();
+	            setSelectOptions(modalitySelect, options, active);
+	        }}
+	        if (modalityControl) {{
+	            const defaultControls = document.getElementById('visual-default-controls');
+	            const isFeatureMode = defaultControls?.classList.contains('feature-mode');
+	            modalityControl.style.display = isFeatureMode && options.length > 1 ? '' : 'none';
+	        }}
+	        ['a', 'b'].forEach((side) => {{
+	            const select = document.getElementById(`overview-blend-${{side}}-namespace`);
+	            if (!select) return;
+	            const selected = getPanelModality(`split.${{side}}`);
+	            setSelectOptions(select, options, selected);
+	        }});
+	    }}
+
+	    function getCategoriesForColorColumn(annotationCol) {{
         if (String(annotationCol || '').startsWith(SECTION_METADATA_COLOR_PREFIX)) {{
             const column = String(annotationCol).slice(SECTION_METADATA_COLOR_PREFIX.length);
             return (DATA.metadata_filters?.[column] || []).map((value) => String(value));
@@ -15814,14 +15854,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}));
     }}
 
-    function getCachedSelectionWelchExpression(groupA, groupB = null) {{
-        if (!selectionWelchRunRequested) return [];
-        const key = `${{groupB === null ? 'all' : 'region-b'}}:${{selectionRevision}}:${{selectionWelchRevision}}`;
-        if (selectionWelchCache.has(key)) return selectionWelchCache.get(key);
-        const result = computeSelectionWelchExpression(groupA, groupB);
-        selectionWelchCache.set(key, result);
-        return result;
-    }}
+	    function getCachedSelectionWelchExpression(groupA, groupB = null) {{
+	        if (!selectionWelchRunRequested) return [];
+	        const key = `${{getExplorationModality()}}:${{groupB === null ? 'all' : 'region-b'}}:${{selectionRevision}}:${{selectionWelchRevision}}`;
+	        if (selectionWelchCache.has(key)) return selectionWelchCache.get(key);
+	        const result = computeSelectionWelchExpression(groupA, groupB);
+	        selectionWelchCache.set(key, result);
+	        return result;
+	    }}
 
     function selectWelchTopResults(results, topN, minPct = 0, pctScale = 100) {{
         const n = Math.max(1, Math.min(20, Number(topN) || 3));
@@ -16414,14 +16454,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return top;
     }}
 
-    function computeQuickStatsForGroupGene(group, gene) {{
+    function computeQuickStatsForGroupGene(group, gene, modality = getExplorationModality()) {{
         if (!group || !gene || !Array.isArray(group.sections) || !group.sections.length) return null;
         const stats = {{ sum: 0, sumSq: 0, nnz: 0, n: 0 }};
         for (let s = 0; s < group.sections.length; s++) {{
             const sectionGroup = group.sections[s];
             const section = sectionById.get(sectionGroup.sectionId);
             if (!section) continue;
-            const values = getSectionGeneValues(section, gene);
+            const values = getSectionGeneValues(section, gene, modality);
             // A section lacking this gene contributes zeros (consistent with the
             // full-sidecar path) rather than dropping the gene from the result.
             if (sectionGroup.indices === null) {{
@@ -16481,23 +16521,23 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function computePooledWelchCellSetDE(groupA, groupB) {{
         if (!groupA || !groupB) return {{ available: false, reason: 'missing_groups', results: [] }};
         if (!(groupA.nCells > 0) || !(groupB.nCells > 0)) {{
-            return {{ available: false, reason: 'empty_group', nA: Number(groupA.nCells || 0), nB: Number(groupB.nCells || 0), results: [] }};
+            return {{ available: false, reason: 'empty_group', nA: Number(groupA.nCells || 0), nB: Number(groupB.nCells || 0), modality: getExplorationModality(), results: [] }};
         }}
         if (!(groupA.nCells >= 2) || !(groupB.nCells >= 2)) {{
-            return {{ available: false, reason: 'too_few_cells', nA: Number(groupA.nCells || 0), nB: Number(groupB.nCells || 0), results: [] }};
+            return {{ available: false, reason: 'too_few_cells', nA: Number(groupA.nCells || 0), nB: Number(groupB.nCells || 0), modality: getExplorationModality(), results: [] }};
         }}
-        const activeModality = getVisualModality();
+        const activeModality = getExplorationModality();
         const loadedGenes = getLoadedFeaturesForModality(activeModality);
         const totalGenes = getFeatureCatalog(activeModality).length || loadedGenes.length;
         if (!loadedGenes.length) {{
-            return {{ available: false, reason: 'no_loaded_features', nA: Number(groupA.nCells || 0), nB: Number(groupB.nCells || 0), loadedGeneCount: 0, totalGeneCount: totalGenes, results: [] }};
+            return {{ available: false, reason: 'no_loaded_features', nA: Number(groupA.nCells || 0), nB: Number(groupB.nCells || 0), modality: activeModality, loadedGeneCount: 0, totalGeneCount: totalGenes, results: [] }};
         }}
         const results = [];
         loadedGenes.forEach((gene) => {{
             const entry = buildWelchCellSetDEEntry(
                 gene,
-                computeQuickStatsForGroupGene(groupA, gene),
-                computeQuickStatsForGroupGene(groupB, gene)
+                computeQuickStatsForGroupGene(groupA, gene, activeModality),
+                computeQuickStatsForGroupGene(groupB, gene, activeModality)
             );
             if (entry) results.push(entry);
         }});
@@ -16507,6 +16547,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             reason: null,
             nA: Number(groupA.nCells || 0),
             nB: Number(groupB.nCells || 0),
+            modality: activeModality,
             loadedGeneCount: loadedGenes.length,
             totalGeneCount: totalGenes,
             results,
@@ -16527,11 +16568,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 reason: 'empty_group',
                 nA: Number(groupA.nCells || 0),
                 nB: Number(groupB.nCells || 0),
+                modality: getExplorationModality(),
                 results: [],
             }};
         }}
 
-        const activeModality = getVisualModality();
+        const activeModality = getExplorationModality();
         const loadedGenes = getLoadedFeaturesForModality(activeModality);
         const totalGenes = getFeatureCatalog(activeModality).length || loadedGenes.length;
         if (!loadedGenes.length) {{
@@ -16540,6 +16582,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 reason: 'no_loaded_features',
                 nA: Number(groupA.nCells || 0),
                 nB: Number(groupB.nCells || 0),
+                modality: activeModality,
                 loadedGeneCount: 0,
                 totalGeneCount: totalGenes,
                 results: [],
@@ -16548,8 +16591,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
         const results = [];
         loadedGenes.forEach((gene) => {{
-            const statsA = computeQuickStatsForGroupGene(groupA, gene);
-            const statsB = computeQuickStatsForGroupGene(groupB, gene);
+            const statsA = computeQuickStatsForGroupGene(groupA, gene, activeModality);
+            const statsB = computeQuickStatsForGroupGene(groupB, gene, activeModality);
             const entry = buildDEEntryFromStats(gene, statsA, statsB, groupA.nCells, groupB.nCells);
             if (entry) results.push(entry);
         }});
@@ -16560,6 +16603,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             reason: null,
             nA: Number(groupA.nCells || 0),
             nB: Number(groupB.nCells || 0),
+            modality: activeModality,
             loadedGeneCount: loadedGenes.length,
             totalGeneCount: totalGenes,
             results: selectTwoSidedTopN(results, topN),
@@ -16583,7 +16627,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     function getGroupDECacheKey(groupA, groupB) {{
         if (!groupA || !groupB) return '';
-        return `${{groupA.key}}::${{groupB.key}}`;
+        return `${{getExplorationModality()}}::${{groupA.key}}::${{groupB.key}}`;
     }}
 
     function computeGroupStatsFromSidecarGeneEntry(geneEntry, group, geneMeta = null) {{
@@ -16604,8 +16648,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return combined;
     }}
 
-    function computeCellSetDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB) {{
-        const geneMeta = featureSidecarManifest?.features_meta?.[gene] || DATA.features_meta?.[gene] || null;
+    function computeCellSetDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB, modality = getExplorationModality()) {{
+        const modalityEntry = getFeatureSidecarManifestEntryForModality(featureSidecarManifest, modality);
+        const geneMeta = modalityEntry?.features_meta?.[gene]
+            || (modality === DEFAULT_MODALITY_NAME ? featureSidecarManifest?.features_meta?.[gene] : null)
+            || getFeatureState(modality).features_meta?.[gene]
+            || null;
         const statsA = computeGroupStatsFromSidecarGeneEntry(geneEntry, groupA, geneMeta);
         const statsB = computeGroupStatsFromSidecarGeneEntry(geneEntry, groupB, geneMeta);
         return buildWelchCellSetDEEntry(gene, statsA, statsB, Number(groupA?.nCells || 0), Number(groupB?.nCells || 0));
@@ -16617,7 +16665,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             throw new Error('Failed to load the feature sidecar manifest.');
         }}
 
-        const shardEntries = Object.entries(manifest.shards || {{}});
+        const targetModality = options.modality || getExplorationModality();
+        const modalityEntry = getFeatureSidecarManifestEntryForModality(manifest, targetModality);
+        if (!modalityEntry) {{
+            throw new Error(`No feature sidecar is available for ${{getModalityDisplayLabel(targetModality)}}.`);
+        }}
+        const shardEntries = Object.entries(modalityEntry.shards || {{}});
         const sidecarFormat = getFeatureSidecarFormat(manifest);
         const totalGenes = shardEntries.reduce((sum, [, genes]) => sum + (Array.isArray(genes) ? genes.length : 0), 0);
         const isCancelled = typeof options.isCancelled === 'function' ? options.isCancelled : () => false;
@@ -16642,10 +16695,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         if (!payloadBuffer) continue;
                         const geneEntry = parseBinaryFeaturePayload(
                             payloadBuffer,
-                            manifest.section_order || [],
-                            manifest?.features_meta?.[gene] || null
+                            modalityEntry.section_order || manifest.section_order || [],
+                            modalityEntry?.features_meta?.[gene] || null
                         );
-                        const entry = computeCellSetDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB);
+                        const entry = computeCellSetDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB, targetModality);
                         if (entry) results.push(entry);
                     }} catch (geneError) {{
                         console.warn(`Group DE: skipping gene ${{gene}} due to error:`, geneError);
@@ -16657,7 +16710,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 if (isCancelled()) return null;
                 const featuresPayload = shardPayload?.features || {{}};
                 Object.entries(featuresPayload).forEach(([gene, geneEntry]) => {{
-                    const entry = computeCellSetDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB);
+                    const entry = computeCellSetDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB, targetModality);
                     if (entry) results.push(entry);
                 }});
                 completedGenes += Array.isArray(shardGenes) ? shardGenes.length : Object.keys(featuresPayload).length;
@@ -16679,6 +16732,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             available: true,
             nA: Number(groupA?.nCells || 0),
             nB: Number(groupB?.nCells || 0),
+            modality: targetModality,
             loadedGeneCount: totalGenes,
             totalGeneCount: totalGenes,
             results,
@@ -16726,7 +16780,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     function getAnnotationDECacheKey(annotationA, annotationB) {{
         if (!annotationA || !annotationB) return '';
-        return `${{Number(annotationA.id)}}::${{Number(annotationB.id)}}`;
+        return `${{getExplorationModality()}}::${{Number(annotationA.id)}}::${{Number(annotationB.id)}}`;
     }}
 
     function getAnnotationDEQuickResultKey(annotationA, annotationB) {{
@@ -16914,8 +16968,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return result;
     }}
 
-    function computeRegionAnnotationDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB) {{
-        const geneMeta = featureSidecarManifest?.features_meta?.[gene] || DATA.features_meta?.[gene] || null;
+    function computeRegionAnnotationDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB, modality = getExplorationModality()) {{
+        const modalityEntry = getFeatureSidecarManifestEntryForModality(featureSidecarManifest, modality);
+        const geneMeta = modalityEntry?.features_meta?.[gene]
+            || (modality === DEFAULT_MODALITY_NAME ? featureSidecarManifest?.features_meta?.[gene] : null)
+            || getFeatureState(modality).features_meta?.[gene]
+            || null;
         const statsA = computeGroupStatsFromSidecarGeneEntry(geneEntry, groupA, geneMeta);
         const statsB = computeGroupStatsFromSidecarGeneEntry(geneEntry, groupB, geneMeta);
         return buildWelchCellSetDEEntry(gene, statsA, statsB, groupA?.nCells, groupB?.nCells);
@@ -16941,7 +16999,19 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             return;
         }}
 
-        const shardEntries = Object.entries(manifest.shards || {{}});
+        const targetModality = getExplorationModality();
+        const modalityEntry = getFeatureSidecarManifestEntryForModality(manifest, targetModality);
+        if (!modalityEntry) {{
+            annotationDeFullRun = {{
+                token,
+                running: false,
+                key,
+                error: `No feature sidecar is available for ${{getModalityDisplayLabel(targetModality)}}.`,
+            }};
+            renderAnnotationComparison();
+            return;
+        }}
+        const shardEntries = Object.entries(modalityEntry.shards || {{}});
         const sidecarFormat = getFeatureSidecarFormat(manifest);
         const totalGenes = shardEntries.reduce((sum, [, genes]) => sum + (Array.isArray(genes) ? genes.length : 0), 0);
         annotationDeFullRun = {{
@@ -16987,10 +17057,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                             if (!payloadBuffer) continue;
                             const geneEntry = parseBinaryFeaturePayload(
                                 payloadBuffer,
-                                manifest.section_order || [],
-                                manifest?.features_meta?.[gene] || null
+                                modalityEntry.section_order || manifest.section_order || [],
+                                modalityEntry?.features_meta?.[gene] || null
                             );
-                            const result = computeRegionAnnotationDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB);
+                            const result = computeRegionAnnotationDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB, targetModality);
                             if (result) results.push(result);
                         }} catch (geneError) {{
                             console.warn(`Annotation DE: skipping gene ${{gene}} due to error:`, geneError);
@@ -17002,7 +17072,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
                     const featuresPayload = shardPayload?.features || {{}};
                     Object.entries(featuresPayload).forEach(([gene, geneEntry]) => {{
-                        const result = computeRegionAnnotationDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB);
+                        const result = computeRegionAnnotationDEFromSidecarGeneEntry(gene, geneEntry, groupA, groupB, targetModality);
                         if (result) results.push(result);
                     }});
                 }}
@@ -17045,6 +17115,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 results,
                 completedAt: Date.now(),
                 mode: 'full-sidecar',
+                modality: targetModality,
             }});
             annotationDeFullRun = null;
             renderAnnotationComparison();
@@ -17099,6 +17170,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             'pct_expr_b',
             'mean_a',
             'mean_b',
+            'modality',
             'region_a_label',
             'region_a_n_cells',
             'region_b_label',
@@ -17115,6 +17187,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 entry.pctB,
                 entry.meanA,
                 entry.meanB,
+                result.modality || getExplorationModality(),
                 annotationA.label || `region ${{annotationA.id}}`,
                 Number(result.nA || getAnnotationCellCount(annotationA) || 0),
                 annotationB.label || `region ${{annotationB.id}}`,
@@ -19056,54 +19129,91 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
     }}
 
-    function loadRecentGenes() {{
+    function getFeatureTokensForModality(values, modality = getVisualModality()) {{
+        const seen = new Set();
+        const tokens = [];
+        (Array.isArray(values) ? values : []).forEach((value) => {{
+            const token = resolveFeatureTokenForModality(value, modality);
+            if (!token || seen.has(token)) return;
+            seen.add(token);
+            tokens.push(token);
+        }});
+        return tokens;
+    }}
+
+    function _getModalityScopedStorageEntries(stored, modality) {{
+        if (Array.isArray(stored)) return stored;
+        if (!stored || typeof stored !== 'object') return [];
+        const key = normalizeFeatureModalityName(modality);
+        return Array.isArray(stored[key]) ? stored[key] : [];
+    }}
+
+    function _updateModalityScopedStorage(key, modality, value) {{
+        const stored = readViewerJsonStorage(key, {{}});
+        const next = stored && typeof stored === 'object' && !Array.isArray(stored) ? stored : {{}};
+        next[normalizeFeatureModalityName(modality)] = value;
+        writeViewerJsonStorage(key, next);
+    }}
+
+    function loadRecentGenes(modality = getVisualModality()) {{
         const stored = readViewerJsonStorage(GENE_RECENTS_STORAGE_KEY, []);
-        if (!Array.isArray(stored)) return [];
-        return stored
-            .map(resolveCanonicalFeatureName)
-            .filter(Boolean)
-            .slice(0, GENE_DISCOVERY_RECENT_LIMIT);
+        return getFeatureTokensForModality(
+            _getModalityScopedStorageEntries(stored, modality),
+            modality
+        ).slice(0, GENE_DISCOVERY_RECENT_LIMIT);
     }}
 
-    function persistRecentGenes() {{
-        writeViewerJsonStorage(GENE_RECENTS_STORAGE_KEY, recentGenes);
+    function persistRecentGenes(modality = getVisualModality()) {{
+        _updateModalityScopedStorage(GENE_RECENTS_STORAGE_KEY, modality, recentGenes);
     }}
 
-    function recordRecentGene(gene) {{
-        const token = resolveCanonicalFeatureName(gene);
+    function recordRecentGene(gene, modality = getVisualModality()) {{
+        const token = resolveFeatureTokenForModality(gene, modality);
         if (!token) return;
         recentGenes = [token, ...recentGenes.filter(item => item !== token)].slice(0, GENE_DISCOVERY_RECENT_LIMIT);
-        persistRecentGenes();
+        persistRecentGenes(modality);
     }}
 
-    function loadSavedGenePanels() {{
+    function loadSavedGenePanels(modality = getVisualModality()) {{
         const stored = readViewerJsonStorage(GENE_PANELS_STORAGE_KEY, []);
-        if (!Array.isArray(stored)) return [];
-        return stored
+        return _getModalityScopedStorageEntries(stored, modality)
             .map((entry) => {{
                 const name = String(entry?.name || '').trim();
-                const genes = Array.isArray(entry?.genes)
-                    ? entry.genes.map(resolveCanonicalFeatureName).filter(Boolean)
-                    : [];
+                const genes = getFeatureTokensForModality(entry?.genes || [], modality);
                 if (!name) return null;
                 return {{ name, genes: [...new Set(genes)] }};
             }})
             .filter(Boolean);
     }}
 
-    function persistSavedGenePanels() {{
-        writeViewerJsonStorage(GENE_PANELS_STORAGE_KEY, savedGenePanels);
+    function persistSavedGenePanels(modality = getVisualModality()) {{
+        _updateModalityScopedStorage(GENE_PANELS_STORAGE_KEY, modality, savedGenePanels);
     }}
 
-    function getGeneModuleToken(module) {{
-        const id = String(module?.id || '').trim();
-        return id ? `module:${{id}}` : '';
-    }}
+	    function getGeneModuleToken(module) {{
+	        const id = String(module?.id || '').trim();
+	        return id ? `module:${{id}}` : '';
+	    }}
 
-    function getGeneModuleDisplayValue(module) {{
-        const name = String(module?.name || '').trim() || 'Module';
-        return `Module: ${{name}}`;
-    }}
+	    function normalizeGeneModuleModality(modality = DEFAULT_MODALITY_NAME) {{
+	        const name = normalizeFeatureModalityName(modality || DEFAULT_MODALITY_NAME);
+	        return isModuleModality(name) ? DEFAULT_MODALITY_NAME : name;
+	    }}
+
+	    function getGeneModuleModality(module) {{
+	        return normalizeGeneModuleModality(module?.modality || DEFAULT_MODALITY_NAME);
+	    }}
+
+	    function getGeneModulesForModality(modality = getModuleBuilderModality()) {{
+	        const sourceModality = normalizeGeneModuleModality(modality);
+	        return geneModules.filter((module) => getGeneModuleModality(module) === sourceModality);
+	    }}
+
+	    function getGeneModuleDisplayValue(module) {{
+	        const name = String(module?.name || '').trim() || 'Module';
+	        const modalityLabel = getModalityDisplayLabel(getGeneModuleModality(module));
+	        return `Module: ${{name}} (${{modalityLabel}})`;
+	    }}
 
     function getGeneModuleByToken(token) {{
         const text = String(token || '').trim();
@@ -19112,22 +19222,24 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return geneModules.find((module) => String(module.id) === id) || null;
     }}
 
-    function resolveGeneModuleToken(value) {{
-        const text = String(value || '').trim();
-        if (!text) return '';
-        if (text.startsWith('module:') && getGeneModuleByToken(text)) return text;
-        const lower = text.toLowerCase();
-        const prefixed = lower.startsWith('module:') ? lower.slice('module:'.length).trim() : lower;
-        const found = geneModules.find((module) => {{
-            const name = String(module.name || '').trim();
-            return name && (name.toLowerCase() === lower || name.toLowerCase() === prefixed);
-        }});
-        return found ? getGeneModuleToken(found) : '';
-    }}
+	    function resolveGeneModuleToken(value) {{
+	        const text = String(value || '').trim();
+	        if (!text) return '';
+	        if (text.startsWith('module:') && getGeneModuleByToken(text)) return text;
+	        const lower = text.toLowerCase();
+	        const prefixed = lower.startsWith('module:') ? lower.slice('module:'.length).trim() : lower;
+	        const found = geneModules.find((module) => {{
+	            const name = String(module.name || '').trim();
+	            const display = getGeneModuleDisplayValue(module).toLowerCase();
+	            return (name && (name.toLowerCase() === lower || name.toLowerCase() === prefixed)) || display === lower;
+	        }});
+	        return found ? getGeneModuleToken(found) : '';
+	    }}
 
-    function getGeneModuleDatalistValues() {{
-        return geneModules.map(getGeneModuleDisplayValue).filter(Boolean);
-    }}
+	    function getGeneModuleDatalistValues(modality = null) {{
+	        const modules = modality ? getGeneModulesForModality(modality) : geneModules;
+	        return modules.map(getGeneModuleDisplayValue).filter(Boolean);
+	    }}
 
     function getGeneDisplayLabel(token) {{
         const module = getGeneModuleByToken(token);
@@ -19138,35 +19250,41 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return [];
     }}
 
-    function normalizeGeneModules(entries) {{
-        if (!Array.isArray(entries)) return [];
-        return entries.map((entry, index) => {{
-            const id = String(entry?.id || `m${{Date.now()}}-${{index}}`).trim();
-            const name = String(entry?.name || `Module ${{index + 1}}`).trim() || `Module ${{index + 1}}`;
-            const genes = Array.isArray(entry?.genes)
-                ? entry.genes.map(resolveCanonicalFeatureName).filter(gene => gene && !gene.startsWith('module:'))
-                : [];
-            return {{ id, name, genes: [...new Set(genes)] }};
-        }}).filter(module => module.id && module.name);
-    }}
+	    function normalizeGeneModules(entries) {{
+	        if (!Array.isArray(entries)) return [];
+	        return entries.map((entry, index) => {{
+	            const id = String(entry?.id || `m${{Date.now()}}-${{index}}`).trim();
+	            const name = String(entry?.name || `Module ${{index + 1}}`).trim() || `Module ${{index + 1}}`;
+	            const modality = normalizeGeneModuleModality(entry?.modality || entry?.source_modality || DEFAULT_MODALITY_NAME);
+	            const rawFeatures = Array.isArray(entry?.features)
+	                ? entry.features
+	                : (Array.isArray(entry?.genes) ? entry.genes : []);
+	            const genes = Array.isArray(rawFeatures)
+	                ? rawFeatures.map(feature => resolveCanonicalFeatureName(feature, modality)).filter(gene => gene && !gene.startsWith('module:'))
+	                : [];
+	            return {{ id, name, modality, genes: [...new Set(genes)] }};
+	        }}).filter(module => module.id && module.name);
+	    }}
 
-    function buildGeneModulesExport() {{
-        return {{
-            format: 'karospace-gene-modules-v1',
-            created_at: new Date().toISOString(),
-            n_modules: geneModules.length,
-            modules: geneModules.map(module => ({{
-                id: module.id,
-                name: module.name,
-                genes: module.genes.slice(),
-            }})),
-        }};
-    }}
+	    function buildGeneModulesExport() {{
+	        return {{
+	            format: 'karospace-feature-modules-v2',
+	            created_at: new Date().toISOString(),
+	            n_modules: geneModules.length,
+	            modules: geneModules.map(module => ({{
+	                id: module.id,
+	                name: module.name,
+	                modality: getGeneModuleModality(module),
+	                features: module.genes.slice(),
+	                genes: module.genes.slice(),
+	            }})),
+	        }};
+	    }}
 
-    function downloadGeneModulesJson() {{
-        if (!geneModules.length) return;
-        downloadJsonFile(buildGeneModulesExport(), `karospace-gene-modules-${{getScreenshotTimestamp()}}.json`);
-    }}
+	    function downloadGeneModulesJson() {{
+	        if (!geneModules.length) return;
+	        downloadJsonFile(buildGeneModulesExport(), `karospace-feature-modules-${{getScreenshotTimestamp()}}.json`);
+	    }}
 
     function applyGeneModulesImport(payload) {{
         const entries = Array.isArray(payload?.modules)
@@ -19192,58 +19310,66 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!file) return;
         const reader = new FileReader();
         reader.onload = () => {{
-            try {{
-                const payload = JSON.parse(String(reader.result || ''));
-                const count = applyGeneModulesImport(payload);
-                if (!count) alert('No valid gene modules found in this JSON file.');
-            }} catch (error) {{
-                alert(`Could not parse gene modules JSON: ${{error.message || error}}`);
-            }}
-        }};
-        reader.onerror = () => alert('Could not read the selected gene modules file.');
-        reader.readAsText(file);
-    }}
+	            try {{
+	                const payload = JSON.parse(String(reader.result || ''));
+	                const count = applyGeneModulesImport(payload);
+	                if (!count) alert('No valid feature modules found in this JSON file.');
+	            }} catch (error) {{
+	                alert(`Could not parse feature modules JSON: ${{error.message || error}}`);
+	            }}
+	        }};
+	        reader.onerror = () => alert('Could not read the selected feature modules file.');
+	        reader.readAsText(file);
+	    }}
 
-    function createGeneModule(name, genes) {{
-        const cleanGenes = Array.isArray(genes) ? genes.filter(Boolean) : [];
-        if (!cleanGenes.length) return null;
-        const id = `m${{Date.now().toString(36)}}${{Math.random().toString(36).slice(2, 7)}}`;
-        const module = {{
-            id,
-            name: String(name || '').trim() || `Module ${{geneModules.length + 1}}`,
-            genes: [...new Set(cleanGenes)],
-        }};
-        geneModules.push(module);
-        populateGeneInputDatalist();
-        return module;
-    }}
+	    function createGeneModule(name, genes, modality = getModuleBuilderModality()) {{
+	        const sourceModality = normalizeGeneModuleModality(modality);
+	        const cleanGenes = Array.isArray(genes)
+	            ? genes.map(feature => resolveCanonicalFeatureName(feature, sourceModality)).filter(Boolean)
+	            : [];
+	        if (!cleanGenes.length) return null;
+	        const id = `m${{Date.now().toString(36)}}${{Math.random().toString(36).slice(2, 7)}}`;
+	        const module = {{
+	            id,
+	            name: String(name || '').trim() || `Module ${{geneModules.length + 1}}`,
+	            modality: sourceModality,
+	            genes: [...new Set(cleanGenes)],
+	        }};
+	        geneModules.push(module);
+	        populateGeneInputDatalist();
+	        return module;
+	    }}
 
-    async function ensureGeneModuleAvailable(module, options = {{}}) {{
-        if (!module || !Array.isArray(module.genes) || !module.genes.length) return false;
-        const loaded = [];
-        for (const gene of module.genes) {{
-            const ok = await ensureFeatureAvailable(gene, {{ showErrors: options.showErrors !== false }});
-            if (ok) {{
-                loaded.push(gene);
-                ensureGeneAutoScale(gene);
-            }}
-        }}
-        module.genes = [...new Set(loaded)];
-        populateGeneInputDatalist();
-        return module.genes.length > 0;
-    }}
+	    async function ensureGeneModuleAvailable(module, options = {{}}) {{
+	        if (!module || !Array.isArray(module.genes) || !module.genes.length) return false;
+	        const sourceModality = getGeneModuleModality(module);
+	        const loaded = [];
+	        for (const gene of module.genes) {{
+	            const ok = await ensureFeatureAvailable(gene, {{ showErrors: options.showErrors !== false, modality: sourceModality }});
+	            if (ok) {{
+	                loaded.push(gene);
+	                ensureGeneAutoScale(gene, sourceModality);
+	            }}
+	        }}
+	        module.modality = sourceModality;
+	        module.genes = [...new Set(loaded)];
+	        populateGeneInputDatalist();
+	        rebuildFeatureIndex(MODULE_MODALITY_NAME);
+	        return module.genes.length > 0;
+	    }}
 
     function getGenePanelSeedToken() {{
-        const fromCurrent = resolveCanonicalFeatureName(currentGene);
+        const modality = getVisualModality();
+        const fromCurrent = resolveFeatureTokenForModality(currentGene, modality);
         if (fromCurrent) return fromCurrent;
         const geneInput = document.getElementById('feature-input');
-        return resolveCanonicalFeatureName(geneInput?.value || '');
+        return resolveFeatureTokenForModality(geneInput?.value || '', modality);
     }}
 
-    function upsertSavedGenePanel(panelName, gene = '') {{
+    function upsertSavedGenePanel(panelName, gene = '', modality = getVisualModality()) {{
         const normalizedName = String(panelName || '').trim();
         if (!normalizedName) return false;
-        const geneToken = resolveCanonicalFeatureName(gene);
+        const geneToken = resolveFeatureTokenForModality(gene, modality);
         const existingIndex = savedGenePanels.findIndex(
             panel => panel.name.toLowerCase() === normalizedName.toLowerCase()
         );
@@ -19258,15 +19384,15 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 genes: geneToken ? [geneToken] : [],
             }});
         }}
-        persistSavedGenePanels();
+        persistSavedGenePanels(modality);
         return true;
     }}
 
-    function deleteSavedGenePanel(panelName) {{
+    function deleteSavedGenePanel(panelName, modality = getVisualModality()) {{
         const normalizedName = String(panelName || '').trim().toLowerCase();
         if (!normalizedName) return;
         savedGenePanels = savedGenePanels.filter(panel => panel.name.toLowerCase() !== normalizedName);
-        persistSavedGenePanels();
+        persistSavedGenePanels(modality);
     }}
 
     function fuzzyGeneMatchScore(candidate, query) {{
@@ -19294,6 +19420,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function getGeneSearchResults(query, limit = GENE_DISCOVERY_MAX_RESULTS) {{
         const token = String(query || '').trim();
         if (!token) return [];
+        const modality = getVisualModality();
+        const modalityMeta = getFeatureState(modality).features_meta || {{}};
         return getGeneInputFeatureList()
             .map((gene) => {{
                 const match = fuzzyGeneMatchScore(gene, token);
@@ -19302,7 +19430,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     gene,
                     bucket: match.bucket,
                     score: match.score,
-                    loaded: !!DATA.features_meta?.[gene],
+                    loaded: !!modalityMeta[gene],
                 }};
             }})
             .filter(Boolean)
@@ -19317,8 +19445,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             .map(entry => entry.gene);
     }}
 
-    function getAvailableMarkerGeneColors() {{
-        return Object.entries(getExplorationMarkerFeaturesPayload())
+    function getAvailableMarkerGeneColors(modality = getExplorationModality()) {{
+        return Object.entries(getExplorationMarkerFeaturesPayload(modality))
             .filter(([, groups]) => groups && typeof groups === 'object' && Object.keys(groups).length > 0)
             .map(([color]) => color)
             .sort((a, b) => a.localeCompare(b));
@@ -19609,7 +19737,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return matched ? count : null;
     }}
 
-    function getGeneSuggestionGroups() {{
+    function getGeneSuggestionGroups(modality = getExplorationModality()) {{
         const config = getColorConfig();
         if (!config || config.is_continuous) {{
             return {{
@@ -19620,12 +19748,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }};
         }}
 
-        const markersByColor = (DATA.marker_genes || {{}})[currentAnnotation];
+        const markersByColor = getMarkerFeaturesPayloadForModality(modality)[currentAnnotation];
         if (!markersByColor || typeof markersByColor !== 'object') {{
-            const availableColors = getAvailableMarkerGeneColors();
+            const availableColors = getAvailableMarkerGeneColors(modality);
             const availableLabel = availableColors.length
                 ? ` Available for: ${{availableColors.join(', ')}}.`
-                : ' No pseudobulk DE features are embedded in this viewer.';
+                : ` No ${{getModalityDisplayLabel(modality)}} marker features are embedded in this viewer.`;
             return {{
                 title: `Suggested from ${{formatMetadataLabel(currentAnnotation)}}`,
                 subtitle: `No pseudobulk DE features are available for the active color.${{availableLabel}}`,
@@ -19637,8 +19765,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const categoryOrder = (config.categories || Object.keys(markersByColor)).map(cat => String(cat));
         const groups = categoryOrder
             .map((category) => {{
-                const genes = getMarkerGenesForColorCategory(currentAnnotation, category)
-                    .map(resolveCanonicalFeatureName)
+                const genes = getMarkerGenesForColorCategory(currentAnnotation, category, modality)
+                    .map(gene => resolveFeatureTokenForModality(gene, modality))
                     .filter(Boolean)
                     .slice(0, GENE_DISCOVERY_SUGGESTION_GENES_PER_GROUP);
                 if (!genes.length) return null;
@@ -20502,11 +20630,13 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             samples_view: samplesView || null,
             exploration_annotation_col: explorationColorCol || null,
             samples_meta_sort_by: samplesMetaSortBy || null,
-            gene_modules: geneModules.map(module => ({{
-                id: module.id,
-                name: module.name,
-                genes: module.genes.slice(),
-            }})),
+	            gene_modules: geneModules.map(module => ({{
+	                id: module.id,
+	                name: module.name,
+	                modality: getGeneModuleModality(module),
+	                features: module.genes.slice(),
+	                genes: module.genes.slice(),
+	            }})),
             section_rotations: sectionRotations,
             cell_opacity: cellOpacity,
             he_alignment: buildSessionHeAlignment(),
@@ -20638,10 +20768,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         let rotationsApplied = 0;
         const labelUpdatesApplied = applySessionCategoryLabelState(state.category_labels);
         const paletteUpdatesApplied = applySessionPaletteState(state.color_palettes);
-        if (Array.isArray(state.gene_modules)) {{
-            geneModules = normalizeGeneModules(state.gene_modules).filter(module => module.genes.length);
-            populateGeneInputDatalist();
-        }}
+	        if (Array.isArray(state.gene_modules)) {{
+	            geneModules = normalizeGeneModules(state.gene_modules).filter(module => module.genes.length);
+	            populateGeneInputDatalist();
+	            if (typeof syncVisualFeatureNamespaceSelect === 'function') syncVisualFeatureNamespaceSelect();
+	        }}
         if (state.section_rotations && typeof state.section_rotations === 'object') {{
             Object.entries(state.section_rotations).forEach(([sectionId, deg]) => {{
                 const section = sectionById.get(sectionId);
@@ -24650,7 +24781,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const referenceSelectStyle = getAnnotationDisplayColor(reference)
             ? ` style="border-color:${{getAnnotationDisplayColor(reference)}}"`
             : '';
-        const runButtonHtml = annotationDeQuickRunning
+        const runButtonHtml = annotationDeQuickRunning || fullRun?.running
             ? '<div class="selection-query-icon-btn selection-summary-find-markers loading" role="status" aria-label="Finding region markers"><span class="selection-summary-find-markers-spinner"></span></div>'
             : (!hasCompletedCalculation
                 ? '<button class="selection-query-icon-btn" id="region-de-run" type="button" title="Find region markers" aria-label="Find region markers"><svg viewBox="0 0 24 24" aria-hidden="true" data-icon="search"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg></button>'
@@ -24701,6 +24832,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ? getAnnotationDEExportState(source, reference, hasQuickResult ? deResult : null)
             : null;
         const renderCards = (result) => {{
+            const resultModality = result?.modality || getExplorationModality();
             const topN = Math.max(1, Number(annotationDeTopN) || ANNOTATION_DE_TOP_N);
             const colorA = getAnnotationDisplayColor(source) || 'var(--accent-strong)';
             const colorB = getAnnotationDisplayColor(reference) || '#4cc9f0';
@@ -24712,7 +24844,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         <div class="comparison-card-title comparison-de-card-title">
                             <div class="comparison-de-card-title-main">
                                 ${{renderGeneTokenButton(entry.gene, {{
+                                    allowUnknown: true,
                                     isActive: entry.gene === currentGene,
+                                    modality: resultModality,
                                     showMeta: false,
                                     title: 'Load region DE feature into the viewer',
                                 }})}}
@@ -24950,6 +25084,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const comparisonResult = annotationDeQuickResultKey === quickResultKey
                 ? annotationDeQuickResult
                 : annotationDeFullCache.get(pairKey);
+            const comparisonModality = comparisonResult?.modality || getExplorationModality();
             const expressionEntries = selectWelchTopResults(
                 comparisonResult?.results || [], annotationDeTopN, annotationDeMinPct, 1
             );
@@ -24965,7 +25100,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     const vmax = Math.max(1e-12, meanA, meanB);
                     const factor = meanB > 0 ? (meanA / meanB).toFixed(1) + 'x' : '—';
                     summaryHtml += `<div class="selection-summary-expr-row">
-                        <span class="selection-summary-expr-gene" data-gene-activate="${{escapeHtml(entry.gene)}}" title="Load ${{escapeHtml(entry.gene)}} into the viewer">${{escapeHtml(entry.gene)}}</span>
+                        <span class="selection-summary-expr-gene" data-gene-activate="${{escapeHtml(entry.gene)}}" data-gene-modality="${{escapeHtml(comparisonModality)}}" title="Load ${{escapeHtml(entry.gene)}} into the viewer">${{escapeHtml(entry.gene)}}</span>
                         <div class="selection-summary-expr-bars">
                             <div class="selection-summary-expr-bar" style="width:${{clampPercent(100 * meanA / vmax)}}%;background:${{colorA}}" title="Region A mean: ${{formatCompactNumber(meanA)}}">${{formatCompactNumber(meanA)}} (${{pctA.toFixed(0)}}%)</div>
                             <div class="selection-summary-expr-bar" style="width:${{clampPercent(100 * meanB / vmax)}}%;background:${{colorB}}" title="Region B mean: ${{formatCompactNumber(meanB)}}">${{formatCompactNumber(meanB)}} (${{pctB.toFixed(0)}}%)</div>
@@ -25047,6 +25182,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const runQuickBtn = container.querySelector('#region-de-run');
         if (runQuickBtn && source && reference) {{
             runQuickBtn.addEventListener('click', () => {{
+                if (shouldRunFullSidecarDE(getExplorationModality())) {{
+                    runFullRegionAnnotationDE(source, reference);
+                    return;
+                }}
                 if (annotationDeQuickRunning) return;
                 const token = ++annotationDeQuickRunToken;
                 annotationDeQuickRunning = true;
@@ -25108,10 +25247,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function refreshAfterGeneModuleChange() {{
-        geneDenseCache.clear();
-        invalidateGeneDensityCaches();
-        populateGeneInputDatalist();
-        const geneInput = document.getElementById('feature-input');
+	        geneDenseCache.clear();
+	        invalidateGeneDensityCaches();
+	        populateGeneInputDatalist();
+	        if (typeof syncVisualFeatureNamespaceSelect === 'function') syncVisualFeatureNamespaceSelect();
+	        const geneInput = document.getElementById('feature-input');
         if (geneInput && currentGene) geneInput.value = getGeneDisplayLabel(currentGene);
         renderGeneDiscoveryPanel();
         updateExpressionScaleUI();
@@ -25123,36 +25263,54 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         updateSelectionInfo();
     }}
 
-    function renderGeneModulePanel() {{
-        const panel = document.getElementById('insights-module-panel');
-        if (!panel) return;
-        const moduleGeneOptions = getGeneInputFeatureList()
-            .filter(gene => !geneModuleDraftGenes.includes(gene))
-            .map(gene => `<option value="${{escapeHtml(gene)}}">${{escapeHtml(gene)}}</option>`)
-            .join('');
+	    function renderGeneModulePanel() {{
+	        const panel = document.getElementById('insights-module-panel');
+	        if (!panel) return;
+	        const moduleModalityOptions = MODALITY_DESCRIPTORS.length
+	            ? MODALITY_DESCRIPTORS.map(desc => ({{ value: desc.name, label: desc.label || desc.name }}))
+	            : [{{ value: DEFAULT_MODALITY_NAME, label: getModalityDisplayLabel(DEFAULT_MODALITY_NAME) }}];
+	        const validModuleModalities = moduleModalityOptions.map(entry => entry.value).filter(Boolean);
+	        if (!validModuleModalities.includes(getModuleBuilderModality())) {{
+	            setModuleBuilderModality(validModuleModalities[0] || DEFAULT_MODALITY_NAME);
+	            geneModuleDraftGenes = [];
+	        }}
+	        const moduleFocusedModality = getModuleBuilderModality();
+	        const moduleFocusedModalityLabel = getModalityDisplayLabel(moduleFocusedModality);
+	        const activeModules = getGeneModulesForModality(moduleFocusedModality);
+	        const moduleModalityOptionsHtml = moduleModalityOptions
+	            .map(entry => `<option value="${{escapeHtml(entry.value)}}"${{entry.value === moduleFocusedModality ? ' selected' : ''}}>${{escapeHtml(entry.label)}}</option>`)
+	            .join('');
+	        const moduleGeneOptions = getFeatureDatalistValuesForModality(moduleFocusedModality)
+	            .filter(gene => !geneModuleDraftGenes.includes(gene))
+	            .map(gene => `<option value="${{escapeHtml(gene)}}"></option>`)
+	            .join('');
         const draftGenesHtml = geneModuleDraftGenes.length
             ? `<div class="gene-token-grid">${{geneModuleDraftGenes.map(gene => `
                 <button type="button" class="gene-token-btn" data-gene-module-draft-remove="${{escapeHtml(gene)}}" title="Remove ${{escapeHtml(gene)}} from this module">
                     <span>${{escapeHtml(gene)}}</span>
                 </button>
             `).join('')}}</div>`
-            : '<div class="gene-discovery-empty">Select genes from the dropdown.</div>';
-        const moduleListHtml = geneModules.length
-            ? geneModules.map((module) => {{
-                const token = getGeneModuleToken(module);
-                const isActive = currentGene === token;
-                const geneChips = module.genes.length
-                    ? `<div class="gene-token-grid">${{module.genes.map((gene) => renderGeneTokenButton(gene, {{
-                        isActive: gene === currentGene,
-                        title: `Load ${{gene}}`,
-                    }})).join('')}}</div>`
-                    : '<div class="gene-discovery-empty">No valid genes in this module.</div>';
-                return `
-                    <div class="gene-module-card" data-gene-module-id="${{escapeHtml(module.id)}}">
-                        <input type="text" name="gene_module_name_${{escapeHtml(module.id)}}" data-module-name-input="${{escapeHtml(module.id)}}" value="${{escapeHtml(module.name)}}" aria-label="Module name">
-                        <div class="gene-module-genes">${{geneChips}}</div>
-                        <div class="gene-module-actions">
-                            <button class="legend-btn icon-only${{isActive ? ' active' : ''}}" type="button" data-gene-module-load="${{escapeHtml(module.id)}}" title="${{isActive ? 'Module loaded' : 'Load module assay'}}" aria-label="${{isActive ? 'Module loaded' : 'Load module assay'}}"${{module.genes.length ? '' : ' disabled'}}>${{MODULE_LOAD_ICON}}</button>
+            : '<div class="gene-discovery-empty">Type or select features to add them.</div>';
+	        const moduleListHtml = activeModules.length
+	            ? activeModules.map((module) => {{
+	                const token = getGeneModuleToken(module);
+	                const isActive = currentGene === token;
+	                const sourceModality = getGeneModuleModality(module);
+	                const sourceModalityLabel = getModalityDisplayLabel(sourceModality);
+	                const geneChips = module.genes.length
+	                    ? `<div class="gene-token-grid">${{module.genes.map((gene) => renderGeneTokenButton(gene, {{
+	                        isActive: gene === currentGene && getVisualModality() === sourceModality,
+	                        modality: sourceModality,
+	                        title: `Load ${{gene}} into the ${{sourceModalityLabel}} viewer`,
+	                    }})).join('')}}</div>`
+	                    : '<div class="gene-discovery-empty">No valid features in this module.</div>';
+	                return `
+	                    <div class="gene-module-card" data-gene-module-id="${{escapeHtml(module.id)}}">
+	                        <input type="text" name="gene_module_name_${{escapeHtml(module.id)}}" data-module-name-input="${{escapeHtml(module.id)}}" value="${{escapeHtml(module.name)}}" aria-label="Module name">
+	                        <div class="agg-group-meta">${{escapeHtml(sourceModalityLabel)}} · ${{module.genes.length}} features</div>
+	                        <div class="gene-module-genes">${{geneChips}}</div>
+	                        <div class="gene-module-actions">
+	                            <button class="legend-btn icon-only${{isActive ? ' active' : ''}}" type="button" data-gene-module-load="${{escapeHtml(module.id)}}" title="${{isActive ? 'Module loaded' : 'Load module assay'}}" aria-label="${{isActive ? 'Module loaded' : 'Load module assay'}}"${{module.genes.length ? '' : ' disabled'}}>${{MODULE_LOAD_ICON}}</button>
                             <button class="legend-btn icon-only" type="button" data-gene-module-delete="${{escapeHtml(module.id)}}" title="Delete module" aria-label="Delete module">${{MODULE_DELETE_ICON}}</button>
                         </div>
                     </div>
@@ -25161,41 +25319,62 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             : '';
 
         panel.innerHTML = `
-            <div class="insights-panel-section" style="display:block">
-                <div class="gene-module-section-header">
-                    <label>Gene Modules</label>${{renderCalcInfoButton('module')}}
-                </div>
-                <div class="gene-module-form">
-                    <select id="gene-module-gene-picker" aria-label="Add gene to module"${{moduleGeneOptions ? '' : ' disabled'}}>
-                        <option value="">Select gene...</option>
-                        ${{moduleGeneOptions}}
-                    </select>
-                    <div class="gene-module-draft" id="gene-module-draft-genes">${{draftGenesHtml}}</div>
-                    <div class="gene-module-form-actions">
+	            <div class="insights-panel-section" style="display:block">
+	                <div class="gene-module-section-header">
+	                    <label>Feature Modules</label>${{renderCalcInfoButton('module')}}
+	                </div>
+	                <div class="gene-module-form">
+	                    <div>
+	                        <label for="gene-module-modality-select">Focused modality</label>
+	                        <select id="gene-module-modality-select"${{moduleModalityOptions.length > 1 ? '' : ' disabled'}}>${{moduleModalityOptionsHtml}}</select>
+	                    </div>
+	                    <input type="text" id="gene-module-gene-picker" list="gene-module-gene-list" placeholder="Add ${{escapeHtml(moduleFocusedModalityLabel)}} feature..." autocomplete="off" spellcheck="false" aria-label="Add feature to module"${{moduleGeneOptions ? '' : ' disabled'}}>
+	                    <datalist id="gene-module-gene-list">${{moduleGeneOptions}}</datalist>
+	                    <div class="gene-module-draft" id="gene-module-draft-genes">${{draftGenesHtml}}</div>
+	                    <div class="gene-module-form-actions">
                         <button class="legend-btn icon-only" id="gene-module-create" type="button" title="Create module" aria-label="Create module"${{geneModuleDraftGenes.length ? '' : ' disabled'}}>${{MODULE_CREATE_ICON}}</button>
                     </div>
                 </div>
-            </div>
-            <div class="insights-panel-section" style="display:block">
-                ${{moduleListHtml ? '<label>Modules</label>' : ''}}
-                <div>${{moduleListHtml}}</div>
-                <div class="gene-module-form-actions" style="margin-top: 7px;">
-                    <button class="legend-btn icon-only" id="gene-module-download" type="button" title="Download modules JSON" aria-label="Download modules JSON"${{geneModules.length ? '' : ' disabled'}}>${{LEGEND_EXPORT_ICON}}</button>
-                    <button class="legend-btn icon-only" id="gene-module-upload" type="button" title="Upload modules JSON" aria-label="Upload modules JSON">${{LEGEND_IMPORT_ICON}}</button>
-                    <input type="file" id="gene-module-upload-input" accept="application/json,.json" style="display:none">
-                </div>
-            </div>
-        `;
+	            </div>
+	            <div class="insights-panel-section" style="display:block">
+	                <label>${{escapeHtml(moduleFocusedModalityLabel)}} modules</label>
+	                <div>${{moduleListHtml || `<div class="gene-discovery-empty">No ${{escapeHtml(moduleFocusedModalityLabel)}} feature modules yet.</div>`}}</div>
+	                <div class="gene-module-form-actions" style="margin-top: 7px;">
+	                    <button class="legend-btn icon-only" id="gene-module-download" type="button" title="Download feature modules JSON" aria-label="Download feature modules JSON"${{geneModules.length ? '' : ' disabled'}}>${{LEGEND_EXPORT_ICON}}</button>
+	                    <button class="legend-btn icon-only" id="gene-module-upload" type="button" title="Upload feature modules JSON" aria-label="Upload feature modules JSON">${{LEGEND_IMPORT_ICON}}</button>
+	                    <input type="file" id="gene-module-upload-input" accept="application/json,.json" style="display:none">
+	                </div>
+	            </div>
+	        `;
 
-        panel.querySelector('#gene-module-gene-picker')?.addEventListener('change', (event) => {{
-            const gene = resolveCanonicalFeatureName(event.target.value);
-            if (gene && !geneModuleDraftGenes.includes(gene)) {{
-                geneModuleDraftGenes.push(gene);
+	        const moduleModalitySelect = panel.querySelector('#gene-module-modality-select');
+	        moduleModalitySelect?.addEventListener('change', () => {{
+	            const nextModality = moduleModalitySelect.value || DEFAULT_MODALITY_NAME;
+	            if (nextModality === getModuleBuilderModality()) return;
+	            setModuleBuilderModality(nextModality);
+	            geneModuleDraftGenes = [];
+	            renderGeneModulePanel();
+	            updateTutorialStepGate?.();
+	        }});
+
+	        const moduleGenePicker = panel.querySelector('#gene-module-gene-picker');
+	        const commitModuleGenePicker = () => {{
+	            if (!moduleGenePicker) return;
+	            const gene = resolveCanonicalFeatureName(moduleGenePicker.value, moduleFocusedModality);
+	            if (gene && !geneModuleDraftGenes.includes(gene)) {{
+	                geneModuleDraftGenes.push(gene);
+	                moduleGenePicker.value = '';
                 renderGeneModulePanel();
                 updateTutorialStepGate?.();
             }} else {{
-                event.target.value = '';
+                moduleGenePicker.value = '';
             }}
+        }};
+        moduleGenePicker?.addEventListener('change', commitModuleGenePicker);
+        moduleGenePicker?.addEventListener('keydown', (event) => {{
+            if (event.key !== 'Enter') return;
+            event.preventDefault();
+            commitModuleGenePicker();
         }});
         panel.querySelectorAll('[data-gene-module-draft-remove]').forEach((btn) => {{
             btn.addEventListener('click', () => {{
@@ -25205,17 +25384,17 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 updateTutorialStepGate?.();
             }});
         }});
-        panel.querySelector('#gene-module-create')?.addEventListener('click', async () => {{
-            const genes = geneModuleDraftGenes.slice();
-            if (!genes.length) {{
-                alert('Select at least one valid gene for the module.');
-                return;
-            }}
-            const advanceTutorialFromModuleCreate = tutorialActive && tutorialSteps[tutorialStepIndex]?.requiresModuleCreateClicked;
-            const module = createGeneModule('', genes);
-            if (module) {{
-                geneModuleDraftGenes = [];
-                await ensureGeneModuleAvailable(module, {{ showErrors: false }});
+	        panel.querySelector('#gene-module-create')?.addEventListener('click', async () => {{
+	            const genes = geneModuleDraftGenes.slice();
+	            if (!genes.length) {{
+	                alert('Select at least one valid feature for the module.');
+	                return;
+	            }}
+	            const advanceTutorialFromModuleCreate = tutorialActive && tutorialSteps[tutorialStepIndex]?.requiresModuleCreateClicked;
+	            const module = createGeneModule('', genes, moduleFocusedModality);
+	            if (module) {{
+	                geneModuleDraftGenes = [];
+	                await ensureGeneModuleAvailable(module, {{ showErrors: false }});
                 refreshAfterGeneModuleChange();
                 renderGeneModulePanel();
                 if (advanceTutorialFromModuleCreate) {{
@@ -25243,13 +25422,16 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             moduleUploadInput.value = '';
         }});
 
-        panel.querySelectorAll('[data-gene-module-load]').forEach((btn) => {{
-            btn.addEventListener('click', async () => {{
-                const module = geneModules.find(item => String(item.id) === String(btn.getAttribute('data-gene-module-load')));
-                if (!module) return;
-                await activateViewerGene(getGeneModuleToken(module), {{ showErrors: true }});
-                renderGeneModulePanel();
-            }});
+	        panel.querySelectorAll('[data-gene-module-load]').forEach((btn) => {{
+	            btn.addEventListener('click', async () => {{
+	                const module = geneModules.find(item => String(item.id) === String(btn.getAttribute('data-gene-module-load')));
+	                if (!module) return;
+	                if (getVisualModality() !== MODULE_MODALITY_NAME && typeof setActiveModality === 'function') {{
+	                    await setActiveModality(MODULE_MODALITY_NAME);
+	                }}
+	                await activateViewerGene(getGeneModuleToken(module), {{ showErrors: true }});
+	                renderGeneModulePanel();
+	            }});
         }});
 
         panel.querySelectorAll('[data-module-name-input]').forEach((input) => {{
@@ -25331,6 +25513,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 <div class="insights-panel-section">
                     <label id="exploration-annotation-label">Annotation</label>
                     <select id="exploration-annotation-select"></select>
+                </div>
+                <div class="insights-panel-section" id="exploration-feature-modality-section">
+                    <label for="exploration-feature-modality-select">Focused modality</label>
+                    <select id="exploration-feature-modality-select"></select>
                 </div>
                 <div class="insights-panel-section">
                     <label id="visualization-menu-label">Select</label>
@@ -25425,16 +25611,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 <div class="insights-tab-content" id="insights-tab-genes-content">
                     <div id="genes-details-warnings"></div>
                     <div id="genes-details-content">
-                    <div class="insights-panel-section" id="exploration-feature-modality-section">
-                        <label for="exploration-feature-modality-select">Feature namespace</label>
-                        <select id="exploration-feature-modality-select"></select>
-                    </div>
                     <div class="insights-panel-section" id="genes-search-section">
                         <label for="marker-gene-search">Search</label>
                         <div class="marker-gene-search-wrap">
-                            <select class="marker-search" id="marker-gene-search" aria-label="Search pseudobulk features">
-                                ${{renderInsightsGeneSearchOptions('', 'All features')}}
-                            </select>
+                            <input class="marker-search" id="marker-gene-search" type="text" list="marker-gene-search-list" placeholder="All features" autocomplete="off" spellcheck="false" aria-label="Search pseudobulk features">
+                            <datalist id="marker-gene-search-list">${{renderInsightsGeneSearchDatalistOptions()}}</datalist>
                             <button class="marker-gene-clear-btn" id="marker-gene-search-clear" type="button" title="Clear selected feature" aria-label="Clear selected feature">&times;</button>
                         </div>
                     </div>
@@ -25641,18 +25822,26 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             if (explorationFeatureModalitySection) {{
                 explorationFeatureModalitySection.style.display = modalityOptions.length > 1 ? '' : 'none';
             }}
-            explorationFeatureModalitySelect.addEventListener('change', async () => {{
-                const nextModality = explorationFeatureModalitySelect.value || DEFAULT_MODALITY_NAME;
-                setExplorationModality(nextModality);
-                const markerSearch = document.getElementById('marker-gene-search');
-                if (markerSearch) {{
-                    markerSearch.value = '';
-                    refreshLoadedGeneFilterDropdowns();
-                }}
-                await activateViewerGene('', {{ showErrors: false }});
-                renderGeneDiscoveryPanel?.();
-                renderActiveInsightsPanel();
-            }});
+	            explorationFeatureModalitySelect.addEventListener('change', async () => {{
+	                const nextModality = explorationFeatureModalitySelect.value || DEFAULT_MODALITY_NAME;
+	                const shouldRerunSelectionComparison = selectionWelchRunRequested && selectedCells.size > 0;
+	                setExplorationModality(nextModality);
+	                invalidateAnnotationDEState(true);
+	                invalidateGroupDEState(true);
+	                selectionWelchRevision += 1;
+	                selectionWelchCache.clear();
+	                selectionWelchRunRequested = shouldRerunSelectionComparison;
+	                selectionWelchRunning = false;
+	                selectionWelchButtonHidden = shouldRerunSelectionComparison;
+	                const markerSearch = document.getElementById('marker-gene-search');
+	                if (markerSearch) {{
+	                    markerSearch.value = '';
+	                    refreshLoadedGeneFilterDropdowns();
+	                }}
+	                renderGeneDiscoveryPanel?.();
+	                updateSelectionInfo?.();
+	                renderActiveInsightsPanel();
+	            }});
         }}
 
         const groupBy = document.getElementById('annotation-section-key');
@@ -25736,7 +25925,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }});
         }});
         const markerSearch = document.getElementById('marker-gene-search');
-        markerSearch?.addEventListener('change', async () => {{
+        const commitMarkerSearch = async () => {{
             const advanceTutorialFromInsightsGene = tutorialActive && tutorialSteps[tutorialStepIndex]?.requiresInsightsGeneSelected;
             const advanceTutorialIfReady = () => {{
                 updateTutorialStepGate?.();
@@ -25769,6 +25958,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             // Keep the selected term as a panel filter, without trying to load it.
             renderActiveInsightsPanel();
             advanceTutorialIfReady();
+        }};
+        markerSearch?.addEventListener('change', commitMarkerSearch);
+        markerSearch?.addEventListener('keydown', async (event) => {{
+            if (event.key !== 'Enter') return;
+            event.preventDefault();
+            await commitMarkerSearch();
         }});
         document.getElementById('marker-gene-search-clear')?.addEventListener('click', async () => {{
             const markerSearch = document.getElementById('marker-gene-search');
@@ -29874,6 +30069,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             format: 'karospace-group-de-report-v1',
             exported_at: new Date().toISOString(),
             result_mode: exportState.mode,
+            modality: result.modality || getExplorationModality(),
             annotation_column: currentAnnotation || null,
             top_genes_requested: topN,
             group_a: buildGroupBlock(groupA, result.nA),
@@ -29913,6 +30109,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             'pct_expr_b',
             'mean_a',
             'mean_b',
+            'modality',
             'result_mode',
             'annotation_column',
             'group_a_label',
@@ -29945,6 +30142,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 entry.pct_expr_b,
                 entry.mean_a,
                 entry.mean_b,
+                report.modality,
                 report.result_mode,
                 report.annotation_column,
                 report.group_a?.label,
@@ -30002,6 +30200,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         renderGroupDE();
         try {{
             const result = await runFullCellSetDE(groupA, groupB, {{
+                modality: getExplorationModality(),
                 isCancelled: () => groupDeFullRunToken !== token,
                 onProgress: (progress) => {{
                     if (groupDeFullRunToken !== token) return;
@@ -30178,11 +30377,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 reason: 'empty_group',
                 nA: Number(groupA.nCells || 0),
                 nB: Number(groupB.nCells || 0),
+                modality: getExplorationModality(),
                 results: [],
             }};
         }}
 
-        const activeModality = getVisualModality();
+        const activeModality = getExplorationModality();
         const loadedGenes = getLoadedFeaturesForModality(activeModality);
         const totalGenes = getFeatureCatalog(activeModality).length || loadedGenes.length;
         if (!loadedGenes.length) {{
@@ -30191,6 +30391,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 reason: 'no_loaded_features',
                 nA: Number(groupA.nCells || 0),
                 nB: Number(groupB.nCells || 0),
+                modality: activeModality,
                 loadedGeneCount: 0,
                 totalGeneCount: totalGenes,
                 results: [],
@@ -30204,8 +30405,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const end = Math.min(i + BATCH, loadedGenes.length);
             for (let j = i; j < end; j++) {{
                 const gene = loadedGenes[j];
-                const statsA = computeQuickStatsForGroupGene(groupA, gene);
-                const statsB = computeQuickStatsForGroupGene(groupB, gene);
+                const statsA = computeQuickStatsForGroupGene(groupA, gene, activeModality);
+                const statsB = computeQuickStatsForGroupGene(groupB, gene, activeModality);
                 const entry = buildDEEntryFromStats(gene, statsA, statsB, groupA.nCells, groupB.nCells);
                 if (entry) results.push(entry);
             }}
@@ -30219,6 +30420,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             reason: null,
             nA: Number(groupA.nCells || 0),
             nB: Number(groupB.nCells || 0),
+            modality: activeModality,
             loadedGeneCount: loadedGenes.length,
             totalGeneCount: totalGenes,
             results: selectTwoSidedTopN(results, topN),
@@ -30454,13 +30656,16 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const fullRun = (groupDeFullRun && groupDeFullRun.key === pairKey) ? groupDeFullRun : null;
             const sidecarAvailable = !!DATA.feature_manifest_url;
             const renderCards = (result) => {{
+                const resultModality = result?.modality || getExplorationModality();
                 const topN = Math.max(1, Number(deferredTopN) || ANNOTATION_DE_TOP_N);
                 return selectTwoSidedTopN(result.results || [], topN).map((entry) => {{
                     return `
                         <div class="comparison-card">
                             <div class="comparison-card-title">
                                 ${{renderGeneTokenButton(entry.gene, {{
+                                    allowUnknown: true,
                                     isActive: entry.gene === currentGene,
+                                    modality: resultModality,
                                     showMeta: false,
                                     title: 'Load group DE feature into the viewer',
                                 }})}}
@@ -30700,7 +30905,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function getAnnotationGroupDEPairKey(spec, valueA, valueB, restrictSpec, restrictValue) {{
         const groupAKey = buildGroupDEKey(spec, valueA, restrictSpec, restrictValue, 'all');
         const groupBKey = buildGroupDEKey(spec, valueB, restrictSpec, restrictValue, 'all');
-        return `${{groupAKey}}::${{groupBKey}}`;
+        return `${{getExplorationModality()}}::${{groupAKey}}::${{groupBKey}}`;
     }}
 
     function syncAnnotationGroupDEState() {{
@@ -30754,7 +30959,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const options = {{ restrictSpec, restrictValue, scope: 'all', isCancelled: () => token !== groupDeQuickRunToken }};
         const groupA = await buildGroupDECellSetAsync(sourceSpec, valueA, options);
         const groupB = await buildGroupDECellSetAsync(sourceSpec, valueB, options);
-        if (token !== groupDeQuickRunToken || !groupA || !groupB) return;
+        if (token !== groupDeQuickRunToken) return;
+        if (!groupA || !groupB) {{
+            groupDeQuickRunning = false;
+            renderGroupDE();
+            return;
+        }}
         const result = computePooledWelchCellSetDE(groupA, groupB);
         if (token !== groupDeQuickRunToken) return;
         groupDeQuickGroups = {{ key: getGroupDECacheKey(groupA, groupB), groupA, groupB }};
@@ -30762,6 +30972,31 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         groupDeQuickResultKey = groupDeQuickGroups.key;
         groupDeQuickRunning = false;
         renderGroupDE();
+    }}
+
+    async function runAnnotationGroupDE(sourceSpec, valueA, valueB, restrictSpec, restrictValue) {{
+        if (!shouldRunFullSidecarDE(getExplorationModality())) {{
+            await runAnnotationGroupDEQuick(sourceSpec, valueA, valueB, restrictSpec, restrictValue);
+            return;
+        }}
+        const token = ++groupDeQuickRunToken;
+        groupDeQuickRunning = true;
+        renderGroupDE();
+        await new Promise((resolve) => window.setTimeout(resolve, 30));
+        const options = {{ restrictSpec, restrictValue, scope: 'all', isCancelled: () => token !== groupDeQuickRunToken }};
+        const groupA = await buildGroupDECellSetAsync(sourceSpec, valueA, options);
+        const groupB = await buildGroupDECellSetAsync(sourceSpec, valueB, options);
+        if (token !== groupDeQuickRunToken) return;
+        if (!groupA || !groupB) {{
+            groupDeQuickRunning = false;
+            renderGroupDE();
+            return;
+        }}
+        groupDeQuickGroups = {{ key: getGroupDECacheKey(groupA, groupB), groupA, groupB }};
+        groupDeQuickResult = null;
+        groupDeQuickResultKey = '';
+        groupDeQuickRunning = false;
+        runFullGroupDE(groupA, groupB);
     }}
 
     function renderGroupDE() {{
@@ -30799,7 +31034,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const fullCached = groupDeFullCache.get(pairKey) || null;
         const fullRun = groupDeFullRun?.key === pairKey ? groupDeFullRun : null;
         const hasCompletedCalculation = !!quickResult?.available || !!fullCached?.available;
-        const runButtonHtml = groupDeQuickRunning
+        const runButtonHtml = groupDeQuickRunning || fullRun?.running
             ? '<div class="selection-query-icon-btn selection-summary-find-markers loading" role="status" aria-label="Finding annotation markers"><span class="selection-summary-find-markers-spinner"></span></div>'
             : (!hasCompletedCalculation ? '<button class="selection-query-icon-btn" id="group-de-run" type="button" title="Find annotation markers" aria-label="Find annotation markers"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg></button>' : '');
         const controlsHtml = `
@@ -30827,7 +31062,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const displayed = result?.available ? selectWelchTopResults(result.results || [], groupDeTopN, groupDeMinPct, 1) : [];
         const renderCards = () => displayed.map((entry) => {{
             const sideColor = Number(entry.score || 0) >= 0 ? colorA : colorB;
-            return `<div class="comparison-card"><div class="comparison-card-title comparison-de-card-title"><div class="comparison-de-card-title-main">${{renderGeneTokenButton(entry.gene, {{ isActive: entry.gene === currentGene, showMeta: false, title: 'Load annotation DE feature into the viewer' }})}}${{renderGeneGoogleSearchButton(entry.gene, {{ title: 'Search Google for this feature' }})}}</div><div class="comparison-de-title-stats" style="border-color:${{sideColor}}"><span>log2FC ${{formatScaleNumber(entry.log2fc)}}</span><span>Score ${{formatScaleNumber(entry.score)}}</span></div></div><div class="comparison-metric-grid"><span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorA, sideColor)}};color:${{getTextColorForBackground(colorA)}}"><span>% detected A</span><strong>${{formatPseudobulkDEPct(entry.pctA)}}</strong><span>Mean A</span><strong>${{formatScaleNumber(entry.meanA)}}</strong></span><span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorB, sideColor)}};color:${{getTextColorForBackground(colorB)}}"><span>% detected B</span><strong>${{formatPseudobulkDEPct(entry.pctB)}}</strong><span>Mean B</span><strong>${{formatScaleNumber(entry.meanB)}}</strong></span></div></div>`;
+            const resultModality = result?.modality || getExplorationModality();
+            return `<div class="comparison-card"><div class="comparison-card-title comparison-de-card-title"><div class="comparison-de-card-title-main">${{renderGeneTokenButton(entry.gene, {{ allowUnknown: true, isActive: entry.gene === currentGene, modality: resultModality, showMeta: false, title: 'Load annotation DE feature into the viewer' }})}}${{renderGeneGoogleSearchButton(entry.gene, {{ title: 'Search Google for this feature' }})}}</div><div class="comparison-de-title-stats" style="border-color:${{sideColor}}"><span>log2FC ${{formatScaleNumber(entry.log2fc)}}</span><span>Score ${{formatScaleNumber(entry.score)}}</span></div></div><div class="comparison-metric-grid"><span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorA, sideColor)}};color:${{getTextColorForBackground(colorA)}}"><span>% detected A</span><strong>${{formatPseudobulkDEPct(entry.pctA)}}</strong><span>Mean A</span><strong>${{formatScaleNumber(entry.meanA)}}</strong></span><span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorB, sideColor)}};color:${{getTextColorForBackground(colorB)}}"><span>% detected B</span><strong>${{formatPseudobulkDEPct(entry.pctB)}}</strong><span>Mean B</span><strong>${{formatScaleNumber(entry.meanB)}}</strong></span></div></div>`;
         }}).join('');
         if (groupDeQuickRunning) {{
             html += '<div id="group-de-results"></div>';
@@ -30851,7 +31087,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     }});
                 }}
             }}
-            html += `<div class="selection-summary-expr"><div class="selection-summary-title">Feature Values by Annotation</div>${{displayed.map((entry) => {{ const vmax = Math.max(1e-12, Number(entry.meanA || 0), Number(entry.meanB || 0)); const factor = entry.meanB > 0 ? `${{(entry.meanA / entry.meanB).toFixed(1)}}x` : '—'; return `<div class="selection-summary-expr-row"><span class="selection-summary-expr-gene" data-gene-activate="${{escapeHtml(entry.gene)}}">${{escapeHtml(entry.gene)}}</span><div class="selection-summary-expr-bars"><div class="selection-summary-expr-bar" style="width:${{clampPercent(100 * entry.meanA / vmax)}}%;background:${{colorA}}">${{formatCompactNumber(entry.meanA)}} (${{(100 * entry.pctA).toFixed(0)}}%)</div><div class="selection-summary-expr-bar" style="width:${{clampPercent(100 * entry.meanB / vmax)}}%;background:${{colorB}}">${{formatCompactNumber(entry.meanB)}} (${{(100 * entry.pctB).toFixed(0)}}%)</div></div><span class="selection-summary-expr-factor">${{factor}}</span></div>`; }}).join('')}}</div>`;
+            html += `<div class="selection-summary-expr"><div class="selection-summary-title">Feature Values by Annotation</div>${{displayed.map((entry) => {{ const resultModality = result?.modality || getExplorationModality(); const vmax = Math.max(1e-12, Number(entry.meanA || 0), Number(entry.meanB || 0)); const factor = entry.meanB > 0 ? `${{(entry.meanA / entry.meanB).toFixed(1)}}x` : '—'; return `<div class="selection-summary-expr-row"><span class="selection-summary-expr-gene" data-gene-activate="${{escapeHtml(entry.gene)}}" data-gene-modality="${{escapeHtml(resultModality)}}">${{escapeHtml(entry.gene)}}</span><div class="selection-summary-expr-bars"><div class="selection-summary-expr-bar" style="width:${{clampPercent(100 * entry.meanA / vmax)}}%;background:${{colorA}}">${{formatCompactNumber(entry.meanA)}} (${{(100 * entry.pctA).toFixed(0)}}%)</div><div class="selection-summary-expr-bar" style="width:${{clampPercent(100 * entry.meanB / vmax)}}%;background:${{colorB}}">${{formatCompactNumber(entry.meanB)}} (${{(100 * entry.pctB).toFixed(0)}}%)</div></div><span class="selection-summary-expr-factor">${{factor}}</span></div>`; }}).join('')}}</div>`;
             const volcanoToolbar = '<button class="icon-btn" type="button" data-group-de-export-volcano title="Download volcano plot as SVG" aria-label="Download volcano plot as SVG"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg></button>';
             html += `<div id="group-de-results">${{buildGroupVolcanoPlot(displayed, volcanoToolbar, {{ positive: colorA, negative: colorB }})}}<div class="comparison-stack">${{renderCards()}}</div><div style="display:flex;justify-content:flex-end;gap:6px;margin-top:6px;"><button class="icon-btn" type="button" data-group-de-export-csv title="Download all annotation comparison features as CSV" aria-label="Download all annotation comparison features as CSV"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg></button></div>${{DATA.feature_manifest_url && result === quickResult && Number(result.loadedGeneCount || 0) < Number(result.totalGeneCount || 0) ? '<div style="display:flex;justify-content:flex-end"><button class="legend-btn" id="group-de-run-full" type="button">Run Full DE</button></div>' : ''}}</div>`;
         }} else if (quickResult && !quickResult.available) {{
@@ -30881,7 +31117,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             if (oldFull) groupDeFullCache.set(nextKey, invertGroupDEResult(oldFull));
             renderGroupDE();
         }});
-        container.querySelector('#group-de-run')?.addEventListener('click', () => {{ runAnnotationGroupDEQuick(sourceSpec, groupDeSourceValue, groupDeReferenceValue, restrictSpec, groupDeRestrictValue); }});
+        container.querySelector('#group-de-run')?.addEventListener('click', () => {{ runAnnotationGroupDE(sourceSpec, groupDeSourceValue, groupDeReferenceValue, restrictSpec, groupDeRestrictValue); }});
         container.querySelector('#group-de-run-full')?.addEventListener('click', () => {{ if (groupDeQuickGroups?.key === pairKey) runFullGroupDE(groupDeQuickGroups.groupA, groupDeQuickGroups.groupB); }});
         container.querySelector('[data-group-de-export-volcano]')?.addEventListener('click', () => {{
             downloadComparisonVolcanoSvg(
@@ -33950,34 +34186,20 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
         const visualDefaultControls = document.getElementById('visual-default-controls');
         const defaultSourceAnnotationBtn = document.getElementById('default-source-annotation');
-        const defaultSourceGeneBtn = document.getElementById('default-source-feature');
-        const modalityControl = document.getElementById('visual-feature-namespace-control');
-        const modalitySelect = document.getElementById('visual-feature-namespace-select');
-        const syncFeatureNamespaceSelect = () => {{
-            if (!modalityControl || !modalitySelect) return;
-            const options = getFeatureNamespaceOptions();
-            const active = getVisualModality();
-            modalitySelect.replaceChildren();
-            options.forEach((entry) => {{
-                const opt = document.createElement('option');
-                opt.value = entry.value;
-                opt.textContent = entry.label;
-                if (entry.value === active) opt.selected = true;
-                modalitySelect.appendChild(opt);
-            }});
-            modalityControl.style.display = options.length > 1 ? '' : 'none';
-        }};
+	        const defaultSourceGeneBtn = document.getElementById('default-source-feature');
+	        const modalityControl = document.getElementById('visual-feature-namespace-control');
+	        const modalitySelect = document.getElementById('visual-feature-namespace-select');
+	        const syncFeatureNamespaceSelect = () => {{
+	            syncVisualFeatureNamespaceSelect();
+	        }};
         const setDefaultVisualSource = (source) => {{
             const mode = source === 'feature' ? 'feature' : 'color';
             visualDefaultControls?.classList.toggle('annotation-mode', mode === 'color');
             visualDefaultControls?.classList.toggle('feature-mode', mode === 'feature');
-            defaultSourceAnnotationBtn?.classList.toggle('active', mode === 'color');
-            defaultSourceGeneBtn?.classList.toggle('active', mode === 'feature');
-            if (modalityControl) {{
-                const hasMultipleNamespaces = getFeatureNamespaceOptions().length > 1;
-                modalityControl.style.display = mode === 'feature' && hasMultipleNamespaces ? '' : 'none';
-            }}
-        }};
+	            defaultSourceAnnotationBtn?.classList.toggle('active', mode === 'color');
+	            defaultSourceGeneBtn?.classList.toggle('active', mode === 'feature');
+	            syncFeatureNamespaceSelect();
+	        }};
         const applyDefaultVisualSource = async (source) => {{
             const mode = source === 'feature' ? 'feature' : 'color';
             setDefaultVisualSource(mode);
@@ -33986,8 +34208,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 return;
             }}
             const geneInput = document.getElementById('feature-input');
-            const requested = resolveCanonicalFeatureName(geneInput?.value || '')
-                || resolveCanonicalFeatureName(currentGene)
+            const visualModality = getVisualModality();
+            const requested = resolveFeatureTokenForModality(geneInput?.value || '', visualModality)
+                || resolveFeatureTokenForModality(currentGene, visualModality)
                 || '';
             if (!requested) return;
             await activateViewerGene(requested, {{ showErrors: false }});
@@ -34048,7 +34271,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
             if (e.key === 'Enter') {{
                 const highlightedGene = geneDiscoveryResults[geneDiscoveryActiveIndex];
-                const exactGene = resolveCanonicalFeatureName(geneInput.value);
+                const exactGene = resolveFeatureTokenForModality(geneInput.value, getVisualModality());
                 if (!highlightedGene && !exactGene && geneInput.value.trim()) return;
                 e.preventDefault();
                 await activateViewerGene(highlightedGene || exactGene || geneInput.value, {{ showErrors: false }});
@@ -34066,7 +34289,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 refreshInsights();
                 return;
             }}
-            const exactGene = resolveCanonicalFeatureName(raw);
+            const exactGene = resolveFeatureTokenForModality(raw, getVisualModality());
             if (exactGene) {{
                 await activateViewerGene(exactGene, {{ showErrors: false }});
                 refreshInsights();
@@ -34075,7 +34298,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
         }});
         genePanelNew?.addEventListener('click', () => {{
-            const seedGene = resolveCanonicalFeatureName(currentGene);
+            const seedGene = resolveFeatureTokenForModality(currentGene, getVisualModality());
             const suggestedName = seedGene ? `${{seedGene}} panel` : '';
             const panelName = prompt('Panel name', suggestedName);
             if (!panelName) return;
@@ -34099,7 +34322,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 const panelName = addBtn.getAttribute('data-gene-panel-add') || '';
                 const geneToken = getGenePanelSeedToken();
                 if (!geneToken) {{
-                    alert('Load or type an exact gene first, then add it to a panel.');
+                    alert('Load or type an exact feature first, then add it to a panel.');
                     return;
                 }}
                 upsertSavedGenePanel(panelName, geneToken);
@@ -36106,6 +36329,7 @@ def export_to_html(
     else:
         data.pop("export_reproducibility", None)
 
+    log_step("Serializing viewer data")
     data_json_safe, section_data_scripts = _serialize_embedded_viewer_data(data)
 
     tutorial_trigger_html = ""
@@ -36269,6 +36493,9 @@ def export_to_html(
                     f"in {shard_elapsed:.1f}s",
                     level=2,
                 )
+        if progress is not None:
+            progress.close()
+            progress = None
         # Mirror RNA fields under manifest.modalities for forward-compat.
         manifest["modalities"] = {
             default_modality_name: {
@@ -36351,8 +36578,6 @@ def export_to_html(
             _validate_feature_sidecar_manifest_payload(manifest, resolved_feature_manifest_path)
         if total_sidecar_features:
             total_elapsed = time.perf_counter() - sidecar_t0
-            if progress is not None:
-                progress.close()
             log_detail(f"Completed feature sidecar build in {total_elapsed:.1f}s.")
     log_step("Writing HTML viewer")
     log_detail(f"Output path: {output_path}")

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -7719,9 +7719,6 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
         }});
     }}
-    DATA.features_meta = DATA.features_meta || {{}};
-    DATA.feature_encodings = DATA.feature_encodings || {{}};
-    DATA.feature_value_encodings = DATA.feature_value_encodings || {{}};
     DATA.pseudobulk_de = DATA.pseudobulk_de || DATA.pseudobulk_de_json || {{}};
     delete DATA.pseudobulk_de_json;
     const TUTORIAL_CONFIG = DATA.tutorial && typeof DATA.tutorial === 'object' ? DATA.tutorial : {{ enabled: false }};
@@ -7734,6 +7731,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     const FEATURES_BY_MODALITY = (DATA.features_by_modality && typeof DATA.features_by_modality === 'object')
         ? DATA.features_by_modality
         : {{}};
+    const FEATURE_STATE_BY_MODALITY = (DATA.feature_state_by_modality && typeof DATA.feature_state_by_modality === 'object')
+        ? DATA.feature_state_by_modality
+        : {{}};
     const DEFAULT_MODALITY_NAME = DATA.default_modality
         || (MODALITY_DESCRIPTORS.find(d => d && d.is_default)?.name)
         || (MODALITY_DESCRIPTORS[0]?.name)
@@ -7743,12 +7743,6 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     function getActiveModalityDescriptor() {{
         return MODALITY_DESCRIPTORS.find(d => d && d.name === CURRENT_MODALITY) || null;
-    }}
-    function getLoadedFeaturesForModality(modality = CURRENT_MODALITY) {{
-        const meta = (modality === CURRENT_MODALITY || (modality === 'gene' && CURRENT_MODALITY === 'rna'))
-            ? DATA.features_meta
-            : (MODALITY_GENE_STATE[modality]?.features_meta);
-        return Object.keys(meta || {{}}).sort((a, b) => a.localeCompare(b));
     }}
     function uniqueSortedFeatures(features) {{
         const seen = new Set();
@@ -7761,21 +7755,75 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }});
         return result.sort((a, b) => a.localeCompare(b));
     }}
-    function getAvailableFeaturesForModality(modality = CURRENT_MODALITY) {{
+    function normalizeFeatureState(state) {{
+        const raw = state && typeof state === 'object' ? state : {{}};
+        return {{
+            features_meta: raw.features_meta && typeof raw.features_meta === 'object' ? raw.features_meta : {{}},
+            feature_encodings: raw.feature_encodings && typeof raw.feature_encodings === 'object' ? raw.feature_encodings : {{}},
+            feature_value_encodings: raw.feature_value_encodings && typeof raw.feature_value_encodings === 'object' ? raw.feature_value_encodings : {{}},
+            sections: raw.sections && typeof raw.sections === 'object' ? raw.sections : {{}},
+        }};
+    }}
+    function normalizeFeatureModalityName(modality = CURRENT_MODALITY) {{
+        const name = String(modality || CURRENT_MODALITY || DEFAULT_MODALITY_NAME || 'rna').trim();
+        return name || DEFAULT_MODALITY_NAME || 'rna';
+    }}
+    function getFeatureState(modality = CURRENT_MODALITY) {{
+        const name = normalizeFeatureModalityName(modality);
+        if (!FEATURE_STATE_BY_MODALITY[name]) {{
+            FEATURE_STATE_BY_MODALITY[name] = normalizeFeatureState(null);
+        }} else {{
+            FEATURE_STATE_BY_MODALITY[name] = normalizeFeatureState(FEATURE_STATE_BY_MODALITY[name]);
+        }}
+        return FEATURE_STATE_BY_MODALITY[name];
+    }}
+    function getFeatureSectionPayload(sectionOrId, modality = CURRENT_MODALITY) {{
+        const sectionId = typeof sectionOrId === 'string'
+            ? sectionOrId
+            : String(sectionOrId?.id || '');
+        const state = getFeatureState(modality);
+        const payload = sectionId ? (state.sections?.[sectionId] || {{}}) : {{}};
+        return {{
+            features: payload.features || payload.genes || {{}},
+            features_sparse: payload.features_sparse || payload.genes_sparse || {{}},
+        }};
+    }}
+    function setFeatureSectionPayload(sectionId, modality, payload) {{
+        const id = String(sectionId || '');
+        if (!id) return;
+        const state = getFeatureState(modality);
+        if (!state.sections || typeof state.sections !== 'object') state.sections = {{}};
+        state.sections[id] = {{
+            features: payload?.features || payload?.genes || {{}},
+            features_sparse: payload?.features_sparse || payload?.genes_sparse || {{}},
+        }};
+    }}
+    function getFeatureSectionList(modality = CURRENT_MODALITY) {{
+        return (DATA.sections || []).map((section) => {{
+            const payload = getFeatureSectionPayload(section, modality);
+            return Object.assign({{}}, section, {{
+                genes: payload.features,
+                genes_sparse: payload.features_sparse,
+            }});
+        }});
+    }}
+    function getLoadedFeaturesForModality(modality = CURRENT_MODALITY) {{
+        const state = getFeatureState(modality);
+        return Object.keys(state.features_meta || {{}}).sort((a, b) => a.localeCompare(b));
+    }}
+    function getFeatureCatalog(modality = CURRENT_MODALITY) {{
+        if (isModuleModality(modality)) return uniqueSortedFeatures(getGeneModuleDatalistValues());
         const modalityFeatures = FEATURES_BY_MODALITY?.[modality];
         if (Array.isArray(modalityFeatures) && modalityFeatures.length) {{
             return uniqueSortedFeatures(modalityFeatures);
         }}
-        if (modality === DEFAULT_MODALITY_NAME || modality === 'rna' || modality === 'gene') {{
-            const availableGenes = DATA.available_features || [];
-            if (Array.isArray(availableGenes) && availableGenes.length) {{
-                return uniqueSortedFeatures(availableGenes);
-            }}
-        }}
         return getLoadedFeaturesForModality(modality);
     }}
+    function getAvailableFeaturesForModality(modality = CURRENT_MODALITY) {{
+        return getFeatureCatalog(modality);
+    }}
     function getActiveFeatureList() {{
-        return getAvailableFeaturesForModality(CURRENT_MODALITY);
+        return getFeatureCatalog(CURRENT_MODALITY);
     }}
     function isModuleModality(modality) {{
         return String(modality || '').trim().toLowerCase() === MODULE_MODALITY_NAME;
@@ -7800,29 +7848,32 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         geneListEl.replaceChildren(fragment);
         refreshLoadedGeneFilterDropdowns();
     }}
-    function getEmbeddedGeneSet() {{
-        const embedded = Array.isArray(DATA.embedded_features) && DATA.embedded_features.length
-            ? DATA.embedded_features
-            : Object.keys(DATA.features_meta || {{}});
-        return new Set(embedded.map(gene => String(gene)));
+    function getEmbeddedFeatureSet(modality = CURRENT_MODALITY) {{
+        const embeddedByModality = DATA.embedded_features_by_modality && typeof DATA.embedded_features_by_modality === 'object'
+            ? DATA.embedded_features_by_modality
+            : {{}};
+        const embedded = Array.isArray(embeddedByModality[modality]) && embeddedByModality[modality].length
+            ? embeddedByModality[modality]
+            : getLoadedFeaturesForModality(modality);
+        return new Set(embedded.map(feature => String(feature)));
     }}
-    function isEmbeddedViewerGene(gene) {{
-        const raw = String(gene || '').trim();
+    function isEmbeddedViewerFeature(feature, modality = CURRENT_MODALITY) {{
+        const raw = String(feature || '').trim();
         if (!raw) return false;
-        const canonical = resolveCanonicalGeneName(raw);
-        const embedded = getEmbeddedGeneSet();
+        const canonical = resolveCanonicalFeatureName(raw, modality);
+        const embedded = getEmbeddedFeatureSet(modality);
         return embedded.has(raw) || (!!canonical && embedded.has(canonical));
     }}
-    function isSidecarViewerGene(gene) {{
+    function isSidecarViewerFeature(feature, modality = CURRENT_MODALITY) {{
         if (!DATA.feature_manifest_url) return false;
-        const raw = String(gene || '').trim();
+        const raw = String(feature || '').trim();
         if (!raw) return false;
-        const canonical = resolveCanonicalGeneName(raw);
-        const available = new Set((DATA.available_features || []).map(g => String(g)));
+        const canonical = resolveCanonicalFeatureName(raw, modality);
+        const available = new Set(getFeatureCatalog(modality).map(g => String(g)));
         return available.has(raw) || (!!canonical && available.has(canonical));
     }}
-    function isViewerGeneLoadable(gene) {{
-        return isEmbeddedViewerGene(gene) || isSidecarViewerGene(gene);
+    function isViewerFeatureLoadable(feature, modality = CURRENT_MODALITY) {{
+        return isEmbeddedViewerFeature(feature, modality) || isSidecarViewerFeature(feature, modality);
     }}
     function getCategoryVsRestGenes(annotationCol = explorationColorCol || currentAnnotation || '') {{
         const pseudobulkKey = getPseudobulkDEColorKey(annotationCol);
@@ -7878,7 +7929,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
     function getInsightsSelectedGene() {{
         const value = String(document.getElementById('marker-gene-search')?.value || '').trim();
-        return value ? (resolveCanonicalGeneName(value) || value) : '';
+        return value ? (resolveCanonicalFeatureName(value) || value) : '';
     }}
     function getFeatureDatalistValuesForModality(modality = CURRENT_MODALITY) {{
         if (isModuleModality(modality)) return uniqueSortedFeatures(getGeneModuleDatalistValues());
@@ -7890,56 +7941,68 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return desc?.value_kind === 'intensity';
     }}
 
-    // Rebuilt on modality switch. Sidecar RNA viewers use the full available gene catalog.
-    let AVAILABLE_GENE_SET = new Set(getActiveFeatureList());
-    let GENE_NAME_BY_LOWER = new Map(
-        getActiveFeatureList().map(gene => [String(gene).toLowerCase(), gene])
-    );
-    function rebuildActiveFeatureIndex() {{
-        const features = getActiveFeatureList();
-        AVAILABLE_GENE_SET = new Set(features);
-        GENE_NAME_BY_LOWER = new Map(features.map(gene => [String(gene).toLowerCase(), gene]));
-    }}
-    function getActiveFeatureSet() {{
-        return AVAILABLE_GENE_SET;
-    }}
-
-    // Per-modality cache of hydrated gene state. On switch we stash the current
-    // state and restore (or initialize) the new modality's slice.
-    const MODALITY_GENE_STATE = {{}};
-    function _snapshotModalityGeneState(name) {{
-        if (!name) return;
-        const sections = Array.isArray(DATA.sections) ? DATA.sections : [];
-        MODALITY_GENE_STATE[name] = {{
-            features_meta: DATA.features_meta || {{}},
-            feature_encodings: DATA.feature_encodings || {{}},
-            feature_value_encodings: DATA.feature_value_encodings || {{}},
-            sections: sections.map(s => ({{
-                genes: s.genes || {{}},
-                genes_sparse: s.genes_sparse || {{}},
-            }})),
+    const FEATURE_INDEX_BY_MODALITY = new Map();
+    function buildFeatureIndex(modality = CURRENT_MODALITY) {{
+        const name = normalizeFeatureModalityName(modality);
+        const catalog = getFeatureCatalog(name);
+        return {{
+            exact: new Set(catalog.map(feature => String(feature))),
+            byLower: new Map(catalog.map(feature => [String(feature).toLowerCase(), feature])),
         }};
     }}
-    function _restoreModalityGeneState(name) {{
-        const cached = MODALITY_GENE_STATE[name];
-        const sections = Array.isArray(DATA.sections) ? DATA.sections : [];
-        if (cached) {{
-            DATA.features_meta = cached.features_meta;
-            DATA.feature_encodings = cached.feature_encodings;
-            DATA.feature_value_encodings = cached.feature_value_encodings;
-            sections.forEach((s, i) => {{
-                s.genes = cached.sections[i]?.genes || {{}};
-                s.genes_sparse = cached.sections[i]?.genes_sparse || {{}};
-            }});
-        }} else {{
-            DATA.features_meta = {{}};
-            DATA.feature_encodings = {{}};
-            DATA.feature_value_encodings = {{}};
-            sections.forEach(s => {{
-                s.genes = {{}};
-                s.genes_sparse = {{}};
-            }});
+    function getFeatureIndex(modality = CURRENT_MODALITY) {{
+        const name = normalizeFeatureModalityName(modality);
+        if (!FEATURE_INDEX_BY_MODALITY.has(name)) {{
+            FEATURE_INDEX_BY_MODALITY.set(name, buildFeatureIndex(name));
         }}
+        return FEATURE_INDEX_BY_MODALITY.get(name);
+    }}
+    function rebuildFeatureIndex(modality = null) {{
+        if (modality) {{
+            FEATURE_INDEX_BY_MODALITY.delete(normalizeFeatureModalityName(modality));
+        }} else {{
+            FEATURE_INDEX_BY_MODALITY.clear();
+        }}
+    }}
+    function rebuildActiveFeatureIndex() {{
+        rebuildFeatureIndex(CURRENT_MODALITY);
+    }}
+    function getActiveFeatureSet() {{
+        return getFeatureIndex(CURRENT_MODALITY).exact;
+    }}
+
+    function _snapshotModalityFeatureState(name) {{
+        if (!name) return;
+        const state = getFeatureState(name);
+        const sections = Array.isArray(DATA.sections) ? DATA.sections : [];
+        state.features_meta = DATA.features_meta || state.features_meta || {{}};
+        state.feature_encodings = DATA.feature_encodings || state.feature_encodings || {{}};
+        state.feature_value_encodings = DATA.feature_value_encodings || state.feature_value_encodings || {{}};
+        const sectionState = {{}};
+        sections.forEach((s) => {{
+            const sectionId = String(s.id || '');
+            if (!sectionId) return;
+            sectionState[sectionId] = {{
+                features: s.genes || {{}},
+                features_sparse: s.genes_sparse || {{}},
+            }};
+        }});
+        state.sections = sectionState;
+        FEATURE_STATE_BY_MODALITY[name] = state;
+        rebuildFeatureIndex(name);
+    }}
+    function _restoreModalityFeatureState(name) {{
+        const cached = getFeatureState(name);
+        const sections = Array.isArray(DATA.sections) ? DATA.sections : [];
+        DATA.features_meta = cached.features_meta || {{}};
+        DATA.feature_encodings = cached.feature_encodings || {{}};
+        DATA.feature_value_encodings = cached.feature_value_encodings || {{}};
+        const sectionState = cached.sections || {{}};
+        sections.forEach((s) => {{
+            const payload = sectionState[String(s.id || '')] || {{}};
+            s.genes = payload.features || payload.genes || {{}};
+            s.genes_sparse = payload.features_sparse || payload.genes_sparse || {{}};
+        }});
     }}
     function getActiveModalityManifestEntry(manifest) {{
         if (!manifest) return null;
@@ -7955,9 +8018,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             console.warn('Unknown modality:', name);
             return;
         }}
-        _snapshotModalityGeneState(CURRENT_MODALITY);
+        _snapshotModalityFeatureState(CURRENT_MODALITY);
         CURRENT_MODALITY = name;
-        _restoreModalityGeneState(CURRENT_MODALITY);
+        _restoreModalityFeatureState(CURRENT_MODALITY);
         rebuildActiveFeatureIndex();
         populateGeneInputDatalist();
         // Clear any active gene selection so cells don't render with a feature
@@ -7969,6 +8032,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             try {{ renderGeneDiscoveryPanel(); }} catch (e) {{}}
         }}
     }}
+    _restoreModalityFeatureState(CURRENT_MODALITY);
 
     const USER_AGENT = navigator.userAgent || '';
     const IS_SAFARI = /Safari/i.test(USER_AGENT) &&
@@ -10253,7 +10317,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (typeof setInsightsMode === 'function') setInsightsMode('module');
         if (!geneModuleDraftGenes.length) {{
             const genes = (typeof getGeneInputFeatureList === 'function' ? getGeneInputFeatureList() : getFeatureDatalistValuesForModality(CURRENT_MODALITY))
-                .map(gene => resolveCanonicalGeneName(gene) || gene)
+                .map(gene => resolveCanonicalFeatureName(gene) || gene)
                 .filter(Boolean);
             geneModuleDraftGenes = [...new Set(genes)].slice(0, 2);
         }}
@@ -13161,9 +13225,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             return {{ vmin, vmax }};
         }}
         const targetModality = modality || CURRENT_MODALITY;
-        const isCurrent = targetModality === CURRENT_MODALITY;
-        const manifest = isCurrent ? DATA : (MODALITY_GENE_STATE[targetModality] || DATA);
-        const base = manifest.features_meta?.[gene] || {{}};
+        const base = getFeatureState(targetModality).features_meta?.[gene] || {{}};
         
         const autoScale = geneScaleAuto[gene];
         const overrideScale = options.includeOverrides === false ? null : geneScaleOverrides[gene];
@@ -13281,10 +13343,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const targetModality = modality || CURRENT_MODALITY;
         const isCurrent = targetModality === CURRENT_MODALITY;
         
-        let sectionsSource = DATA.sections || [];
-        if (!isCurrent && MODALITY_GENE_STATE[targetModality]) {{
-            sectionsSource = MODALITY_GENE_STATE[targetModality].sections;
-        }}
+        let sectionsSource = isCurrent ? (DATA.sections || []) : getFeatureSectionList(targetModality);
 
         const samples = [];
         let seenNonZero = 0;
@@ -13772,17 +13831,17 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const targetModality = modality || CURRENT_MODALITY;
         const isCurrent = targetModality === CURRENT_MODALITY;
         
-        let sectionSource = section;
-        let manifestSource = DATA;
-
-        if (!isCurrent && MODALITY_GENE_STATE[targetModality]) {{
-            const cachedMod = MODALITY_GENE_STATE[targetModality];
-            const sectionIdx = DATA.sections.indexOf(section);
-            if (sectionIdx >= 0 && cachedMod.sections[sectionIdx]) {{
-                sectionSource = cachedMod.sections[sectionIdx];
-                manifestSource = cachedMod;
-            }}
-        }}
+        const sectionPayload = getFeatureSectionPayload(section, targetModality);
+        const sectionSource = isCurrent
+            ? Object.assign({{}}, section, {{
+                genes: section.genes || sectionPayload.features,
+                genes_sparse: section.genes_sparse || sectionPayload.features_sparse,
+            }})
+            : Object.assign({{}}, section, {{
+                genes: sectionPayload.features,
+                genes_sparse: sectionPayload.features_sparse,
+            }});
+        const manifestSource = getFeatureState(targetModality);
 
         const dense = sectionSource.genes?.[gene];
         if (dense) return dense;
@@ -13900,21 +13959,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             || manifest?.features_meta?.[gene];
         if (!geneEntry || !geneMeta) return false;
 
-        let targetManifest = DATA;
-        let targetSections = DATA.sections || [];
-
-        if (!isCurrent) {{
-            if (!MODALITY_GENE_STATE[targetModality]) {{
-                MODALITY_GENE_STATE[targetModality] = {{
-                    features_meta: {{}},
-                    feature_encodings: {{}},
-                    feature_value_encodings: {{}},
-                    sections: (DATA.sections || []).map(() => ({{ genes: {{}}, genes_sparse: {{}} }})),
-                }};
-            }}
-            targetManifest = MODALITY_GENE_STATE[targetModality];
-            targetSections = targetManifest.sections;
-        }}
+        const targetState = getFeatureState(targetModality);
+        const targetManifest = isCurrent ? DATA : targetState;
+        targetManifest.features_meta = targetManifest.features_meta || {{}};
+        targetManifest.feature_encodings = targetManifest.feature_encodings || {{}};
+        targetManifest.feature_value_encodings = targetManifest.feature_value_encodings || {{}};
 
         targetManifest.features_meta[gene] = geneMeta;
         const encoding = auxData?.feature_encodings?.[gene]
@@ -13930,12 +13979,15 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             targetManifest.feature_value_encodings[gene] = valueEncoding;
         }}
 
-        targetSections.forEach((section, i) => {{
-            const sectionId = isCurrent ? section.id : (DATA.sections[i]?.id);
+        (DATA.sections || []).forEach((section) => {{
+            const sectionId = section.id;
             const sectionEntry = geneEntry.sections?.[sectionId];
             if (!sectionEntry) return;
-            section.genes = section.genes || {{}};
-            section.genes_sparse = section.genes_sparse || {{}};
+            const targetPayload = isCurrent
+                ? {{ features: section.genes || {{}}, features_sparse: section.genes_sparse || {{}} }}
+                : getFeatureSectionPayload(sectionId, targetModality);
+            targetPayload.features = targetPayload.features || {{}};
+            targetPayload.features_sparse = targetPayload.features_sparse || {{}};
             if (typeof sectionEntry.db64 === 'string' || typeof sectionEntry.dq16b64 === 'string' || typeof sectionEntry.dq8b64 === 'string') {{
                 const denseValues = decodeDenseSidecarSection({{
                     ...sectionEntry,
@@ -13943,16 +13995,22 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     qmax: geneMeta?.vmax,
                 }});
                 if (!denseValues) return;
-                section.genes[gene] = denseValues;
-                if (section.genes_sparse[gene]) delete section.genes_sparse[gene];
+                targetPayload.features[gene] = denseValues;
+                if (targetPayload.features_sparse[gene]) delete targetPayload.features_sparse[gene];
             }} else if (Array.isArray(sectionEntry.dense)) {{
-                section.genes[gene] = sectionEntry.dense;
-                if (section.genes_sparse[gene]) delete section.genes_sparse[gene];
+                targetPayload.features[gene] = sectionEntry.dense;
+                if (targetPayload.features_sparse[gene]) delete targetPayload.features_sparse[gene];
             }} else if (sectionEntry.sparse) {{
-                section.genes_sparse[gene] = sectionEntry.sparse;
-                if (section.genes[gene]) delete section.genes[gene];
+                targetPayload.features_sparse[gene] = sectionEntry.sparse;
+                if (targetPayload.features[gene]) delete targetPayload.features[gene];
             }}
+            if (isCurrent) {{
+                section.genes = targetPayload.features;
+                section.genes_sparse = targetPayload.features_sparse;
+            }}
+            setFeatureSectionPayload(sectionId, targetModality, targetPayload);
         }});
+        rebuildFeatureIndex(targetModality);
         return true;
     }}
 
@@ -14199,22 +14257,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const geneMeta = modalityEntry?.features_meta?.[gene] || manifest?.features_meta?.[gene];
         if (!geneEntry || !geneMeta) return false;
 
-        let targetManifest = DATA;
-        let targetSections = DATA.sections || [];
-
-        if (!isCurrent) {{
-            if (!MODALITY_GENE_STATE[targetModality]) {{
-                // Initialize if missing
-                MODALITY_GENE_STATE[targetModality] = {{
-                    features_meta: {{}},
-                    feature_encodings: {{}},
-                    feature_value_encodings: {{}},
-                    sections: (DATA.sections || []).map(() => ({{ genes: {{}}, genes_sparse: {{}} }})),
-                }};
-            }}
-            targetManifest = MODALITY_GENE_STATE[targetModality];
-            targetSections = targetManifest.sections;
-        }}
+        const targetState = getFeatureState(targetModality);
+        const targetManifest = isCurrent ? DATA : targetState;
+        targetManifest.features_meta = targetManifest.features_meta || {{}};
+        targetManifest.feature_encodings = targetManifest.feature_encodings || {{}};
+        targetManifest.feature_value_encodings = targetManifest.feature_value_encodings || {{}};
 
         targetManifest.features_meta[gene] = geneMeta;
         const encoding = modalityEntry?.feature_encodings?.[gene] || manifest?.feature_encodings?.[gene];
@@ -14226,20 +14273,29 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             targetManifest.feature_value_encodings[gene] = valueEncoding;
         }}
 
-        targetSections.forEach((section, i) => {{
-            const sectionId = isCurrent ? section.id : (DATA.sections[i]?.id);
+        (DATA.sections || []).forEach((section) => {{
+            const sectionId = section.id;
             const sectionEntry = geneEntry?.sections?.[sectionId];
             if (!sectionEntry) return;
-            section.genes = section.genes || {{}};
-            section.genes_sparse = section.genes_sparse || {{}};
+            const targetPayload = isCurrent
+                ? {{ features: section.genes || {{}}, features_sparse: section.genes_sparse || {{}} }}
+                : getFeatureSectionPayload(sectionId, targetModality);
+            targetPayload.features = targetPayload.features || {{}};
+            targetPayload.features_sparse = targetPayload.features_sparse || {{}};
             if (sectionEntry.dense) {{
-                section.genes[gene] = sectionEntry.dense;
-                if (section.genes_sparse[gene]) delete section.genes_sparse[gene];
+                targetPayload.features[gene] = sectionEntry.dense;
+                if (targetPayload.features_sparse[gene]) delete targetPayload.features_sparse[gene];
             }} else if (sectionEntry.sparse) {{
-                section.genes_sparse[gene] = sectionEntry.sparse;
-                if (section.genes[gene]) delete section.genes[gene];
+                targetPayload.features_sparse[gene] = sectionEntry.sparse;
+                if (targetPayload.features[gene]) delete targetPayload.features[gene];
             }}
+            if (isCurrent) {{
+                section.genes = targetPayload.features;
+                section.genes_sparse = targetPayload.features_sparse;
+            }}
+            setFeatureSectionPayload(sectionId, targetModality, targetPayload);
         }});
+        rebuildFeatureIndex(targetModality);
         return true;
     }}
 
@@ -14338,8 +14394,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return promise;
     }}
 
-    async function ensureGeneAvailable(gene, options = {{}}) {{
-        const token = String(gene || '').trim();
+    async function ensureFeatureAvailable(feature, options = {{}}) {{
+        const token = String(feature || '').trim();
         const showErrors = options.showErrors !== false;
         const targetModality = options.modality || CURRENT_MODALITY;
         const isCurrent = targetModality === CURRENT_MODALITY;
@@ -14348,13 +14404,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const module = getGeneModuleByToken(token);
         if (module) return await ensureGeneModuleAvailable(module, options);
         
-        // Check if already in current DATA or MODALITY_GENE_STATE
-        const currentMeta = (isCurrent || (targetModality === 'gene' && CURRENT_MODALITY === 'rna'))
-            ? DATA.features_meta
-            : (MODALITY_GENE_STATE[targetModality]?.features_meta);
+        // Check if already hydrated for the requested modality.
+        const currentMeta = getFeatureState(targetModality).features_meta;
         if (currentMeta && currentMeta[token]) return true;
 
-        if (!AVAILABLE_GENE_SET.has(token) && isCurrent) {{
+        if (!getFeatureIndex(targetModality).exact.has(token)) {{
             if (showErrors) {{
                 alert(`Gene "${{token}}" was not found in this dataset.`);
             }}
@@ -14727,7 +14781,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
         if (geneInput) geneInput.value = getGeneDisplayLabel(token);
         const ok = await runAsyncUIAction('Gene selection', async () => {{
-            if (!(await ensureGeneAvailable(token, {{ showErrors }}))) {{
+            if (!(await ensureFeatureAvailable(token, {{ showErrors }}))) {{
                 return false;
             }}
             currentGene = token;
@@ -14889,7 +14943,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const genes = [];
         parts.forEach(g => {{
             if (seen.has(g)) return;
-            if (AVAILABLE_GENE_SET.has(g)) {{
+            if (getActiveFeatureSet().has(g)) {{
                 seen.add(g);
                 genes.push(g);
             }}
@@ -15241,7 +15295,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!token || isModuleModality(modality) || isFeatureLoadedForModality(token, modality) || overviewBlendGeneLoads.has(key)) return;
         overviewBlendGeneLoads.add(key);
         runAsyncUIAction(`Overview split gene load (${{token}})`, async () => {{
-            const ok = await ensureGeneAvailable(token, {{ showErrors: false, modality }});
+            const ok = await ensureFeatureAvailable(token, {{ showErrors: false, modality }});
             if (ok) {{
                 ensureGeneAutoScale(token, modality);
                 renderLegend('legend');
@@ -15844,7 +15898,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         typeSummary.entries.forEach((entry) => {{
             const genes = getMarkerGenesForColorCategory(typeSummary.annotationCol, entry.category);
             genes.forEach((rawGene, rankIdx) => {{
-                const token = resolveCanonicalGeneName(rawGene) || (AVAILABLE_GENE_SET.has(String(rawGene || '').trim()) ? String(rawGene || '').trim() : null);
+                const rawToken = String(rawGene || '').trim();
+                const token = resolveCanonicalFeatureName(rawGene) || (getActiveFeatureSet().has(rawToken) ? rawToken : null);
                 if (!token) return;
                 const key = token.toLowerCase();
                 const next = ranked.get(key) || {{
@@ -18372,16 +18427,17 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
     }}
 
-    function resolveCanonicalGeneName(token) {{
+    function resolveCanonicalFeatureName(token, modality = CURRENT_MODALITY) {{
         const text = String(token || '').trim();
         if (!text) return '';
-        if (AVAILABLE_GENE_SET.has(text)) return text;
-        return GENE_NAME_BY_LOWER.get(text.toLowerCase()) || '';
+        const index = getFeatureIndex(typeof modality === 'string' ? modality : CURRENT_MODALITY);
+        if (index.exact.has(text)) return text;
+        return index.byLower.get(text.toLowerCase()) || '';
     }}
 
     function resolveFeatureTokenForModality(value, modality = CURRENT_MODALITY) {{
         if (isModuleModality(modality)) return resolveGeneModuleToken(value);
-        return resolveCanonicalGeneName(value);
+        return resolveCanonicalFeatureName(value, modality);
     }}
 
     function resolveViewerFeatureToken(value) {{
@@ -18390,16 +18446,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (lower.startsWith(`${{MODULE_MODALITY_NAME}}:`)) {{
             return resolveGeneModuleToken(text) || '';
         }}
-        return resolveCanonicalGeneName(text);
+        return resolveCanonicalFeatureName(text);
     }}
 
     function isFeatureLoadedForModality(feature, modality = CURRENT_MODALITY) {{
         const token = String(feature || '').trim();
         if (!token) return false;
         if (isModuleModality(modality)) return !!getGeneModuleByToken(token);
-        const meta = (modality === CURRENT_MODALITY || (modality === 'gene' && CURRENT_MODALITY === 'rna'))
-            ? DATA.features_meta
-            : (MODALITY_GENE_STATE[modality]?.features_meta);
+        const meta = getFeatureState(modality).features_meta;
         return !!(meta && meta[token]);
     }}
 
@@ -18665,7 +18719,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             return {{ type: 'ref', kind: 'obs', name: colorName }};
         }}
         if (fnName === 'gene') {{
-            const geneName = resolveCanonicalGeneName(rawName);
+            const geneName = resolveCanonicalFeatureName(rawName);
             if (!geneName) throw new Error(`Unknown gene "${{rawName}}".`);
             return {{ type: 'ref', kind: 'gene', name: geneName }};
         }}
@@ -18684,7 +18738,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (colorName) return {{ type: 'ref', kind: 'obs', name: colorName }};
         const metadataKey = resolveCanonicalSectionMetadataKey(raw);
         if (metadataKey) return {{ type: 'ref', kind: 'section', name: metadataKey }};
-        const geneName = resolveCanonicalGeneName(raw);
+        const geneName = resolveCanonicalFeatureName(raw);
         if (geneName) return {{ type: 'ref', kind: 'gene', name: geneName }};
         return {{ type: 'string', value: raw }};
     }}
@@ -18889,7 +18943,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     ? `Loading gene ${{gene}}…`
                     : `Loading gene ${{i + 1}}/${{genes.length}}: ${{gene}}…`;
                 syncSelectionQueryUi();
-                const ok = await ensureGeneAvailable(gene, {{ showErrors: false }});
+                const ok = await ensureFeatureAvailable(gene, {{ showErrors: false }});
                 if (!ok) throw new Error(`Failed to load gene "${{gene}}".`);
             }}
 
@@ -18993,7 +19047,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const stored = readViewerJsonStorage(GENE_RECENTS_STORAGE_KEY, []);
         if (!Array.isArray(stored)) return [];
         return stored
-            .map(resolveCanonicalGeneName)
+            .map(resolveCanonicalFeatureName)
             .filter(Boolean)
             .slice(0, GENE_DISCOVERY_RECENT_LIMIT);
     }}
@@ -19003,7 +19057,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function recordRecentGene(gene) {{
-        const token = resolveCanonicalGeneName(gene);
+        const token = resolveCanonicalFeatureName(gene);
         if (!token) return;
         recentGenes = [token, ...recentGenes.filter(item => item !== token)].slice(0, GENE_DISCOVERY_RECENT_LIMIT);
         persistRecentGenes();
@@ -19016,7 +19070,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             .map((entry) => {{
                 const name = String(entry?.name || '').trim();
                 const genes = Array.isArray(entry?.genes)
-                    ? entry.genes.map(resolveCanonicalGeneName).filter(Boolean)
+                    ? entry.genes.map(resolveCanonicalFeatureName).filter(Boolean)
                     : [];
                 if (!name) return null;
                 return {{ name, genes: [...new Set(genes)] }};
@@ -19077,7 +19131,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const id = String(entry?.id || `m${{Date.now()}}-${{index}}`).trim();
             const name = String(entry?.name || `Module ${{index + 1}}`).trim() || `Module ${{index + 1}}`;
             const genes = Array.isArray(entry?.genes)
-                ? entry.genes.map(resolveCanonicalGeneName).filter(gene => gene && !gene.startsWith('module:'))
+                ? entry.genes.map(resolveCanonicalFeatureName).filter(gene => gene && !gene.startsWith('module:'))
                 : [];
             return {{ id, name, genes: [...new Set(genes)] }};
         }}).filter(module => module.id && module.name);
@@ -19155,7 +19209,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!module || !Array.isArray(module.genes) || !module.genes.length) return false;
         const loaded = [];
         for (const gene of module.genes) {{
-            const ok = await ensureGeneAvailable(gene, {{ showErrors: options.showErrors !== false }});
+            const ok = await ensureFeatureAvailable(gene, {{ showErrors: options.showErrors !== false }});
             if (ok) {{
                 loaded.push(gene);
                 ensureGeneAutoScale(gene);
@@ -19167,16 +19221,16 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function getGenePanelSeedToken() {{
-        const fromCurrent = resolveCanonicalGeneName(currentGene);
+        const fromCurrent = resolveCanonicalFeatureName(currentGene);
         if (fromCurrent) return fromCurrent;
         const geneInput = document.getElementById('gene-input');
-        return resolveCanonicalGeneName(geneInput?.value || '');
+        return resolveCanonicalFeatureName(geneInput?.value || '');
     }}
 
     function upsertSavedGenePanel(panelName, gene = '') {{
         const normalizedName = String(panelName || '').trim();
         if (!normalizedName) return false;
-        const geneToken = resolveCanonicalGeneName(gene);
+        const geneToken = resolveCanonicalFeatureName(gene);
         const existingIndex = savedGenePanels.findIndex(
             panel => panel.name.toLowerCase() === normalizedName.toLowerCase()
         );
@@ -19390,7 +19444,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         (Array.isArray(genes) ? genes : []).forEach((gene) => {{
             const raw = String(gene || '').trim();
             if (!raw) return;
-            const canonical = resolveCanonicalGeneName(raw);
+            const canonical = resolveCanonicalFeatureName(raw);
             const key = (canonical || raw).toLowerCase();
             if (seen.has(key)) return;
             seen.add(key);
@@ -19570,7 +19624,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const groups = categoryOrder
             .map((category) => {{
                 const genes = getMarkerGenesForColorCategory(currentAnnotation, category)
-                    .map(resolveCanonicalGeneName)
+                    .map(resolveCanonicalFeatureName)
                     .filter(Boolean)
                     .slice(0, GENE_DISCOVERY_SUGGESTION_GENES_PER_GROUP);
                 if (!genes.length) return null;
@@ -20900,14 +20954,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }};
 
         try {{
-            if (genesToExport.length && typeof ensureGeneAvailable === 'function') {{
+            if (genesToExport.length && typeof ensureFeatureAvailable === 'function') {{
                 updateExportProgress('Fetching feature shards', 0, genesToExport.length);
                 for (let i = 0; i < genesToExport.length; i++) {{
                     checkCancel();
                     const g = genesToExport[i];
                     if (!DATA.features_meta?.[g]) {{
                         setLabel(`Fetching genes ${{i + 1}}/${{genesToExport.length}}`);
-                        try {{ await ensureGeneAvailable(g, {{ showErrors: false }}); }} catch (_) {{}}
+                        try {{ await ensureFeatureAvailable(g, {{ showErrors: false }}); }} catch (_) {{}}
                     }}
                     updateExportProgress('Fetching feature shards', i + 1, genesToExport.length);
                 }}
@@ -25100,7 +25154,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         `;
 
         panel.querySelector('#gene-module-gene-picker')?.addEventListener('change', (event) => {{
-            const gene = resolveCanonicalGeneName(event.target.value);
+            const gene = resolveCanonicalFeatureName(event.target.value);
             if (gene && !geneModuleDraftGenes.includes(gene)) {{
                 geneModuleDraftGenes.push(gene);
                 renderGeneModulePanel();
@@ -25624,7 +25678,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 advanceTutorialIfReady();
                 return;
             }}
-            if (isViewerGeneLoadable(gene)) {{
+            if (isViewerFeatureLoadable(gene)) {{
                 await activateViewerGene(gene, {{ showErrors: true }});
                 advanceTutorialIfReady();
                 return;
@@ -26636,7 +26690,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const token = String(gene || '').trim();
             if (!token) return '';
             if (meanGeneSet.has(token)) return token;
-            const canonical = resolveCanonicalGeneName(token);
+            const canonical = resolveCanonicalFeatureName(token);
             if (canonical && meanGeneSet.has(canonical)) return canonical;
             return meanGeneByLower.get(token.toLowerCase()) || '';
         }}
@@ -26989,7 +27043,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     if (!raw) return null;
                     return {{
                         raw,
-                        canonical: resolveCanonicalGeneName(raw),
+                        canonical: resolveCanonicalFeatureName(raw),
                     }};
                 }})
                 .filter(Boolean);
@@ -27001,7 +27055,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
             const geneButtons = genes.length
                 ? genes.map((entry) => {{
-                    const loadable = isViewerGeneLoadable(entry.raw);
+                    const loadable = isViewerFeatureLoadable(entry.raw);
                     return renderGeneTokenButton(entry.raw, {{
                         allowUnknown: true,
                         disableActivation: !loadable,
@@ -27225,7 +27279,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const geneIndex = new Map(payload.genes.map((g, idx) => [String(g), idx]));
         let idx = geneIndex.get(geneToken);
         if (idx === undefined) {{
-            const canonical = resolveCanonicalGeneName(geneToken);
+            const canonical = resolveCanonicalFeatureName(geneToken);
             if (canonical) idx = geneIndex.get(canonical);
         }}
         if (idx === undefined) {{
@@ -27684,7 +27738,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return `
             <div class="gene-token-grid">
                 ${{entries.map((entry) => {{
-                    const loadable = isViewerGeneLoadable(entry.raw);
+                    const loadable = isViewerFeatureLoadable(entry.raw);
                     return renderGeneTokenButton(entry.raw, {{
                         allowUnknown: true,
                         disableActivation: !loadable,
@@ -28019,7 +28073,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const padjDisplay = formatAdjustedPValue(padj);
             const baseDisplay = formatScaleNumber(xValues[i]);
             const color = dotClass === 'red' ? '#d94f4f' : 'var(--border-color)';
-            const loadable = isViewerGeneLoadable(gene);
+            const loadable = isViewerFeatureLoadable(gene);
             const pctLine = 'pct expr: ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(sourcePct) ? sourcePct : NaN)) + ' / ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(referencePct) ? referencePct : NaN));
             const extraLine = loadable ? '' : '" data-tooltip-line6="Expression vector unavailable"';
             dots.push({{ dotClass, html: '<circle class="volcano-dot" cx="' + xs(xValues[i]).toFixed(1) + '" cy="' + ys(fc).toFixed(1) + '" r="2.8" fill="' + color + '" fill-opacity="0.78" data-volcano-gene="' + escapeHtml(gene) + '" data-gene-loadable="' + (loadable ? 'true' : 'false') + '" data-volcano-fc="' + fc.toFixed(3) + '" data-volcano-p="' + rawPDisplay + '" data-volcano-padj="' + padjDisplay + '" data-tooltip-title="' + escapeHtml(gene) + '" data-tooltip-line1="baseMean: ' + escapeHtml(baseDisplay) + '" data-tooltip-line2="logFC: ' + escapeHtml(fc.toFixed(3)) + '" data-tooltip-line3="pvalue: ' + escapeHtml(rawPDisplay) + '" data-tooltip-line4="adj. p: ' + escapeHtml(padjDisplay) + '" data-tooltip-line5="' + pctLine + extraLine + '"/>' }});
@@ -28206,7 +28260,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const col = dotClass === 'source' ? sourceColor : (dotClass === 'reference' ? referenceColor : 'var(--border-color)');
             const safePAdj = Number.isFinite(pvalAdj) ? pvalAdj : 1;
             const padjDisplay = formatAdjustedPValue(safePAdj);
-            const loadable = isViewerGeneLoadable(gene);
+            const loadable = isViewerFeatureLoadable(gene);
             const pctLine = 'pct expr: ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(sourcePct) ? sourcePct : NaN)) + ' / ' + escapeHtml(formatPseudobulkDEPct(Number.isFinite(referencePct) ? referencePct : NaN));
             const extraLine = loadable ? '' : '" data-tooltip-line4="Expression vector unavailable"';
             dots.push({{ dotClass, html: '<circle class="volcano-dot" cx="' + xs(fc).toFixed(1) + '" cy="' + ys(nlpi).toFixed(1) + '" r="3" fill="' + col + '" fill-opacity="0.82" data-volcano-class="' + dotClass + '" data-volcano-gene="' + escapeHtml(gene) + '" data-gene-loadable="' + (loadable ? 'true' : 'false') + '" data-volcano-fc="' + fc.toFixed(3) + '" data-volcano-padj="' + padjDisplay + '" data-tooltip-title="' + escapeHtml(gene) + '" data-tooltip-line1="log\u2082FC: ' + escapeHtml(fc.toFixed(3)) + '" data-tooltip-line2="adj. p: ' + escapeHtml(padjDisplay) + '" data-tooltip-line3="' + pctLine + extraLine + '"/>' }});
@@ -29216,7 +29270,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const scoreValue = scores[idx];
             const pctSourceValue = pctSource[idx];
             const pctReferenceValue = pctReference[idx];
-            const loadable = isViewerGeneLoadable(gene);
+            const loadable = isViewerFeatureLoadable(gene);
             const rowColor = Number.isFinite(log2fcValue)
                 ? (log2fcValue >= 0 ? sourceColor : referenceColor)
                 : '';
@@ -32697,7 +32751,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
         const topEntries = sortedEntries.slice(0, 12);
         const renderInlineGeneLinks = (genes) => genes.map(g => {{
-            const loadable = isViewerGeneLoadable(g);
+            const loadable = isViewerFeatureLoadable(g);
             const cls = loadable ? 'interaction-gene-link' : 'interaction-gene-link disabled';
             const activateAttr = loadable ? ` data-gene-activate="${{escapeHtml(g)}}"` : '';
             const title = loadable
@@ -33721,8 +33775,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 return;
             }}
             const geneInput = document.getElementById('gene-input');
-            const requested = resolveCanonicalGeneName(geneInput?.value || '')
-                || resolveCanonicalGeneName(currentGene)
+            const requested = resolveCanonicalFeatureName(geneInput?.value || '')
+                || resolveCanonicalFeatureName(currentGene)
                 || '';
             if (!requested) return;
             await activateViewerGene(requested, {{ showErrors: false }});
@@ -33790,7 +33844,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
             if (e.key === 'Enter') {{
                 const highlightedGene = geneDiscoveryResults[geneDiscoveryActiveIndex];
-                const exactGene = resolveCanonicalGeneName(geneInput.value);
+                const exactGene = resolveCanonicalFeatureName(geneInput.value);
                 if (!highlightedGene && !exactGene && geneInput.value.trim()) return;
                 e.preventDefault();
                 await activateViewerGene(highlightedGene || exactGene || geneInput.value, {{ showErrors: false }});
@@ -33808,7 +33862,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 refreshInsights();
                 return;
             }}
-            const exactGene = resolveCanonicalGeneName(raw);
+            const exactGene = resolveCanonicalFeatureName(raw);
             if (exactGene) {{
                 await activateViewerGene(exactGene, {{ showErrors: false }});
                 refreshInsights();
@@ -33817,7 +33871,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
         }});
         genePanelNew?.addEventListener('click', () => {{
-            const seedGene = resolveCanonicalGeneName(currentGene);
+            const seedGene = resolveCanonicalFeatureName(currentGene);
             const suggestedName = seedGene ? `${{seedGene}} panel` : '';
             const panelName = prompt('Panel name', suggestedName);
             if (!panelName) return;
@@ -34082,7 +34136,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                             controls.gene.value = getGeneDisplayLabel(overviewBlendSpec[side].gene);
                             return;
                         }}
-                        if (!await ensureGeneAvailable(gene, {{ modality: modName }})) {{
+                        if (!await ensureFeatureAvailable(gene, {{ modality: modName }})) {{
                             controls.gene.value = getGeneDisplayLabel(overviewBlendSpec[side].gene);
                             return;
                         }}

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -16475,8 +16475,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!(groupA.nCells >= 2) || !(groupB.nCells >= 2)) {{
             return {{ available: false, reason: 'too_few_cells', nA: Number(groupA.nCells || 0), nB: Number(groupB.nCells || 0), results: [] }};
         }}
-        const loadedGenes = Object.keys(DATA.features_meta || {{}}).sort((a, b) => a.localeCompare(b));
-        const totalGenes = Array.isArray(DATA.available_features) ? DATA.available_features.length : loadedGenes.length;
+        const activeModality = getVisualModality();
+        const loadedGenes = getLoadedFeaturesForModality(activeModality);
+        const totalGenes = getFeatureCatalog(activeModality).length || loadedGenes.length;
         if (!loadedGenes.length) {{
             return {{ available: false, reason: 'no_loaded_features', nA: Number(groupA.nCells || 0), nB: Number(groupB.nCells || 0), loadedGeneCount: 0, totalGeneCount: totalGenes, results: [] }};
         }}
@@ -16519,8 +16520,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }};
         }}
 
-        const loadedGenes = Object.keys(DATA.features_meta || {{}}).sort((a, b) => a.localeCompare(b));
-        const totalGenes = Array.isArray(DATA.available_features) ? DATA.available_features.length : loadedGenes.length;
+        const activeModality = getVisualModality();
+        const loadedGenes = getLoadedFeaturesForModality(activeModality);
+        const totalGenes = getFeatureCatalog(activeModality).length || loadedGenes.length;
         if (!loadedGenes.length) {{
             return {{
                 available: false,
@@ -17253,17 +17255,19 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function getSelectionQueryExampleGene() {{
-        const loadedGenes = Object.keys(DATA.features_meta || {{}})
+        const activeModality = getVisualModality();
+        const activeMeta = getFeatureState(activeModality).features_meta || {{}};
+        const loadedGenes = Object.keys(activeMeta)
             .filter((gene) => String(gene || '').trim().length > 0)
             .sort((a, b) => a.localeCompare(b));
         const preferred = [
             currentGene,
-            ...(DATA.available_features || []),
+            ...getFeatureCatalog(activeModality),
             ...loadedGenes,
         ];
         for (const rawGene of preferred) {{
             const gene = String(rawGene || '').trim();
-            if (gene && DATA.features_meta?.[gene]) return gene;
+            if (gene && activeMeta?.[gene]) return gene;
         }}
         return loadedGenes[0] || '';
     }}
@@ -20877,9 +20881,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }});
     }}
 
-    function collectLoadedGenes() {{
-        const meta = DATA.features_meta || {{}};
-        return (DATA.available_features || []).filter(g => meta[g]);
+    function collectLoadedGenes(modality = getVisualModality()) {{
+        const loaded = new Set(getLoadedFeaturesForModality(modality));
+        return getFeatureCatalog(modality).filter(g => loaded.has(g));
     }}
 
     function makeChunkWriter(chunkTargetBytes) {{
@@ -20918,13 +20922,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             return;
         }}
 
-        const allGenes = DATA.available_features || [];
-        let genesToExport = collectLoadedGenes();
+        const exportModality = getVisualModality();
+        const allGenes = getFeatureCatalog(exportModality);
+        let genesToExport = collectLoadedGenes(exportModality);
         if (allGenes.length > 0) {{
             const choice = window.confirm(
-                `Include ALL ${{allGenes.length}} genes in X.csv?\n\n` +
-                `OK  = fetch + include every gene (may be slow and large for big datasets).\n` +
-                `Cancel = include only the ${{genesToExport.length}} gene${{genesToExport.length === 1 ? '' : 's'}} currently loaded in this session.`
+                `Include ALL ${{allGenes.length}} features from ${{getModalityDisplayLabel(exportModality)}} in X.csv?\n\n` +
+                `OK  = fetch + include every feature in that namespace (may be slow and large for big datasets).\n` +
+                `Cancel = include only the ${{genesToExport.length}} feature${{genesToExport.length === 1 ? '' : 's'}} currently loaded in this session.`
             );
             if (choice) genesToExport = allGenes.slice();
         }}
@@ -20958,13 +20963,15 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 for (let i = 0; i < genesToExport.length; i++) {{
                     checkCancel();
                     const g = genesToExport[i];
-                    if (!DATA.features_meta?.[g]) {{
-                        setLabel(`Fetching genes ${{i + 1}}/${{genesToExport.length}}`);
-                        try {{ await ensureFeatureAvailable(g, {{ showErrors: false }}); }} catch (_) {{}}
+                    const exportMeta = getFeatureState(exportModality).features_meta || {{}};
+                    if (!exportMeta?.[g]) {{
+                        setLabel(`Fetching features ${{i + 1}}/${{genesToExport.length}}`);
+                        try {{ await ensureFeatureAvailable(g, {{ modality: exportModality, showErrors: false }}); }} catch (_) {{}}
                     }}
                     updateExportProgress('Fetching feature shards', i + 1, genesToExport.length);
                 }}
-                genesToExport = genesToExport.filter(g => DATA.features_meta?.[g]);
+                const exportMeta = getFeatureState(exportModality).features_meta || {{}};
+                genesToExport = genesToExport.filter(g => exportMeta?.[g]);
             }}
 
             checkCancel();
@@ -21019,7 +21026,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     return {{ values, cats, isContinuous: !!meta?.is_continuous }};
                 }});
 
-                const geneArrays = genesToExport.map(gene => getSectionGeneValues(section, gene) || null);
+                const geneArrays = genesToExport.map(gene => getSectionGeneValues(section, gene, exportModality) || null);
 
                 for (let i = 0; i < n; i++) {{
                     const globalIdx = (obsIdx && obsIdx.length > i) ? obsIdx[i] : (totalCells + i);
@@ -30164,8 +30171,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }};
         }}
 
-        const loadedGenes = Object.keys(DATA.features_meta || {{}}).sort((a, b) => a.localeCompare(b));
-        const totalGenes = Array.isArray(DATA.available_features) ? DATA.available_features.length : loadedGenes.length;
+        const activeModality = getVisualModality();
+        const loadedGenes = getLoadedFeaturesForModality(activeModality);
+        const totalGenes = getFeatureCatalog(activeModality).length || loadedGenes.length;
         if (!loadedGenes.length) {{
             return {{
                 available: false,

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -7218,6 +7218,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             <div class="overview-blend-row" id="overview-blend-row-a">
                 <span class="overview-blend-side">A</span>
                 <select id="overview-blend-a-kind"></select>
+                <select id="overview-blend-a-namespace" style="display:none;"></select>
                 <select id="overview-blend-a-annotation"></select>
                 <select id="overview-blend-a-category"></select>
                 <input type="text" id="overview-blend-a-gene" list="overview-blend-a-feature-list" placeholder="Gene symbol" style="display:none;">
@@ -7226,6 +7227,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             <div class="overview-blend-row" id="overview-blend-row-b">
                 <span class="overview-blend-side">B</span>
                 <select id="overview-blend-b-kind"></select>
+                <select id="overview-blend-b-namespace" style="display:none;"></select>
                 <select id="overview-blend-b-annotation"></select>
                 <select id="overview-blend-b-category"></select>
                 <input type="text" id="overview-blend-b-gene" list="overview-blend-b-feature-list" placeholder="Gene symbol" style="display:none;">
@@ -8793,8 +8795,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     let overviewBlendEnabled = false;
     let overviewBlendMix = 0.5;
     let overviewBlendSpec = {{
-        a: {{ kind: 'cell', color: null, category: null, gene: '' }},
-        b: {{ kind: 'cell', color: null, category: null, gene: '' }},
+        a: {{ source: 'annotation', modality: DEFAULT_MODALITY_NAME, color: null, category: null, feature: '' }},
+        b: {{ source: 'annotation', modality: DEFAULT_MODALITY_NAME, color: null, category: null, feature: '' }},
     }};
     let overviewBlendGeneScaleOverrides = {{
         a: null,
@@ -10710,8 +10712,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             overviewBlendEnabled = false;
             overviewBlendMix = 0.5;
             overviewBlendSpec = {{
-                a: {{ kind: 'cell', color: null, category: null, gene: '' }},
-                b: {{ kind: 'cell', color: null, category: null, gene: '' }},
+                a: {{ source: 'annotation', modality: DEFAULT_MODALITY_NAME, color: null, category: null, feature: '' }},
+                b: {{ source: 'annotation', modality: DEFAULT_MODALITY_NAME, color: null, category: null, feature: '' }},
             }};
             overviewBlendGeneScaleOverrides = {{ a: null, b: null }};
             safeTutorialClick('#overview-mode-default');
@@ -10972,14 +10974,17 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         overviewBlendMix = 0.5;
         [['a', geneA], ['b', geneB || geneA]].forEach(([side, gene]) => {{
             if (!overviewBlendSpec?.[side] || !gene) return;
-            overviewBlendSpec[side].kind = modality;
-            overviewBlendSpec[side].gene = resolveFeatureTokenForModality(gene, modality) || gene;
-            overviewBlendSpec[side].geneCleared = false;
-            ensureGeneAutoScale?.(overviewBlendSpec[side].gene, modality);
-            setTutorialSelectValue(`#overview-blend-${{side}}-kind`, modality);
+            overviewBlendSpec[side].source = 'feature';
+            overviewBlendSpec[side].modality = modality;
+            setPanelModality(`split.${{side}}`, modality);
+            overviewBlendSpec[side].feature = resolveFeatureTokenForModality(gene, modality) || gene;
+            overviewBlendSpec[side].featureCleared = false;
+            ensureGeneAutoScale?.(overviewBlendSpec[side].feature, modality);
+            setTutorialSelectValue(`#overview-blend-${{side}}-kind`, 'feature');
+            setTutorialSelectValue(`#overview-blend-${{side}}-namespace`, modality);
             const geneInput = document.getElementById(`overview-blend-${{side}}-gene`);
             if (geneInput) {{
-                geneInput.value = getGeneDisplayLabel(overviewBlendSpec[side].gene);
+                geneInput.value = getGeneDisplayLabel(overviewBlendSpec[side].feature);
                 geneInput.dispatchEvent(new Event('change', {{ bubbles: true }}));
             }}
         }});
@@ -14855,12 +14860,31 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
     }}
 
+    function getOverviewBlendSource(spec) {{
+        if (!spec) return 'annotation';
+        if (spec.source === 'feature') return 'feature';
+        if (spec.source === 'annotation') return 'annotation';
+        return spec.kind && spec.kind !== 'cell' ? 'feature' : 'annotation';
+    }}
+
+    function getOverviewBlendModality(spec, side = null) {{
+        if (!spec) return side ? getPanelModality(`split.${{side}}`) : DEFAULT_MODALITY_NAME;
+        const fallback = side ? getPanelModality(`split.${{side}}`) : DEFAULT_MODALITY_NAME;
+        const legacyKind = spec.kind && spec.kind !== 'cell' ? spec.kind : '';
+        return spec.modality || legacyKind || fallback || DEFAULT_MODALITY_NAME;
+    }}
+
+    function getOverviewBlendFeature(spec) {{
+        return String(spec?.feature || spec?.gene || '').trim();
+    }}
+
     function getOverviewSplitGeneTarget(side) {{
         const spec = overviewBlendSpec?.[side];
-        if (!spec || spec.kind === 'cell') return null;
-        const gene = String(spec.gene || '').trim();
+        if (!spec || getOverviewBlendSource(spec) !== 'feature') return null;
+        const gene = getOverviewBlendFeature(spec);
         if (!gene) return null;
-        if (isFeatureLoadedForModality(gene, spec.kind)) return {{ gene, modality: spec.kind, side }};
+        const modality = getOverviewBlendModality(spec, side);
+        if (isFeatureLoadedForModality(gene, modality)) return {{ gene, modality, side }};
         return null;
     }}
 
@@ -15079,16 +15103,24 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function getBlendKindOptions() {{
-        const kindOptions = [{{ value: 'cell', label: 'Annotation' }}];
-        if (MODALITY_DESCRIPTORS.length > 0) {{
-            for (const mod of MODALITY_DESCRIPTORS) {{
-                kindOptions.push({{ value: mod.name, label: mod.label || mod.name }});
-            }}
-        }} else {{
-            kindOptions.push({{ value: 'gene', label: 'Gene' }});
+        return [
+            {{ value: 'annotation', label: 'Annotation' }},
+            {{ value: 'feature', label: 'Feature' }},
+        ];
+    }}
+
+    function getFeatureNamespaceOptions() {{
+        const options = MODALITY_DESCRIPTORS.map(desc => ({{
+            value: desc.name,
+            label: desc.label || desc.name,
+        }}));
+        if (!options.length) {{
+            options.push({{ value: DEFAULT_MODALITY_NAME, label: getModalityDisplayLabel(DEFAULT_MODALITY_NAME) }});
         }}
-        kindOptions.push({{ value: MODULE_MODALITY_NAME, label: 'Module' }});
-        return kindOptions;
+        if (Array.isArray(geneModules) && geneModules.length) {{
+            options.push({{ value: MODULE_MODALITY_NAME, label: 'Module' }});
+        }}
+        return options;
     }}
 
     function getCategoriesForColorColumn(annotationCol) {{
@@ -15198,18 +15230,19 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const defaultLabels = {{ a: 'A (left)', b: 'B (right)' }};
         const sideLabel = sideLabels?.[side] || defaultLabels[side] || side.toUpperCase();
         
-        if (spec.kind !== 'cell') {{
-            const modName = spec.kind;
+        if (getOverviewBlendSource(spec) === 'feature') {{
+            const modName = getOverviewBlendModality(spec, side);
             const modLabel = getModalityDisplayLabel(modName);
             const isGene = ['RNA', 'rna', 'Gene', 'gene'].includes(modLabel);
             const featureTypeLabel = isGene ? 'Gene' : modLabel;
-            const displayLabel = getGeneDisplayLabel(spec.gene);
-            const featureLabel = spec.gene
+            const feature = getOverviewBlendFeature(spec);
+            const displayLabel = getGeneDisplayLabel(feature);
+            const featureLabel = feature
                 ? (isModuleModality(modName) ? displayLabel : `${{featureTypeLabel}}: ${{displayLabel}}`)
                 : featureTypeLabel;
             
             const scale = (typeof scaleResolver === 'function' ? scaleResolver(side, spec) : null)
-                || getGeneScaleRange(spec.gene, modName);
+                || getGeneScaleRange(feature, modName);
             return {{
                 side,
                 sideLabel,
@@ -15273,11 +15306,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function getOverviewBlendRuntime(section, spec, scaleOverride = null) {{
         if (!section || !spec) return null;
         
-        if (spec.kind !== 'cell') {{
-            const gene = (spec.gene || '').trim();
+        if (getOverviewBlendSource(spec) === 'feature') {{
+            const gene = getOverviewBlendFeature(spec);
             if (!gene) return null;
             
-            const modName = spec.kind;
+            const modName = getOverviewBlendModality(spec);
             if (!isFeatureLoadedForModality(gene, modName)) {{
                 requestOverviewBlendGene(gene, modName);
                 return null;
@@ -23153,10 +23186,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!overviewBlendEnabled) return false;
         return ['a', 'b'].some(side => {{
             const spec = overviewBlendSpec?.[side];
-            if (!spec || spec.kind === 'cell') return false;
-            const gene = String(spec.gene || '').trim();
+            if (!spec || getOverviewBlendSource(spec) !== 'feature') return false;
+            const gene = getOverviewBlendFeature(spec);
             if (!gene) return false;
-            return isFeatureLoadedForModality(gene, spec.kind);
+            return isFeatureLoadedForModality(gene, getOverviewBlendModality(spec, side));
         }});
     }}
 
@@ -33792,16 +33825,6 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const defaultSourceGeneBtn = document.getElementById('default-source-feature');
         const modalityControl = document.getElementById('visual-feature-namespace-control');
         const modalitySelect = document.getElementById('visual-feature-namespace-select');
-        const getFeatureNamespaceOptions = () => {{
-            const options = MODALITY_DESCRIPTORS.map(desc => ({{
-                value: desc.name,
-                label: desc.label || desc.name,
-            }}));
-            if (Array.isArray(geneModules) && geneModules.length) {{
-                options.push({{ value: MODULE_MODALITY_NAME, label: 'Module' }});
-            }}
-            return options;
-        }};
         const syncFeatureNamespaceSelect = () => {{
             if (!modalityControl || !modalitySelect) return;
             const options = getFeatureNamespaceOptions();
@@ -34016,12 +34039,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const ovBlendControls = {{
                 a: {{
                     kind: document.getElementById('overview-blend-a-kind'),
+                    namespace: document.getElementById('overview-blend-a-namespace'),
                     color: document.getElementById('overview-blend-a-annotation'),
                     category: document.getElementById('overview-blend-a-category'),
                     gene: document.getElementById('overview-blend-a-gene'),
                 }},
                 b: {{
                     kind: document.getElementById('overview-blend-b-kind'),
+                    namespace: document.getElementById('overview-blend-b-namespace'),
                     color: document.getElementById('overview-blend-b-annotation'),
                     category: document.getElementById('overview-blend-b-category'),
                     gene: document.getElementById('overview-blend-b-gene'),
@@ -34031,13 +34056,30 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             function ensureOverviewBlendDefaults() {{
                 const catCols = getCategoricalColorColumns();
                 const preferredCol = catCols.includes(currentAnnotation) ? currentAnnotation : (catCols[0] || null);
-                const modalityNames = MODALITY_DESCRIPTORS.map(m => m.name);
-                const defaultModality = modalityNames.includes(DEFAULT_MODALITY_NAME) ? DEFAULT_MODALITY_NAME : (modalityNames[0] || 'gene');
+                const namespaceOptions = getFeatureNamespaceOptions();
+                const namespaceValues = namespaceOptions.map(entry => entry.value).filter(Boolean);
+                const namespaceSet = new Set(namespaceValues);
+                const defaultModality = namespaceSet.has(DEFAULT_MODALITY_NAME)
+                    ? DEFAULT_MODALITY_NAME
+                    : (namespaceValues[0] || DEFAULT_MODALITY_NAME || 'gene');
+                overviewBlendSpec.a.modality = overviewBlendSpec.a.modality || defaultModality;
+                overviewBlendSpec.b.modality = overviewBlendSpec.b.modality || defaultModality;
 
-                const normalize = (entry, preferSecond) => {{
-                    if (!entry.kind) entry.kind = catCols.length ? 'cell' : defaultModality;
-                    if (entry.kind === 'cell') {{
-                        if (!catCols.length) {{ entry.kind = defaultModality; }}
+                const normalize = (entry, side, preferSecond) => {{
+                    const legacyModality = entry.kind && entry.kind !== 'cell' ? entry.kind : '';
+                    if (!entry.source) entry.source = legacyModality ? 'feature' : (catCols.length ? 'annotation' : 'feature');
+                    if (entry.source !== 'feature' && entry.source !== 'annotation') entry.source = 'annotation';
+                    if (!entry.modality) entry.modality = legacyModality || getPanelModality(`split.${{side}}`, defaultModality);
+                    if (!namespaceSet.has(entry.modality)) entry.modality = defaultModality;
+                    setPanelModality(`split.${{side}}`, entry.modality);
+                    if (!entry.feature && entry.gene) entry.feature = entry.gene;
+                    if (entry.geneCleared && entry.featureCleared === undefined) entry.featureCleared = true;
+
+                    if (entry.source === 'annotation') {{
+                        if (!catCols.length) {{
+                            entry.source = 'feature';
+                            return normalize(entry, side, preferSecond);
+                        }}
                         else {{
                             if (!entry.color || !catCols.includes(entry.color)) entry.color = preferredCol;
                             const cats = getCategoriesForColorColumn(entry.color);
@@ -34047,23 +34089,23 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                             }}
                         }}
                     }}
-                    if (entry.kind !== 'cell') {{
-                        const modName = entry.kind;
+                    if (entry.source === 'feature') {{
+                        const modName = entry.modality;
                         const features = getFeatureDatalistValuesForModality(modName);
                         
                         if (!features.length && catCols.length) {{
-                            entry.kind = 'cell';
-                            return normalize(entry, preferSecond);
+                            entry.source = 'annotation';
+                            return normalize(entry, side, preferSecond);
                         }}
 
-                        if ((!entry.gene || !isFeatureLoadedForModality(entry.gene, modName)) && !entry.geneCleared) {{
+                        if ((!entry.feature || !isFeatureLoadedForModality(entry.feature, modName)) && !entry.featureCleared) {{
                             const defaultFeature = features[preferSecond && features.length > 1 ? 1 : 0] || '';
-                            entry.gene = resolveFeatureTokenForModality(defaultFeature, modName) || defaultFeature;
+                            entry.feature = resolveFeatureTokenForModality(defaultFeature, modName) || defaultFeature;
                         }}
                     }}
                 }};
-                normalize(overviewBlendSpec.a, false);
-                normalize(overviewBlendSpec.b, true);
+                normalize(overviewBlendSpec.a, 'a', false);
+                normalize(overviewBlendSpec.b, 'b', true);
             }}
 
             function syncOverviewBlendSide(side) {{
@@ -34071,13 +34113,20 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 const spec = overviewBlendSpec[side];
                 if (!controls || !spec) return;
 
-                setSelectOptions(controls.kind, getBlendKindOptions(), spec.kind);
+                const source = getOverviewBlendSource(spec);
+                const modName = getOverviewBlendModality(spec, side);
+                spec.source = source;
+                spec.modality = modName;
+                setPanelModality(`split.${{side}}`, modName);
 
-                const isCell = spec.kind === 'cell';
-                controls.color.style.display = isCell ? '' : 'none';
-                controls.category.style.display = isCell ? '' : 'none';
-                controls.gene.style.display = isCell ? 'none' : '';
-                if (isCell) {{
+                setSelectOptions(controls.kind, getBlendKindOptions(), source);
+
+                const isFeature = source === 'feature';
+                if (controls.namespace) controls.namespace.style.display = isFeature ? '' : 'none';
+                controls.color.style.display = isFeature ? 'none' : '';
+                controls.category.style.display = isFeature ? 'none' : '';
+                controls.gene.style.display = isFeature ? '' : 'none';
+                if (!isFeature) {{
                     const cols = getCategoricalColorColumns();
                     setSelectOptions(controls.color, cols, spec.color);
                     const cats = getCategoriesForColorColumn(spec.color);
@@ -34085,10 +34134,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         .concat(cats.map(cat => ({{ value: cat, label: cat }})));
                     setSelectOptions(controls.category, catOpts, spec.category);
                 }} else {{
-                    const modName = spec.kind;
                     const modLabel = getModalityDisplayLabel(modName);
+                    setSelectOptions(controls.namespace, getFeatureNamespaceOptions(), modName);
                     controls.gene.placeholder = `${{modLabel}} feature`;
-                    controls.gene.value = getGeneDisplayLabel(spec.gene);
+                    controls.gene.value = getGeneDisplayLabel(spec.feature);
 
                     // Populate side-specific feature datalist
                     const listId = `overview-blend-${{side}}-feature-list`;
@@ -34104,7 +34153,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         listEl.replaceChildren(fragment);
                     }}
                     
-                    if (spec.gene) ensureGeneAutoScale(spec.gene, modName);
+                    if (spec.feature) ensureGeneAutoScale(spec.feature, modName);
                 }}
             }}
 
@@ -34162,8 +34211,16 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 const controls = ovBlendControls[side];
                 if (!controls) return;
                 controls.kind?.addEventListener('change', () => {{
-                    overviewBlendSpec[side].kind = controls.kind.value;
-                    overviewBlendSpec[side].geneCleared = false;
+                    overviewBlendSpec[side].source = controls.kind.value === 'feature' ? 'feature' : 'annotation';
+                    overviewBlendSpec[side].featureCleared = false;
+                    clearOverviewSplitGeneScaleOverride(side);
+                    applyOverviewBlendChange();
+                }});
+                controls.namespace?.addEventListener('change', () => {{
+                    overviewBlendSpec[side].modality = controls.namespace.value || DEFAULT_MODALITY_NAME;
+                    setPanelModality(`split.${{side}}`, overviewBlendSpec[side].modality);
+                    overviewBlendSpec[side].featureCleared = false;
+                    clearOverviewSplitGeneScaleOverride(side);
                     applyOverviewBlendChange();
                 }});
                 controls.color?.addEventListener('change', () => {{
@@ -34177,24 +34234,26 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 }});
                 controls.gene?.addEventListener('change', async () => {{
                     await runAsyncUIAction(`Overview split feature (${{side.toUpperCase()}})`, async () => {{
-                        const modName = overviewBlendSpec[side].kind;
+                        const modName = getOverviewBlendModality(overviewBlendSpec[side], side);
                         const gene = resolveFeatureTokenForModality(controls.gene.value.trim(), modName) || controls.gene.value.trim();
                         if (!gene) {{
-                            overviewBlendSpec[side].gene = '';
-                            overviewBlendSpec[side].geneCleared = true;
+                            overviewBlendSpec[side].feature = '';
+                            overviewBlendSpec[side].featureCleared = true;
+                            clearOverviewSplitGeneScaleOverride(side);
                             applyOverviewBlendChange();
                             return;
                         }}
                         if (!isFeatureLoadedForModality(gene, modName)) {{
-                            controls.gene.value = getGeneDisplayLabel(overviewBlendSpec[side].gene);
+                            controls.gene.value = getGeneDisplayLabel(overviewBlendSpec[side].feature);
                             return;
                         }}
                         if (!await ensureFeatureAvailable(gene, {{ modality: modName }})) {{
-                            controls.gene.value = getGeneDisplayLabel(overviewBlendSpec[side].gene);
+                            controls.gene.value = getGeneDisplayLabel(overviewBlendSpec[side].feature);
                             return;
                         }}
-                        overviewBlendSpec[side].gene = gene;
-                        overviewBlendSpec[side].geneCleared = false;
+                        overviewBlendSpec[side].feature = gene;
+                        overviewBlendSpec[side].featureCleared = false;
+                        clearOverviewSplitGeneScaleOverride(side);
                         ensureGeneAutoScale(gene, modName);
                         applyOverviewBlendChange();
                     }});

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -1471,14 +1471,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             position: relative;
             align-items: flex-start;
         }}
-        .gene-input-shell {{
+        .feature-input-shell {{
             position: relative;
             min-width: 180px;
         }}
-        .gene-input-shell input[type="text"] {{
+        .feature-input-shell input[type="text"] {{
             width: 180px;
         }}
-        .gene-discovery-panel {{
+        .feature-discovery-panel {{
             position: absolute;
             top: calc(100% + 6px);
             left: 0;
@@ -1495,7 +1495,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             display: none;
             z-index: 40;
         }}
-        .gene-discovery-panel.active {{
+        .feature-discovery-panel.active {{
             display: block;
         }}
         .gene-discovery-header {{
@@ -1929,16 +1929,16 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             box-shadow: 0 1px 4px rgba(0, 0, 0, 0.14);
         }}
         .visual-annotation-controls,
-        .visual-gene-controls {{
+        .visual-feature-controls {{
             display: inline-flex;
             align-items: center;
             gap: 10px;
             flex-wrap: wrap;
         }}
-        .visual-default-controls.annotation-mode .visual-gene-controls {{
+        .visual-default-controls.annotation-mode .visual-feature-controls {{
             display: none;
         }}
-        .visual-default-controls.gene-mode .visual-annotation-controls {{
+        .visual-default-controls.feature-mode .visual-annotation-controls {{
             display: none;
         }}
         .visual-params-bar.split-mode .visual-default-controls {{
@@ -7183,7 +7183,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         <div class="visual-default-controls annotation-mode" id="visual-default-controls">
             <div class="visual-source-switch" id="visual-source-switch" role="group" aria-label="Default view source">
                 <button class="visual-source-btn active" id="default-source-annotation" type="button" data-default-source="annotation">Annotation</button>
-                <button class="visual-source-btn" id="default-source-gene" type="button" data-default-source="gene">Gene</button>
+                <button class="visual-source-btn" id="default-source-feature" type="button" data-default-source="feature">Feature</button>
+            </div>
+            <div class="control-group visual-feature-namespace-control" id="visual-feature-namespace-control" style="display: none;">
+                <label class="sr-only" for="visual-feature-namespace-select">Feature namespace</label>
+                <select id="visual-feature-namespace-select"></select>
             </div>
             <div class="visual-annotation-controls" id="visual-annotation-controls">
                 <div class="control-group">
@@ -7191,24 +7195,20 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     <select id="annotation-select"></select>
                 </div>
             </div>
-            <div class="visual-gene-controls" id="visual-gene-controls">
-                <div class="control-group" id="modality-control-group" style="display: none;">
-                    <label>Modality:</label>
-                    <select id="modality-select"></select>
-                </div>
+            <div class="visual-feature-controls" id="visual-feature-controls">
                 <div class="control-group gene-control-group">
-                    <label class="sr-only" for="gene-input">Gene</label>
-                    <div class="gene-input-shell" id="gene-input-shell">
-                        <input type="text" id="gene-input" placeholder="e.g. Cd4, Gfap..." list="gene-list" autocomplete="off" spellcheck="false" aria-expanded="false" aria-controls="gene-discovery-panel">
-                        <datalist id="gene-list"></datalist>
-                        <div class="gene-discovery-panel" id="gene-discovery-panel" aria-hidden="true">
+                    <label class="sr-only" for="feature-input">Feature</label>
+                    <div class="feature-input-shell" id="feature-input-shell">
+                        <input type="text" id="feature-input" placeholder="Feature" list="feature-list" autocomplete="off" spellcheck="false" aria-expanded="false" aria-controls="feature-discovery-panel">
+                        <datalist id="feature-list"></datalist>
+                        <div class="feature-discovery-panel" id="feature-discovery-panel" aria-hidden="true">
                             <div class="gene-discovery-header">
-                                <div class="gene-discovery-title">Gene discovery</div>
+                                <div class="gene-discovery-title">Feature discovery</div>
                                 <div class="gene-discovery-actions">
-                                    <button class="gene-panel-btn" id="gene-panel-new" type="button">New panel</button>
+                                    <button class="gene-panel-btn" id="feature-panel-new" type="button">New panel</button>
                                 </div>
                             </div>
-                            <div id="gene-discovery-content"></div>
+                            <div id="feature-discovery-content"></div>
                         </div>
                     </div>
                 </div>
@@ -7220,16 +7220,16 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 <select id="overview-blend-a-kind"></select>
                 <select id="overview-blend-a-annotation"></select>
                 <select id="overview-blend-a-category"></select>
-                <input type="text" id="overview-blend-a-gene" list="overview-blend-a-gene-list" placeholder="Gene symbol" style="display:none;">
-                <datalist id="overview-blend-a-gene-list"></datalist>
+                <input type="text" id="overview-blend-a-gene" list="overview-blend-a-feature-list" placeholder="Gene symbol" style="display:none;">
+                <datalist id="overview-blend-a-feature-list"></datalist>
             </div>
             <div class="overview-blend-row" id="overview-blend-row-b">
                 <span class="overview-blend-side">B</span>
                 <select id="overview-blend-b-kind"></select>
                 <select id="overview-blend-b-annotation"></select>
                 <select id="overview-blend-b-category"></select>
-                <input type="text" id="overview-blend-b-gene" list="overview-blend-b-gene-list" placeholder="Gene symbol" style="display:none;">
-                <datalist id="overview-blend-b-gene-list"></datalist>
+                <input type="text" id="overview-blend-b-gene" list="overview-blend-b-feature-list" placeholder="Gene symbol" style="display:none;">
+                <datalist id="overview-blend-b-feature-list"></datalist>
             </div>
             <div class="overview-blend-row" id="overview-blend-row-mix">
                 <svg class="overview-blend-icon" viewBox="0 0 24 24" aria-hidden="true"><rect width="18" height="18" x="3" y="3" rx="2"></rect><path d="M3 12h18"></path></svg>
@@ -7867,7 +7867,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return uniqueSortedFeatures(getLoadedFeaturesForModality(getVisualModality()));
     }}
     function populateGeneInputDatalist() {{
-        const geneListEl = document.getElementById('gene-list');
+        const geneListEl = document.getElementById('feature-list');
         if (!geneListEl) return;
         const fragment = document.createDocumentFragment();
         for (const feat of getGeneInputFeatureList()) {{
@@ -8044,7 +8044,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
     async function setActiveModality(name) {{
         if (!name || name === getVisualModality()) return;
-        if (!FEATURES_BY_MODALITY[name] && name !== DEFAULT_MODALITY_NAME) {{
+        if (!isModuleModality(name) && !FEATURES_BY_MODALITY[name] && name !== DEFAULT_MODALITY_NAME) {{
             console.warn('Unknown modality:', name);
             return;
         }}
@@ -9607,24 +9607,24 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             step('Find cells by query', ['#selection-query-panel', '#selection-query-toggle', '#insights-panel'], [
                 'Select cells based on annotations, level of gene expression or experiment metadata.'
             ], {{ action: () => {{ if (typeof openInsightsMode === 'function') openInsightsMode('selection'); updateSelectionInfo?.(); keepTutorialSelectionQueryPanelOpen(); }}, onNext: () => closeSelectionQueryPanel(), task: 'Cells can be selected by querying the text box rule and clicking the search icon below the text box', requiresQuerySelection: true, combineTargets: true, scroll: false, positionTarget: '#selection-query-panel', placement: 'right', nextLabel: tryIt }}),
-            step('Switch to Gene source', ['#default-source-gene', '#visual-gene-controls'], [
+            step('Switch to Gene source', ['#default-source-feature', '#visual-feature-controls'], [
                 'Gene source changes the grid from categorical annotation colors to gene or feature expression.'
-            ], {{ action: () => safeTutorialClick('#default-source-gene'), nextLabel: tryIt }}),
-            step('Gene discovery panel', '#gene-discovery-panel', [
+            ], {{ action: () => safeTutorialClick('#default-source-feature'), nextLabel: tryIt }}),
+            step('Gene discovery panel', '#feature-discovery-panel', [
                 'Gene discovery helps you search, activate genes, and inspect related gene information.',
                 'Suggestion for gene markers are displayed depending on the selected annotation.',
                 'It can include marker genes, spatial genes, correlations, and module tools depending on the exported payload.'
-            ], {{ action: () => {{ safeTutorialClick('#default-source-gene'); lockTutorialGeneDiscoveryPanel(); setTutorialToolbarPanel(null); document.getElementById('gene-input')?.focus(); }}, positionTarget: '#gene-discovery-panel', placement: 'right', nextLabel: tryIt }}),
-            step('Gene input field', ['#gene-input', '#gene-input-shell'], [
+            ], {{ action: () => {{ safeTutorialClick('#default-source-feature'); lockTutorialGeneDiscoveryPanel(); setTutorialToolbarPanel(null); document.getElementById('feature-input')?.focus(); }}, positionTarget: '#feature-discovery-panel', placement: 'right', nextLabel: tryIt }}),
+            step('Gene input field', ['#feature-input', '#feature-input-shell'], [
                 'The gene input accepts embedded genes and sidecar-loadable genes when sidecar mode is available.'
-            ], {{ action: () => safeTutorialClick('#default-source-gene'), onNext: () => setTutorialSplitGeneDisplay(), nextLabel: tryIt }}),
+            ], {{ action: () => safeTutorialClick('#default-source-feature'), onNext: () => setTutorialSplitGeneDisplay(), nextLabel: tryIt }}),
             step('Gene expression scale', ['#gene-params-panel', '#gene-params-toggle'], [
                 'Modify the default scaling of a gene to highlight its expression. Scaling can be propagated to the other gene in the Split setup to compare gene expression.'
             ], {{ action: () => lockTutorialGeneParamsPanel(), positionTarget: '#gene-params-panel', placement: 'right', prepareDelay: 360, nextLabel: tryIt }}),
-            step('Modality selector', ['#modality-control-group', '#modality-select'], [
+            step('Modality selector', ['#visual-feature-namespace-control', '#visual-feature-namespace-select'], [
                 'If multiple modalities were exported, the modality selector switches the feature namespace.',
                 'For example, RNA genes and protein features can be searched separately.'
-            ], {{ condition: () => Array.isArray(MODALITY_DESCRIPTORS) && MODALITY_DESCRIPTORS.length > 1, action: () => safeTutorialClick('#default-source-gene'), task: 'Switch modality once, then switch back to the one you want.', nextLabel: tryIt }}),
+            ], {{ condition: () => Array.isArray(MODALITY_DESCRIPTORS) && MODALITY_DESCRIPTORS.length > 1, action: () => safeTutorialClick('#default-source-feature'), task: 'Switch modality once, then switch back to the one you want.', nextLabel: tryIt }}),
             step('Open a section modal', ['.section-panel:not(.filtered-out)', '.section-panel', '#grid-stage', '#grid'], [
                 'Clicking a section opens a high-detail modal view for that section.'
             ], {{ action: () => {{ if (typeof closeModal === 'function') closeModal(); }}, task: 'Click the highlighted section to open the modal view.', requiresModalOpen: true, nextLabel: tryIt }}),
@@ -10370,8 +10370,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function ensureTutorialModalityTouched() {{
-        safeTutorialClick('#default-source-gene');
-        const select = document.getElementById('modality-select');
+        safeTutorialClick('#default-source-feature');
+        const select = document.getElementById('visual-feature-namespace-select');
         const options = Array.from(select?.options || []).map(option => option.value).filter(Boolean);
         if (select && options.length > 1) {{
             const original = select.value;
@@ -10721,7 +10721,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
 
             currentGene = null;
-            const geneInput = document.getElementById('gene-input');
+            const geneInput = document.getElementById('feature-input');
             if (geneInput) geneInput.value = '';
             setGeneDiscoveryOpen?.(false);
             geneDiscoveryResults = [];
@@ -10736,9 +10736,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             celltypeTrendTarget = null;
 
             document.getElementById('visual-default-controls')?.classList.add('annotation-mode');
-            document.getElementById('visual-default-controls')?.classList.remove('gene-mode');
+            document.getElementById('visual-default-controls')?.classList.remove('feature-mode');
             document.getElementById('default-source-annotation')?.classList.add('active');
-            document.getElementById('default-source-gene')?.classList.remove('active');
+            document.getElementById('default-source-feature')?.classList.remove('active');
             document.getElementById('grid-side-toolbar')?.classList.remove('visual-open', 'gene-open', 'neighbor-open', 'he-open');
             document.getElementById('visual-params-toggle')?.setAttribute('aria-expanded', 'false');
             document.getElementById('gene-params-toggle')?.setAttribute('aria-expanded', 'false');
@@ -10885,7 +10885,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (document.getElementById('overview-mode-split')?.classList.contains('active')) {{
             safeTutorialClick('#overview-mode-default');
         }}
-        safeTutorialClick(source === 'gene' ? '#default-source-gene' : '#default-source-annotation');
+        safeTutorialClick((source === 'feature' || source === 'gene') ? '#default-source-feature' : '#default-source-annotation');
     }}
 
     function ensureTutorialSplitMode(withGeneSide = false) {{
@@ -10996,7 +10996,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const features = getFeatureDatalistValuesForModality(getVisualModality());
         const firstGene = features[0];
         if (!firstGene) return;
-        const geneInput = document.getElementById('gene-input');
+        const geneInput = document.getElementById('feature-input');
         if (geneInput) geneInput.value = getGeneDisplayLabel(firstGene);
         if (typeof activateViewerGene === 'function') {{
             activateViewerGene(firstGene, {{ showErrors: false }}).catch(error => console.warn('Tutorial first gene selection failed', error));
@@ -11023,7 +11023,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function clearTutorialGeneInput() {{
-        const geneInput = document.getElementById('gene-input');
+        const geneInput = document.getElementById('feature-input');
         if (geneInput) geneInput.value = '';
         geneDiscoveryResults = [];
         geneDiscoveryActiveIndex = -1;
@@ -11031,9 +11031,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         invalidateGeneDensityCaches?.();
         hiddenCategories?.clear?.();
         document.getElementById('visual-default-controls')?.classList.remove('annotation-mode');
-        document.getElementById('visual-default-controls')?.classList.add('gene-mode');
+        document.getElementById('visual-default-controls')?.classList.add('feature-mode');
         document.getElementById('default-source-annotation')?.classList.remove('active');
-        document.getElementById('default-source-gene')?.classList.add('active');
+        document.getElementById('default-source-feature')?.classList.add('active');
         updateExpressionScaleUI?.();
         renderLegend?.('legend');
         renderAllSections?.();
@@ -11067,7 +11067,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function lockTutorialGeneDiscoveryPanel() {{
         tutorialGeneDiscoveryLocked = true;
         clearTutorialGeneInput();
-        document.getElementById('gene-input')?.focus();
+        document.getElementById('feature-input')?.focus();
         setGeneDiscoveryOpen?.(true);
         renderGeneDiscoveryPanel?.();
     }}
@@ -12025,7 +12025,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             }}
 
             if (key === '/') {{
-                const geneInput = document.getElementById('gene-input');
+                const geneInput = document.getElementById('feature-input');
                 if (!geneInput) return;
                 event.preventDefault();
                 geneInput.focus();
@@ -13962,7 +13962,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     function setGeneLoadingState(isLoading, message = '') {{
         featureSidecarLoadingMessage = isLoading ? (message || 'Loading gene expression…') : '';
-        const geneInput = document.getElementById('gene-input');
+        const geneInput = document.getElementById('feature-input');
         if (geneInput) {{
             geneInput.disabled = !!isLoading;
             if (isLoading) {{
@@ -14503,8 +14503,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function setGeneDiscoveryOpen(isOpen) {{
         if (!isOpen && tutorialGeneDiscoveryLocked) isOpen = true;
         geneDiscoveryOpen = !!isOpen;
-        const panel = document.getElementById('gene-discovery-panel');
-        const input = document.getElementById('gene-input');
+        const panel = document.getElementById('feature-discovery-panel');
+        const input = document.getElementById('feature-input');
         if (panel) {{
             panel.classList.toggle('active', geneDiscoveryOpen);
             panel.setAttribute('aria-hidden', geneDiscoveryOpen ? 'false' : 'true');
@@ -14592,8 +14592,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function renderGeneDiscoveryPanel() {{
-        const content = document.getElementById('gene-discovery-content');
-        const input = document.getElementById('gene-input');
+        const content = document.getElementById('feature-discovery-content');
+        const input = document.getElementById('feature-input');
         if (!content || !input) return;
 
         const query = String(input.value || '').trim();
@@ -14776,7 +14776,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const rawToken = String(gene || '').trim();
         const token = resolveViewerFeatureToken(rawToken);
         const showErrors = options.showErrors !== false;
-        const geneInput = document.getElementById('gene-input');
+        const geneInput = document.getElementById('feature-input');
 
         if (!rawToken) {{
             currentGene = null;
@@ -14784,9 +14784,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             hiddenCategories.clear();
             if (geneInput) geneInput.value = '';
             document.getElementById('visual-default-controls')?.classList.add('annotation-mode');
-            document.getElementById('visual-default-controls')?.classList.remove('gene-mode');
+            document.getElementById('visual-default-controls')?.classList.remove('feature-mode');
             document.getElementById('default-source-annotation')?.classList.add('active');
-            document.getElementById('default-source-gene')?.classList.remove('active');
+            document.getElementById('default-source-feature')?.classList.remove('active');
             updateExpressionScaleUI();
             renderLegend('legend');
             renderLegend('modal-legend');
@@ -14832,9 +14832,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }});
         if (ok) {{
             document.getElementById('visual-default-controls')?.classList.remove('annotation-mode');
-            document.getElementById('visual-default-controls')?.classList.add('gene-mode');
+            document.getElementById('visual-default-controls')?.classList.add('feature-mode');
             document.getElementById('default-source-annotation')?.classList.remove('active');
-            document.getElementById('default-source-gene')?.classList.add('active');
+            document.getElementById('default-source-feature')?.classList.add('active');
             recordRecentGene(token);
             geneDiscoveryResults = [];
             geneDiscoveryActiveIndex = -1;
@@ -19253,7 +19253,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function getGenePanelSeedToken() {{
         const fromCurrent = resolveCanonicalFeatureName(currentGene);
         if (fromCurrent) return fromCurrent;
-        const geneInput = document.getElementById('gene-input');
+        const geneInput = document.getElementById('feature-input');
         return resolveCanonicalFeatureName(geneInput?.value || '');
     }}
 
@@ -25107,7 +25107,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         geneDenseCache.clear();
         invalidateGeneDensityCaches();
         populateGeneInputDatalist();
-        const geneInput = document.getElementById('gene-input');
+        const geneInput = document.getElementById('feature-input');
         if (geneInput && currentGene) geneInput.value = getGeneDisplayLabel(currentGene);
         renderGeneDiscoveryPanel();
         updateExpressionScaleUI();
@@ -25944,7 +25944,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         selectedNeighborFocus = null;
         const annotationSelect = document.getElementById('annotation-select');
         if (annotationSelect) annotationSelect.value = col;
-        const geneInput = document.getElementById('gene-input');
+        const geneInput = document.getElementById('feature-input');
         if (geneInput) geneInput.value = '';
         (DATA.sections || []).forEach(s => {{ if (s && s._colorCache) s._colorCache = {{}}; }});
         hiddenCategories.clear();
@@ -33789,60 +33789,83 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
         const visualDefaultControls = document.getElementById('visual-default-controls');
         const defaultSourceAnnotationBtn = document.getElementById('default-source-annotation');
-        const defaultSourceGeneBtn = document.getElementById('default-source-gene');
+        const defaultSourceGeneBtn = document.getElementById('default-source-feature');
+        const modalityControl = document.getElementById('visual-feature-namespace-control');
+        const modalitySelect = document.getElementById('visual-feature-namespace-select');
+        const getFeatureNamespaceOptions = () => {{
+            const options = MODALITY_DESCRIPTORS.map(desc => ({{
+                value: desc.name,
+                label: desc.label || desc.name,
+            }}));
+            if (Array.isArray(geneModules) && geneModules.length) {{
+                options.push({{ value: MODULE_MODALITY_NAME, label: 'Module' }});
+            }}
+            return options;
+        }};
+        const syncFeatureNamespaceSelect = () => {{
+            if (!modalityControl || !modalitySelect) return;
+            const options = getFeatureNamespaceOptions();
+            const active = getVisualModality();
+            modalitySelect.replaceChildren();
+            options.forEach((entry) => {{
+                const opt = document.createElement('option');
+                opt.value = entry.value;
+                opt.textContent = entry.label;
+                if (entry.value === active) opt.selected = true;
+                modalitySelect.appendChild(opt);
+            }});
+            modalityControl.style.display = options.length > 1 ? '' : 'none';
+        }};
         const setDefaultVisualSource = (source) => {{
-            const mode = source === 'gene' ? 'gene' : 'color';
+            const mode = source === 'feature' ? 'feature' : 'color';
             visualDefaultControls?.classList.toggle('annotation-mode', mode === 'color');
-            visualDefaultControls?.classList.toggle('gene-mode', mode === 'gene');
+            visualDefaultControls?.classList.toggle('feature-mode', mode === 'feature');
             defaultSourceAnnotationBtn?.classList.toggle('active', mode === 'color');
-            defaultSourceGeneBtn?.classList.toggle('active', mode === 'gene');
+            defaultSourceGeneBtn?.classList.toggle('active', mode === 'feature');
+            if (modalityControl) {{
+                const hasMultipleNamespaces = getFeatureNamespaceOptions().length > 1;
+                modalityControl.style.display = mode === 'feature' && hasMultipleNamespaces ? '' : 'none';
+            }}
         }};
         const applyDefaultVisualSource = async (source) => {{
-            const mode = source === 'gene' ? 'gene' : 'color';
+            const mode = source === 'feature' ? 'feature' : 'color';
             setDefaultVisualSource(mode);
             if (mode === 'color') {{
                 await activateViewerGene('', {{ showErrors: false }});
                 return;
             }}
-            const geneInput = document.getElementById('gene-input');
+            const geneInput = document.getElementById('feature-input');
             const requested = resolveCanonicalFeatureName(geneInput?.value || '')
                 || resolveCanonicalFeatureName(currentGene)
                 || '';
             if (!requested) return;
             await activateViewerGene(requested, {{ showErrors: false }});
         }};
-        setDefaultVisualSource(currentGene ? 'gene' : 'annotation');
+        geneModules = loadGeneModules();
+        syncFeatureNamespaceSelect();
+        setDefaultVisualSource(currentGene ? 'feature' : 'annotation');
         defaultSourceAnnotationBtn?.addEventListener('click', () => {{
             applyDefaultVisualSource('annotation').catch(error => console.warn(error));
         }});
         defaultSourceGeneBtn?.addEventListener('click', () => {{
-            applyDefaultVisualSource('gene').catch(error => console.warn(error));
+            applyDefaultVisualSource('feature').catch(error => console.warn(error));
         }});
 
         populateGeneInputDatalist();
 
-        // Modality picker: only render when more than one modality is exported.
-        const modalityControl = document.getElementById('modality-control-group');
-        const modalitySelect = document.getElementById('modality-select');
-        if (modalityControl && modalitySelect && MODALITY_DESCRIPTORS.length > 1) {{
-            for (const desc of MODALITY_DESCRIPTORS) {{
-                const opt = document.createElement('option');
-                opt.value = desc.name;
-                opt.textContent = desc.label || desc.name;
-                if (desc.name === getVisualModality()) opt.selected = true;
-                modalitySelect.appendChild(opt);
-            }}
-            modalityControl.style.display = '';
+        if (modalityControl && modalitySelect) {{
             modalitySelect.addEventListener('change', async (e) => {{
                 const target = e.target.value;
                 await setActiveModality(target);
+                syncFeatureNamespaceSelect();
+                setDefaultVisualSource('feature');
             }});
         }}
 
-        const geneInput = document.getElementById('gene-input');
-        const geneInputShell = document.getElementById('gene-input-shell');
-        const geneDiscoveryPanel = document.getElementById('gene-discovery-panel');
-        const genePanelNew = document.getElementById('gene-panel-new');
+        const geneInput = document.getElementById('feature-input');
+        const geneInputShell = document.getElementById('feature-input-shell');
+        const geneDiscoveryPanel = document.getElementById('feature-discovery-panel');
+        const genePanelNew = document.getElementById('feature-panel-new');
         recentGenes = loadRecentGenes();
         savedGenePanels = loadSavedGenePanels();
         renderGeneDiscoveryPanel();
@@ -34068,7 +34091,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     controls.gene.value = getGeneDisplayLabel(spec.gene);
 
                     // Populate side-specific feature datalist
-                    const listId = `overview-blend-${{side}}-gene-list`;
+                    const listId = `overview-blend-${{side}}-feature-list`;
                     const listEl = document.getElementById(listId);
                     if (listEl) {{
                         const features = getFeatureDatalistValuesForModality(modName);

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -7917,9 +7917,16 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function setPseudobulkPanelModality(modality) {{
         return setPanelModality('pseudobulk', modality);
     }}
+    function getInteractionsModality() {{
+        return getPanelModality('interactions');
+    }}
+    function setInteractionsModality(modality) {{
+        return setPanelModality('interactions', modality);
+    }}
     function getModalityPayload(payloadName, modality = getExplorationModality()) {{
         let root = DATA[payloadName];
         if (payloadName === 'pseudobulk_de_by_modality') root = DATA.pseudobulk_de_by_modality;
+        else if (payloadName === 'interaction_markers_by_modality') root = DATA.interaction_markers_by_modality;
         else if (payloadName === 'marker_features_by_modality') root = DATA.marker_features_by_modality;
         else if (payloadName === 'category_feature_means_by_modality') root = DATA.category_feature_means_by_modality;
         else if (payloadName === 'feature_correlations_by_modality') root = DATA.feature_correlations_by_modality;
@@ -7965,6 +7972,35 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
     function getExplorationMarkerFeaturesPayload(modality = getExplorationModality()) {{
         return getModalityPayload('marker_features_by_modality', modality) || {{}};
+    }}
+    function getMarkerFeaturesPayloadForModality(modality = getExplorationModality()) {{
+        return getModalityPayload('marker_features_by_modality', modality) || {{}};
+    }}
+    function getInteractionMarkersPayloadForModality(modality = getInteractionsModality()) {{
+        return getModalityPayload('interaction_markers_by_modality', modality) || {{}};
+    }}
+    function modalityHasInteractionMarkers(modality) {{
+        return Object.values(getInteractionMarkersPayloadForModality(modality)).some((byAnnotation) => (
+            byAnnotation && typeof byAnnotation === 'object' && Object.keys(byAnnotation).length > 0
+        ));
+    }}
+    function getInteractionMarkerModalities() {{
+        const root = DATA.interaction_markers_by_modality && typeof DATA.interaction_markers_by_modality === 'object'
+            ? DATA.interaction_markers_by_modality
+            : {{}};
+        const registryNames = MODALITY_DESCRIPTORS
+            .map((descriptor) => descriptor?.name)
+            .filter(Boolean);
+        return uniqueSortedFeatures([...registryNames, ...Object.keys(root)])
+            .filter((modality) => modalityHasInteractionMarkers(modality));
+    }}
+    function ensureInteractionsModality() {{
+        const available = getInteractionMarkerModalities();
+        const current = getInteractionsModality();
+        if (available.length && !available.includes(current)) {{
+            return setInteractionsModality(available[0]);
+        }}
+        return current;
     }}
     function getExplorationCategoryFeatureMeansPayload(modality = getExplorationModality()) {{
         return getModalityPayload('category_feature_means_by_modality', modality) || null;
@@ -11285,8 +11321,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     function tutorialHasNeighborhoods() {{
         const stats = DATA.neighbor_stats || {{}};
-        const interactions = DATA.interaction_markers || {{}};
-        return !!DATA.has_neighbors || Object.keys(stats).length > 0 || Object.keys(interactions).length > 0;
+        return !!DATA.has_neighbors || Object.keys(stats).length > 0 || getInteractionMarkerModalities().length > 0;
     }}
 
     function openTutorialInsightsPanel(topLevel, subtab) {{
@@ -19545,9 +19580,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }}
     }}
 
-    function getMarkerGenesForColorCategory(annotationCol, category) {{
+    function getMarkerGenesForColorCategory(annotationCol, category, modality = getExplorationModality()) {{
         if (!annotationCol || category === null || category === undefined || category === BLEND_ALL_CATEGORIES) return [];
-        const byColor = getExplorationMarkerFeaturesPayload()[annotationCol];
+        const byColor = getMarkerFeaturesPayloadForModality(modality)[annotationCol];
         if (!byColor || typeof byColor !== 'object') return [];
         const rawCategory = resolveRawCategoryValue(annotationCol, category);
         if (Array.isArray(byColor[category])) return byColor[category];
@@ -19598,7 +19633,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function getMarkerGeneEntries(annotationCol, category, limit = 0, modality = getExplorationModality()) {{
-        return normalizeGeneEntries(getMarkerGenesForColorCategory(annotationCol, category), limit, modality);
+        return normalizeGeneEntries(getMarkerGenesForColorCategory(annotationCol, category, modality), limit, modality);
     }}
 
     function getMarkerOverlapEntries(annotationCol, sourceCategory, referenceCategory, limit = 0, modality = getExplorationModality()) {{
@@ -19687,8 +19722,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }};
     }}
 
-    function getInteractionPairSummary(annotationCol, sourceCategory, targetCategory) {{
-        const annotationData = (DATA.interaction_markers || {{}})[annotationCol] || {{}};
+    function getInteractionPairSummary(annotationCol, sourceCategory, targetCategory, modality = getInteractionsModality()) {{
+        const annotationData = getInteractionMarkersPayloadForModality(modality)[annotationCol] || {{}};
         const rawSource = resolveRawCategoryValue(annotationCol, sourceCategory);
         const rawTarget = resolveRawCategoryValue(annotationCol, targetCategory);
         const result = (annotationData[String(rawSource)] || {{}})[String(rawTarget)];
@@ -19697,7 +19732,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             sourceCategory: String(sourceCategory),
             targetCategory: String(targetCategory),
             result,
-            genes: normalizeGeneEntries(result.genes || [], 4),
+            genes: normalizeGeneEntries(result.genes || [], 4, modality),
         }};
     }}
 
@@ -25658,6 +25693,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     </div>
                     <div class="insights-tab-content" id="neighbors-tab-interactions-content">
                         <div>
+                            <label>Feature namespace</label>
+                            <select id="interaction-marker-modality-select"></select>
+                        </div>
+                        <div>
                             <label>Interaction Source</label>
                             <select id="interaction-source"></select>
                         </div>
@@ -25928,6 +25967,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 renderNeighborStats();
             }});
         }}
+        const interactionModality = document.getElementById('interaction-marker-modality-select');
+        interactionModality?.addEventListener('change', () => {{
+            setInteractionsModality(interactionModality.value || DEFAULT_MODALITY_NAME);
+            interactionSourceCategory = null;
+            renderInteractionBrowser();
+        }});
         const interactionSource = document.getElementById('interaction-source');
         interactionSource?.addEventListener('change', () => {{
             interactionSourceCategory = interactionSource.value || null;
@@ -28093,8 +28138,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             + renderMarkerGroup(referenceMarkerEntries, referenceCategory, 'reference');
     }}
 
-    function renderInteractionComparisonCard(annotationCol, sourceCategory, targetCategory) {{
-        const summary = getInteractionPairSummary(annotationCol, sourceCategory, targetCategory);
+    function renderInteractionComparisonCard(annotationCol, sourceCategory, targetCategory, modality = getInteractionsModality()) {{
+        const summary = getInteractionPairSummary(annotationCol, sourceCategory, targetCategory, modality);
         const title = `${{escapeHtml(sourceCategory)}} → ${{escapeHtml(targetCategory)}}`;
         if (!summary) {{
             return `
@@ -28117,13 +28162,13 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             <div class="agg-group">
                 <div class="agg-group-title">${{title}}</div>
                 <div class="agg-group-meta">${{meta}}</div>
-                ${{renderComparisonGeneTokenGrid(summary.genes, available ? 'No contact-conditioned genes returned.' : 'Contact-conditioned DE genes unavailable for this direction.', 'Load contact-conditioned DE gene into the viewer')}}
+                ${{renderComparisonGeneTokenGrid(summary.genes, available ? 'No contact-conditioned genes returned.' : 'Contact-conditioned DE genes unavailable for this direction.', 'Load contact-conditioned DE gene into the viewer', modality)}}
             </div>
         `;
     }}
 
-    function renderComparisonInteractionSummary(annotationCol, sourceCategory, referenceCategory) {{
-        const annotationData = (DATA.interaction_markers || {{}})[annotationCol] || {{}};
+    function renderComparisonInteractionSummary(annotationCol, sourceCategory, referenceCategory, modality = getInteractionsModality()) {{
+        const annotationData = getInteractionMarkersPayloadForModality(modality)[annotationCol] || {{}};
         if (!Object.keys(annotationData).length) {{
             return `
                 <div class="agg-group">
@@ -28138,8 +28183,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 <div class="agg-group-title">Contact-Conditioned Markers</div>
                 <div class="agg-group-meta">Directional DE between contact-positive and contact-negative source cells.</div>
             </div>
-            ${{renderInteractionComparisonCard(annotationCol, sourceCategory, referenceCategory)}}
-            ${{renderInteractionComparisonCard(annotationCol, referenceCategory, sourceCategory)}}
+            ${{renderInteractionComparisonCard(annotationCol, sourceCategory, referenceCategory, modality)}}
+            ${{renderInteractionComparisonCard(annotationCol, referenceCategory, sourceCategory, modality)}}
         `;
     }}
 
@@ -32937,10 +32982,20 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     function renderInteractionBrowser() {{
         const container = document.getElementById('interaction-browser');
+        const modalitySelect = document.getElementById('interaction-marker-modality-select');
         const sourceSelect = document.getElementById('interaction-source');
         if (!container || !sourceSelect) return;
 
         const annotationCol = getNeighborStatsColorColumn();
+        const availableModalities = getInteractionMarkerModalities();
+        const modality = ensureInteractionsModality();
+        if (modalitySelect) {{
+            modalitySelect.innerHTML = availableModalities
+                .map((name) => `<option value="${{escapeHtml(name)}}"${{name === modality ? ' selected' : ''}}>${{escapeHtml(getModalityDisplayLabel(name))}}</option>`)
+                .join('');
+            modalitySelect.value = availableModalities.includes(modality) ? modality : '';
+            modalitySelect.disabled = availableModalities.length < 2;
+        }}
         if (!DATA.has_neighbors) {{
             setNeighborStatsPanelAvailability('neighbors-tab-interactions-content', true, annotationCol);
             container.innerHTML = '<div class="agg-group-meta">No neighbor graph was found in this dataset.</div>';
@@ -32970,8 +33025,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const zscores = stats.zscore || null;
         const nCells = stats.n_cells || [];
         const meanDegree = stats.mean_degree || [];
-        const markers = (DATA.marker_genes || {{}})[annotationCol] || {{}};
-        const interactionMarkersByColor = (DATA.interaction_markers || {{}})[annotationCol] || {{}};
+        const interactionMarkersByColor = getInteractionMarkersPayloadForModality(modality)[annotationCol] || {{}};
         const hasInteractionMarkers = Object.keys(interactionMarkersByColor).length > 0;
         if (categories.length === 0 || counts.length === 0) {{
             container.innerHTML = '<div class="agg-group-meta">Interaction data is empty for this annotation.</div>';
@@ -33015,7 +33069,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const row = counts[sourceIdx] || [];
         const total = row.reduce((sum, value) => sum + (Number.isFinite(value) ? value : 0), 0);
         const targetQuery = (document.getElementById('interaction-search')?.value || '').trim().toLowerCase();
-        const sourceMarkers = (markers[rawSource] || []).slice(0, 6);
+        const sourceMarkers = getMarkerGenesForColorCategory(annotationCol, source, modality).slice(0, 6);
         const sortedEntries = categories
             .map((target, targetIdx) => {{
                 const count = Number(row[targetIdx] ?? 0);
@@ -33024,7 +33078,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     ? Number(zscores[sourceIdx][targetIdx])
                     : null;
                 const rawTarget = resolveRawCategoryValue(annotationCol, target);
-                const targetMarkers = (markers[rawTarget] || []).slice(0, 4);
+                const targetMarkers = getMarkerGenesForColorCategory(annotationCol, target, modality).slice(0, 4);
                 const contact = sourceInteractionMarkers[rawTarget] || null;
                 const contactMarkers = contact && Array.isArray(contact.genes)
                     ? contact.genes.slice(0, 4).filter(Boolean)
@@ -33046,12 +33100,13 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
         const topEntries = sortedEntries.slice(0, 12);
         const renderInlineGeneLinks = (genes) => genes.map(g => {{
-            const loadable = isViewerFeatureLoadable(g);
+            const token = resolveFeatureTokenForModality(g, modality) || String(g || '').trim();
+            const loadable = isViewerFeatureLoadable(g, modality);
             const cls = loadable ? 'interaction-gene-link' : 'interaction-gene-link disabled';
-            const activateAttr = loadable ? ` data-gene-activate="${{escapeHtml(g)}}"` : '';
+            const activateAttr = loadable ? ` data-gene-activate="${{escapeHtml(token)}}" data-gene-modality="${{escapeHtml(modality)}}"` : '';
             const title = loadable
-                ? `Load ${{g}} into the viewer`
-                : `${{g}} is shown in DE results but its expression vector is unavailable`;
+                ? `Load ${{g}} into the ${{getModalityDisplayLabel(modality)}} viewer`
+                : `${{g}} is shown in DE results but its expression vector is unavailable for ${{getModalityDisplayLabel(modality)}}`;
             return `<span class="${{cls}}"${{activateAttr}} title="${{escapeHtml(title)}}">${{escapeHtml(g)}}</span>`;
         }}).join(', ');
         const sourceMarkerLabel = sourceMarkers.length ? renderInlineGeneLinks(sourceMarkers) : 'No pseudobulk DE genes available.';
@@ -33096,7 +33151,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 <div class="agg-group-title">${{renderAggCategoryChip(annotationCol, source)}} → targets${{renderCalcInfoButton('neighbor_stats')}}</div>
                 <div class="agg-group-meta">n=${{sourceN}} | mean degree=${{degreeLabel}} | neighbor edges=${{formatNeighborCount(total)}}</div>
                 <div class="agg-group-meta">Source DE genes: ${{sourceMarkerLabel}}</div>
-                <div class="agg-group-meta">Contact-conditioned DE genes available for ${{withContactMarkers}}/${{topEntries.length}} shown targets.</div>
+                <div class="agg-group-meta">Contact-conditioned DE genes available for ${{withContactMarkers}}/${{topEntries.length}} shown targets in ${{escapeHtml(getModalityDisplayLabel(modality))}}.</div>
                 ${{hasInteractionMarkers ? '' : '<div class="agg-group-meta">Contact DE genes not precomputed for this annotation (use pseudobulk_additional_annotations during export for extra annotations).</div>'}}
             </div>
             <table class="trend-table">

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -930,6 +930,17 @@ def _serialize_embedded_viewer_data(data: Mapping[str, object]) -> Tuple[str, st
                         )
                     append_fragment(section_index, key, child_value, child_key=child_key)
                 continue
+            if key == "edges_b64":
+                append_fragment(section_index, key, None)
+                section_label = section.get("id", section_index)
+                log_warning(
+                    "Skipping exported neighbor graph for section "
+                    f"{section_label!r}: serialized edges exceed "
+                    f"{EMBEDDED_VIEWER_DATA_SINGLE_SCRIPT_MAX_CHARS // (1024 * 1024)} MB. "
+                    "Spatial coordinates, annotations, and precomputed neighbor summaries remain available.",
+                    level=1,
+                )
+                continue
             raise ValueError(
                 "large viewer export contains a section field that exceeds "
                 f"{EMBEDDED_VIEWER_DATA_SINGLE_SCRIPT_MAX_CHARS // (1024 * 1024)} MB: "

--- a/karospace/exporter.py
+++ b/karospace/exporter.py
@@ -6892,9 +6892,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     <div class="info-block">
                         <div class="info-title">Keyboard Shortcuts</div>
                         <table class="info-shortcuts-table">
-                            <tr><td class="info-shortcuts-key"><kbd>Esc</kbd></td><td>Close the modal, or close gene discovery if the modal is not open.</td></tr>
+                            <tr><td class="info-shortcuts-key"><kbd>Esc</kbd></td><td>Close the modal, or close feature discovery if the modal is not open.</td></tr>
                             <tr><td class="info-shortcuts-key"><kbd>?</kbd></td><td>Open the full keyboard shortcuts overlay.</td></tr>
-                            <tr><td class="info-shortcuts-key"><kbd>/</kbd></td><td>Focus the gene search input and open gene discovery.</td></tr>
+                            <tr><td class="info-shortcuts-key"><kbd>/</kbd></td><td>Focus the feature search input and open feature discovery.</td></tr>
                             <tr><td class="info-shortcuts-key"><kbd>←</kbd> <kbd>→</kbd></td><td>Move to the previous or next section while the modal is open.</td></tr>
                             <tr><td class="info-shortcuts-key"><kbd>T</kbd></td><td>Toggle theme.</td></tr>
                             <tr><td class="info-shortcuts-key"><kbd>I</kbd></td><td>Toggle the Insights panel.</td></tr>
@@ -6920,9 +6920,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Save and load"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3v12"></path><path d="m17 8-5-5-5 5"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path></svg></span></div><div class="button-help-text">Saves the current viewer state to JSON or restores a previously saved state.</div></div>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Export and download"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"></path><path d="M14 2v4a2 2 0 0 0 2 2h4"></path><path d="M12 18v-6"></path><path d="m9 15 3 3 3-3"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg></span></div><div class="button-help-text">Downloads the available table, plot, palette, annotations, session, or data bundle for that panel.</div></div>
                             {reproducibility_button_help_html}
-                            <div class="button-help-item"><div class="button-help-icons" aria-label="Visual and gene settings"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.2 14.8a2 2 0 0 1 2 2"></path><circle cx="18.5" cy="8.5" r="3.5"></circle><circle cx="7.5" cy="16.5" r="5.5"></circle><circle cx="7.5" cy="4.5" r="2.5"></circle></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><line x1="21" x2="14" y1="4" y2="4"></line><line x1="10" x2="3" y1="4" y2="4"></line><line x1="21" x2="12" y1="12" y2="12"></line><line x1="8" x2="3" y1="12" y2="12"></line><line x1="21" x2="16" y1="20" y2="20"></line><line x1="12" x2="3" y1="20" y2="20"></line><line x1="14" x2="14" y1="2" y2="6"></line><line x1="8" x2="8" y1="10" y2="14"></line><line x1="16" x2="16" y1="18" y2="22"></line></svg></span></div><div class="button-help-text">Opens visual parameters, UMAP appearance, or gene-expression display controls.</div></div>
+                            <div class="button-help-item"><div class="button-help-icons" aria-label="Visual and feature settings"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7.2 14.8a2 2 0 0 1 2 2"></path><circle cx="18.5" cy="8.5" r="3.5"></circle><circle cx="7.5" cy="16.5" r="5.5"></circle><circle cx="7.5" cy="4.5" r="2.5"></circle></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><line x1="21" x2="14" y1="4" y2="4"></line><line x1="10" x2="3" y1="4" y2="4"></line><line x1="21" x2="12" y1="12" y2="12"></line><line x1="8" x2="3" y1="12" y2="12"></line><line x1="21" x2="16" y1="20" y2="20"></line><line x1="12" x2="3" y1="20" y2="20"></line><line x1="14" x2="14" y1="2" y2="6"></line><line x1="8" x2="8" y1="10" y2="14"></line><line x1="16" x2="16" y1="18" y2="22"></line></svg></span></div><div class="button-help-text">Opens visual parameters, UMAP appearance, or feature display controls.</div></div>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Cell selection tools"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 11V6a2 2 0 0 0-4 0"></path><path d="M14 10V4a2 2 0 0 0-4 0v6"></path><path d="M10 10.5V6a2 2 0 0 0-4 0v8"></path><path d="M18 8a2 2 0 1 1 4 0v6a8 8 0 0 1-8 8h-2c-2.8 0-4.5-.9-6.5-2.8L2 16a2.3 2.3 0 0 1 3.2-3.3L7 14"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M7 22a5 5 0 0 1-2-4"></path><path d="M3.3 14A6.8 6.8 0 0 1 2 10c0-4.4 4.5-8 10-8s10 3.6 10 8-4.5 8-10 8a12 12 0 0 1-5-1"></path><path d="M5 18a2 2 0 1 0 4 0 2 2 0 0 0-4 0"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m16 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z"></path><path d="m2 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z"></path><path d="M7 21h10"></path><path d="M12 3v18"></path><path d="M3 7h2c2 0 5-1 7-2 2 1 5 2 7 2h2"></path></svg></span></div><div class="button-help-text">Switches cell-selection interaction between moving, lasso selection, and selected-cell comparison.</div></div>
-                            <div class="button-help-item"><div class="button-help-icons" aria-label="Query and search"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><line x1="22" x2="18" y1="12" y2="12"></line><line x1="6" x2="2" y1="12" y2="12"></line><line x1="12" x2="12" y1="6" y2="2"></line><line x1="12" x2="12" y1="22" y2="18"></line></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg></span></div><div class="button-help-text">Finds cells, genes, markers, or annotations depending on the active panel.</div></div>
+                            <div class="button-help-item"><div class="button-help-icons" aria-label="Query and search"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="10"></circle><line x1="22" x2="18" y1="12" y2="12"></line><line x1="6" x2="2" y1="12" y2="12"></line><line x1="12" x2="12" y1="6" y2="2"></line><line x1="12" x2="12" y1="22" y2="18"></line></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg></span></div><div class="button-help-text">Finds cells, features, markers, or annotations depending on the active panel.</div></div>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Swap"><span class="button-help-icon"><svg class="lucide lucide-arrow-left-right" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 3 4 7l4 4"></path><path d="M4 7h16"></path><path d="m16 21 4-4-4-4"></path><path d="M20 17H4"></path></svg></span></div><div class="button-help-text">Swaps the A and B sides of a comparison or changes comparison direction.</div></div>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Visibility and spotlight"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"></path><circle cx="12" cy="12" r="3"></circle></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49"></path><path d="M14.084 14.158a3 3 0 0 1-4.242-4.242"></path><path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143"></path><path d="m2 2 20 20"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M9 18h6"></path><path d="M10 22h4"></path><path d="M12 2v2"></path><path d="m4.93 4.93 1.41 1.41"></path><path d="M2 12h2"></path><path d="m19.07 4.93-1.41 1.41"></path><path d="M20 12h2"></path><path d="M15 14a5 5 0 1 0-6 0l1 4h4z"></path></svg></span></div><div class="button-help-text">Shows, hides, or spotlights categories and overlay elements in legends and panels.</div></div>
                             <div class="button-help-item"><div class="button-help-icons" aria-label="Clear and delete"><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg></span><span class="button-help-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg></span></div><div class="button-help-text">Clears the current filter, selection, highlight, module, annotation, or panel-specific focus.</div></div>
@@ -7084,7 +7084,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     <button class="visual-params-toggle" id="visual-params-toggle" type="button" title="Visual parameters" aria-expanded="false" aria-controls="visual-params-panel">
                         <svg viewBox="0 0 24 24" aria-hidden="true" data-icon="bubbles"><path d="M7.2 14.8a2 2 0 0 1 2 2"></path><circle cx="18.5" cy="8.5" r="3.5"></circle><circle cx="7.5" cy="16.5" r="5.5"></circle><circle cx="7.5" cy="4.5" r="2.5"></circle></svg>
                     </button>
-                    <button class="gene-params-toggle hidden" id="gene-params-toggle" type="button" title="Gene parameters" aria-expanded="false" aria-controls="gene-params-panel">
+                    <button class="gene-params-toggle hidden" id="gene-params-toggle" type="button" title="Feature parameters" aria-expanded="false" aria-controls="gene-params-panel">
                         <svg viewBox="0 0 24 24" aria-hidden="true"><line x1="21" x2="14" y1="4" y2="4"></line><line x1="10" x2="3" y1="4" y2="4"></line><line x1="21" x2="12" y1="12" y2="12"></line><line x1="8" x2="3" y1="12" y2="12"></line><line x1="21" x2="16" y1="20" y2="20"></line><line x1="12" x2="3" y1="20" y2="20"></line><line x1="14" x2="14" y1="2" y2="6"></line><line x1="8" x2="8" y1="10" y2="14"></line><line x1="16" x2="16" y1="18" y2="22"></line></svg>
                     </button>
                     <div class="visual-params-panel" id="visual-params-panel">
@@ -7192,7 +7192,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         <div class="focused-he-status" id="focused-he-status">No image loaded</div>
                     </div>
                     <div class="gene-params-panel" id="gene-params-panel">
-                        <div class="visual-params-title">Gene parameters</div>
+                        <div class="visual-params-title">Feature parameters</div>
                         <div class="gene-param-section">
                             <div class="gene-param-section-title">Scale</div>
                             <div class="control-group" id="expression-scale-section" style="display: none;">
@@ -7225,13 +7225,13 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         <div class="gene-param-section">
                             <div class="gene-param-section-title">Annotation</div>
                             <div class="control-group" id="expression-color-section" style="display: none;">
-                                <select id="expr-colormap" title="Colormap used for gene expression and continuous metadata" style="font-size:11px; padding:3px 4px; border:1px solid var(--border-color); border-radius:4px; background:var(--input-bg); color:var(--text-color);"></select>
+                                <select id="expr-colormap" title="Colormap used for feature values and continuous metadata" style="font-size:11px; padding:3px 4px; border:1px solid var(--border-color); border-radius:4px; background:var(--input-bg); color:var(--text-color);"></select>
                             </div>
                         </div>
                         <div class="gene-param-section">
                             <div class="gene-param-section-title">View</div>
                             <div class="control-group" id="overview-gene-view-block" style="display: none;">
-                                <select id="overview-gene-view-mode" title="Choose how active gene expression is rendered in the overview panels">
+                                <select id="overview-gene-view-mode" title="Choose how active feature values are rendered in the overview panels">
                                     <option value="cells">Cells</option>
                                     <option value="density">Density</option>
                                     <option value="both">Both</option>
@@ -7291,8 +7291,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             <div class="shortcuts-dialog-body">
                 <table class="info-shortcuts-table">
                     <tr><td class="info-shortcuts-key"><kbd>?</kbd></td><td>Open or close this shortcuts overlay.</td></tr>
-                    <tr><td class="info-shortcuts-key"><kbd>Esc</kbd></td><td>Close this overlay, then the modal, or close gene discovery if the modal is not open.</td></tr>
-                    <tr><td class="info-shortcuts-key"><kbd>/</kbd></td><td>Focus the gene search input and open gene discovery.</td></tr>
+                    <tr><td class="info-shortcuts-key"><kbd>Esc</kbd></td><td>Close this overlay, then the modal, or close feature discovery if the modal is not open.</td></tr>
+                    <tr><td class="info-shortcuts-key"><kbd>/</kbd></td><td>Focus the feature search input and open feature discovery.</td></tr>
                     <tr><td class="info-shortcuts-key"><kbd>←</kbd> <kbd>→</kbd></td><td>Move to the previous or next section while the modal is open.</td></tr>
                     <tr><td class="info-shortcuts-key"><kbd>T</kbd></td><td>Toggle theme.</td></tr>
                     <tr><td class="info-shortcuts-key"><kbd>I</kbd></td><td>Toggle the Insights panel.</td></tr>
@@ -8328,12 +8328,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }},
         selection_expression: {{
             title: 'Selection expression',
-            body: 'Genes are selected by a two-sided Welch test. The top positive and negative Welch T scores are displayed after the minimum-expression threshold. The value at the bar end is the mean expression followed by the percentage of cells expressing the gene. The factor is mean A divided by mean B.',
+            body: 'Features are selected by a two-sided Welch test. The top positive and negative Welch T scores are displayed after the minimum-expression threshold. The value at the bar end is the mean feature value followed by the percentage of cells above zero. The factor is mean A divided by mean B.',
             formula: 'Welch T = (mean A - mean B) / sqrt(variance A / n A + variance B / n B); the highest positive and lowest negative T scores are used; factor = mean A / mean B'
         }},
         region_expression: {{
             title: 'Region expression',
-            body: 'Genes are selected by a two-sided Welch test between Region A and Region B. The top positive and negative Welch T scores are retained after the minimum-expression threshold. Bar-end values show mean expression and the percentage of cells expressing the gene; the factor is mean A divided by mean B.',
+            body: 'Features are selected by a two-sided Welch test between Region A and Region B. The top positive and negative Welch T scores are retained after the minimum-expression threshold. Bar-end values show mean feature value and the percentage of cells above zero; the factor is mean A divided by mean B.',
             formula: 'Welch T = (mean A - mean B) / sqrt(variance A / n A + variance B / n B); factor = mean A / mean B; log2FC = log2(mean A / mean B)'
         }},
         selection_compare: {{
@@ -8357,18 +8357,18 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             formula: 'fraction(section, category) = category cells in section / total cells in section'
         }},
         de_genes: {{
-            title: 'Pseudobulk DE genes',
-            body: 'Differential expression uses one shared fit model across replicate and annotation, while statistical tests are calculated category-versus-category. Genes not expressed in a minimal percentage of cells in at least one category are removed from reported DE results. Model and statistical tests are calculated using DESeq2 and multiple testing correction is applied to the retained result genes using your method of choice. The table values report log2 fold-change, p-values, adjusted p-values, DESeq2 score and rank, base_mean, and percent expressed. Gene markers are ordered by adjusted pvalue then log2FC.',
+            title: 'Marker features',
+            body: 'Differential analysis uses one shared fit model across replicate and annotation, while statistical tests are calculated category-versus-category. Features not detected in a minimal percentage of cells in at least one category are removed from reported DE results. Model and statistical tests are calculated using DESeq2 and multiple testing correction is applied to the retained result features using your method of choice. The table values report log2 fold-change, p-values, adjusted p-values, DESeq2 score and rank, base_mean, and percent detected. Marker features are ordered by adjusted pvalue then log2FC.',
             formula: 'fit model: ~ replicate + annotation; reported gene filter: max(% expressed in A, % expressed in B) >= min_pct; statistical test: DESeq2 category A vs category B; padj: retained p-values adjusted with the selected correction method; marker order: padj ascending, then log2FC'
         }},
         pseudobulk_simple_de_section: {{
             title: 'Pseudobulk differential analysis',
-            body: 'This section is based on the selected Simple design category-vs-category pseudobulk DESeq2 contrast. Cells are grouped by biological replicate and annotation, raw counts are summed into pseudobulk samples, and a shared DESeq2 model is fit for the annotation. The selected Annotation A and Annotation B are then extracted as a pairwise contrast. Genes shown as DE pass the minimum percent-expressed result filter, then pass the adjusted p-value and absolute log2FC thresholds.',
+            body: 'This section is based on the selected Simple design category-vs-category pseudobulk DESeq2 contrast. Cells are grouped by biological replicate and annotation, raw counts are summed into pseudobulk samples, and a shared DESeq2 model is fit for the annotation. The selected Annotation A and Annotation B are then extracted as a pairwise contrast. Features shown as DE pass the minimum percent-detected result filter, then pass the adjusted p-value and absolute log2FC thresholds.',
             formula: 'model = ~ replicate + annotation; retained genes: max(% expressing cells in A, B) >= min_pct after DESeq2 statistics; DE genes: padj < padj_cutoff and |log2FC| >= log2fc_cutoff'
         }},
         pseudobulk_simple_de_table: {{
             title: 'Differential expression table',
-            body: 'The table lists genes from the selected Annotation A versus Annotation B contrast that pass the current DE thresholds. Rows are sorted by adjusted p-value, then p-value and log2FC. Gene buttons are disabled only when that gene expression vector is not available in the HTML or sidecar.',
+            body: 'The table lists features from the selected Annotation A versus Annotation B contrast that pass the current DE thresholds. Rows are sorted by adjusted p-value, then p-value and log2FC. Feature buttons are disabled only when that feature vector is not available in the HTML or sidecar.',
             formula: 'displayed rows: padj < padj_cutoff and |log2FC| >= log2fc_cutoff; row direction/color follows sign(log2FC)'
         }},
         pseudobulk_ma_plot: {{
@@ -8408,16 +8408,16 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }},
         de_heatmap: {{
             title: 'DE heatmap',
-            body: 'Tiles use aggregation of gene counts per category/replicate and calculate the mean of each category across replicates, then z-score against the full DE heatmap table before applying the visible gene filter. Genes are selected if found DE versus the balanced rest. A star marks genes found DE versus the balanced rest.',
+            body: 'Tiles use aggregation of feature counts per category/replicate and calculate the mean of each category across replicates, then z-score against the full DE heatmap table before applying the visible feature filter. Features are selected if found DE versus the balanced rest. A star marks features found DE versus the balanced rest.',
             formula: 'category mean = mean over replicates of (category gene counts / category cells); z = (category mean - full table mean) / full table SD'
         }},
         spatial_moran: {{
             title: 'Spatial Moran index',
-            body: 'Moran index measures whether nearby cells have similar expression values for a gene.',
+            body: 'Spatial features are ranked by Moran index, which measures whether nearby cells have similar values for a feature.',
             formula: 'I = (n / W) * sum_i sum_j w_ij (x_i - mean(x))(x_j - mean(x)) / sum_i (x_i - mean(x))^2'
         }},
         distribution: {{
-            title: 'Gene distribution',
+            title: 'Feature distribution',
             body: 'List of values and figures are computed from per-cell expression values in each Exploration annotation category. Selection can be restricted to subcategories',
             formula: 'mean = sum(values) / n; Q1/Q3 = 25th/75th percentile; % Expr = 100 * cells with value > 0 / n'
         }},
@@ -8428,7 +8428,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         }},
         group_de: {{
             title: 'Annotation expression',
-            body: 'Genes are selected by a two-sided Welch test between Annotation A and Annotation B. The top positive and negative Welch T scores are retained after the minimum-expression threshold. Bar-end values show mean expression and the percentage of cells expressing the gene; the factor is mean A divided by mean B.',
+            body: 'Features are selected by a two-sided Welch test between Annotation A and Annotation B. The top positive and negative Welch T scores are retained after the minimum-detection threshold. Bar-end values show mean feature value and the percentage of cells above zero; the factor is mean A divided by mean B.',
             formula: 'Welch T = (mean A - mean B) / sqrt(variance A / n A + variance B / n B); factor = mean A / mean B; log2FC = log2(mean A / mean B)'
         }},
         neighbor_stats: {{
@@ -9403,8 +9403,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 'Start with Default mode when browsing, then move to Split mode when comparing two signals.'
             ], {{ nextLabel: tryIt, placement: 'below' }}),
             step('Default source switch', ['#visual-source-switch'], [
-                'Default mode can show either a cell annotation layer or a gene expression layer.',
-                'The Annotation and Gene buttons decide which controls are visible.'
+                'Default mode can show either a cell annotation layer or a feature layer.',
+                'The Annotation and Feature buttons decide which controls are visible.'
             ], {{ nextLabel: tryIt }}),
             step('Annotation selector', ['#visual-annotation-controls', '#annotation-select'], [
                 'The annotation selector chooses which cell-level annotation colors every section.',
@@ -9412,15 +9412,15 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ], {{ nextLabel: tryIt }}),
             step('Open split mode', ['#overview-mode-split', '#visual-params-bar'], [
                 'Split mode compares two visual layers in the same spatial panels.',
-                'This is the easiest way to compare two annotations, two genes, or annotation versus gene.'
+                'This is the easiest way to compare two annotations, two features, or annotation versus feature.'
             ], {{ action: () => {{ if (typeof closeModal === 'function') closeModal(); safeTutorialClick('#overview-mode-split'); }}, nextLabel: tryIt }}),
             step('Choose split layer A', ['#overview-blend-row-a'], [
                 'Layer A controls the left side or first layer in split comparison.',
-                'It can represent an annotation, a gene, or another exported modality depending on the viewer.'
+                'It can represent an annotation or a feature from any exported namespace depending on the viewer.'
             ], {{ action: () => safeTutorialClick('#overview-mode-split'), nextLabel: tryIt }}),
             step('Choose split layer B', ['#overview-blend-row-b'], [
                 'Layer B is the comparison layer paired with layer A.',
-                'Pick a meaningful counterpart, such as another gene or the same annotation under a different category view.'
+                'Pick a meaningful counterpart, such as another feature or the same annotation under a different category view.'
             ], {{ action: () => safeTutorialClick('#overview-mode-split'), nextLabel: tryIt }}),
             step('Split boundary slider', ['#overview-blend-row-mix', '#overview-blend-mix'], [
                 'The slider controls where layer A ends and layer B begins inside each spatial panel.',
@@ -9453,7 +9453,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 'This lets you keep it pinned while browsing the section grid.'
             ], {{ condition: () => !!DATA.has_umap, action: () => {{ if (DATA.has_umap && !umapVisible && typeof toggleUMAP === 'function') toggleUMAP(); }}, nextLabel: tryIt }}),
             step('Insights panel overview', ['#insights-toggle', '#insights-panel'], [
-                'Insights is the workspace for selected cells, regions, gene modules, and built-in analysis panels.'
+                'Insights is the workspace for selected cells, regions, feature modules, and built-in analysis panels.'
             ], {{ action: () => {{ if (typeof closeModal === 'function') closeModal(); if (typeof openInsightsMode === 'function') openInsightsMode('exploration'); }}, nextLabel: tryIt }}),
             step('Insights Selection mode', ['#insights-mode-selection', '#insights-selection-panel'], [
                 'Selection contains the compact summary for cells selected by lasso, UMAP lasso, or query.',
@@ -9464,31 +9464,31 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 'Use it to organize, group, compare, export, or reuse drawn regions.'
             ], {{ action: () => {{ if (typeof openInsightsMode === 'function') openInsightsMode('exploration'); if (typeof setInsightsMode === 'function') setInsightsMode('region'); }}, nextLabel: tryIt }}),
             step('Insights Module mode', ['#insights-mode-module', '#insights-module-panel'], [
-                'The module area combines gene expression to visualize associated genes or pathways.',
+                'The module area combines feature values to visualize associated genes or pathways.',
                 'Use it for signatures, custom marker lists, or repeated gene-set review.'
             ], {{ action: () => {{ if (typeof openInsightsMode === 'function') openInsightsMode('exploration'); if (typeof setInsightsMode === 'function') setInsightsMode('module'); }}, nextLabel: tryIt }}),
             step('Insights Exploration mode', ['#insights-mode-exploration', '#insights-exploration-panel'], [
                 'Exploration is the main navigation mode for built-in summaries.',
-                'It contains overview, gene, compare, pathway, neighborhood, and export-oriented analysis panels.'
+                'It contains overview, feature, compare, pathway, neighborhood, and export-oriented analysis panels.'
             ], {{ action: () => {{ if (typeof openInsightsMode === 'function') openInsightsMode('exploration'); }}, nextLabel: tryIt }}),
             step('Insights Selection', ['#insights-selection-panel.insights-panel-mode'], [
                 'Selection summarizes the active cells selection by section and main annotation.'
             ], {{ action: () => {{ if (typeof closeModal === 'function') closeModal(); setTutorialFirstGridRandomSelection({{ areaFraction: 0.03, minCells: 8, maxCells: 80, attempts: 28 }}); if (typeof openInsightsMode === 'function') openInsightsMode('selection'); updateSelectionInfo?.(); }}, nextLabel: tryIt }}),
             step('Selection Find More', ['[data-selection-find-more]', '#insights-selection-panel'], [
-                'Use the Find More button to reach the Exploration panel and find gene markers of your selection.'
+                'Use the Find More button to reach the Exploration panel and find feature markers of your selection.'
             ], {{ action: () => {{ tutorialSelectionFindMoreClicked = false; if (typeof closeModal === 'function') closeModal(); if (typeof openInsightsMode === 'function') openInsightsMode('selection'); updateSelectionInfo?.(); }}, nextLabel: tryIt }}),
-            step('Selection gene markers', ['#compare-selection-panel .selection-summary-title-row'], [
-                'Compare > Per cell > Selections is the detailed workspace for marker genes of the active selection.',
-                'The search icon starts the marker-gene calculation for the selected cells.'
+            step('Selection feature markers', ['#compare-selection-panel .selection-summary-title-row'], [
+                'Compare > Per cell > Selections is the detailed workspace for marker features of the active selection.',
+                'The search icon starts the marker-feature calculation for the selected cells.'
             ], {{ action: () => {{ tutorialSelectionMarkersClicked = false; selectionWelchButtonHidden = false; selectionWelchRunRequested = false; selectionWelchRunning = false; openTutorialInsightsPanel('compare', 'selection'); updateSelectionInfo?.(); }}, onNext: () => safeTutorialClick('[data-find-welch-markers]'), nextLabel: tryIt }}),
             step('Selection composition comparison', ['#compare-selection-panel .selection-comparison-composition', '#compare-selection-panel .selection-summary-row', '#compare-selection-panel'], [
                 'The composition result summarizes which main annotations are present in the selected cells.',
                 'When Region B exists, the panel shows Region A versus Region B.'
             ], {{ action: () => {{ openTutorialInsightsPanel('compare', 'selection'); updateSelectionInfo?.(); }}, nextLabel: tryIt }}),
-            step('Selection expression comparison', ['#compare-selection-panel .selection-summary-expr', '#compare-selection-panel'], [
-                'Genes were selected by two sided Welch test.',
-                'The gene-expression area compares expression in the selected cells against the current reference.',
-                'Bars show mean expression and percent expressed for each displayed gene.'
+            step('Selection feature comparison', ['#compare-selection-panel .selection-summary-expr', '#compare-selection-panel'], [
+                'Features were selected by two sided Welch test.',
+                'The feature-value area compares values in the selected cells against the current reference.',
+                'Bars show mean value and percent detected for each displayed feature.'
             ], {{ action: () => {{ openTutorialInsightsPanel('compare', 'selection'); updateSelectionInfo?.(); }}, nextLabel: tryIt }}),
             step('Pan mode', '#selection-pan-btn', [
                 'Pan mode moves around the spatial view, and navigate without selecting cells.',
@@ -9532,21 +9532,21 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 'Both controls clear the active selected-cell set.'
             ], {{ action: () => {{ updateSelectionInfo?.(); updateSelectionLassoButtonState?.(); }}, task: 'Deselect the cells by clicking the cross-format lasso button or the red cross in the selection chip.', requiresNoSelection: true, combineTargets: true, targetAfterGateSatisfied: ['#selection-lasso-btn', 'tutorial-first-grid-section'], scroll: false, nextLabel: tryIt }}),
             step('Find cells by query', ['#selection-query-panel', '#selection-query-toggle', '#insights-panel'], [
-                'Select cells based on annotations, level of gene expression or experiment metadata.'
+                'Select cells based on annotations, feature values or experiment metadata.'
             ], {{ action: () => {{ if (typeof openInsightsMode === 'function') openInsightsMode('selection'); updateSelectionInfo?.(); keepTutorialSelectionQueryPanelOpen(); }}, onNext: () => closeSelectionQueryPanel(), task: 'Cells can be selected by querying the text box rule and clicking the search icon below the text box', requiresQuerySelection: true, combineTargets: true, scroll: false, positionTarget: '#selection-query-panel', placement: 'right', nextLabel: tryIt }}),
-            step('Switch to Gene source', ['#default-source-feature', '#visual-feature-controls'], [
-                'Gene source changes the grid from categorical annotation colors to gene or feature expression.'
+            step('Switch to Feature source', ['#default-source-feature', '#visual-feature-controls'], [
+                'Feature source changes the grid from categorical annotation colors to feature values.'
             ], {{ action: () => safeTutorialClick('#default-source-feature'), nextLabel: tryIt }}),
-            step('Gene discovery panel', '#feature-discovery-panel', [
-                'Gene discovery helps you search, activate genes, and inspect related gene information.',
-                'Suggestion for gene markers are displayed depending on the selected annotation.',
-                'It can include marker genes, spatial genes, correlations, and module tools depending on the exported payload.'
+            step('Feature discovery panel', '#feature-discovery-panel', [
+                'Feature discovery helps you search, activate features, and inspect related feature information.',
+                'Marker feature suggestions are displayed depending on the selected annotation.',
+                'It can include marker features, spatial features, correlations, and module tools depending on the exported payload.'
             ], {{ action: () => {{ safeTutorialClick('#default-source-feature'); lockTutorialGeneDiscoveryPanel(); setTutorialToolbarPanel(null); document.getElementById('feature-input')?.focus(); }}, positionTarget: '#feature-discovery-panel', placement: 'right', nextLabel: tryIt }}),
-            step('Gene input field', ['#feature-input', '#feature-input-shell'], [
-                'The gene input accepts embedded genes and sidecar-loadable genes when sidecar mode is available.'
+            step('Feature input field', ['#feature-input', '#feature-input-shell'], [
+                'The feature input accepts embedded features and sidecar-loadable features when sidecar mode is available.'
             ], {{ action: () => safeTutorialClick('#default-source-feature'), onNext: () => setTutorialSplitGeneDisplay(), nextLabel: tryIt }}),
-            step('Gene expression scale', ['#gene-params-panel', '#gene-params-toggle'], [
-                'Modify the default scaling of a gene to highlight its expression. Scaling can be propagated to the other gene in the Split setup to compare gene expression.'
+            step('Feature value scale', ['#gene-params-panel', '#gene-params-toggle'], [
+                'Modify the default scaling of a feature to highlight its values. Scaling can be propagated to the other feature in the Split setup to compare feature values.'
             ], {{ action: () => lockTutorialGeneParamsPanel(), positionTarget: '#gene-params-panel', placement: 'right', prepareDelay: 360, nextLabel: tryIt }}),
             step('Modality selector', ['#visual-feature-namespace-control', '#visual-feature-namespace-select'], [
                 'If multiple modalities were exported, the modality selector switches the feature namespace.',
@@ -9714,8 +9714,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 'Changing them updates the DE table, plots, diagnostics, and pathway section.'
             ], {{ action: () => {{ ensureTutorialPseudobulkDEAnnotation(); openTutorialInsightsPanel('compare', 'cell-de'); ensureTutorialPseudobulkDEAnnotation(); renderPseudobulkDE?.(); }}, task: 'Choose Annotation A and B if selectors are available.', combineTargets: true, prepareDelay: 420, nextLabel: tryIt }}),
             step('Compare Simple design view switch', ['#pseudobulk-de-section-title', '#pseudobulk-de-results .pseudobulk-de-panel-mode-switch'], [
-                'The Simple design switch separates the contrast into Raw table, Genes, and Samples views.',
-                'Raw table shows exact DE values, Genes shows MA and volcano plots, and Samples shows pseudobulk diagnostics such as PCA or distance matrix.'
+                'The Simple design switch separates the contrast into Raw table, Features, and Samples views.',
+                'Raw table shows exact DE values, Features shows MA and volcano plots, and Samples shows pseudobulk diagnostics such as PCA or distance matrix.'
             ], {{ action: () => {{ ensureTutorialPseudobulkDEAnnotation(); openTutorialInsightsPanel('compare', 'cell-de'); ensureTutorialPseudobulkDEAnnotation(); renderPseudobulkDE?.(); }}, combineTargets: true, prepareDelay: 420, scrollDelay: 620, spotlightPadding: 2, nextLabel: tryIt }}),
             step('Compare Simple design pathway switch', ['#pathway-enrichment-title', '#compare-tab-cell-de-content [data-pathway-annotation-select]', '#compare-tab-cell-de-content .pathway-panel-mode-switch'], [
                 'When pathway enrichment is available, the pathway switch changes between ORA pathways and GSEA enrichment.',
@@ -9758,11 +9758,11 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 'It complements neighbor enrichment by describing global spatial arrangement rather than only immediate adjacency.'
             ], {{ action: () => openTutorialInsightsPanel('neighbors', 'dispersion'), nextLabel: tryIt }}),
             step('Finish the tutorial', '#tutorial-trigger', [
-                'You have now touched the major viewer workflows: browsing, filters, genes, modal inspection, selections, annotations, and Insights.',
+                'You have now touched the major viewer workflows: browsing, filters, features, modal inspection, selections, annotations, and Insights.',
                 'Restart the tutorial from the graduation-cap button if you want to revisit any step.'
             ], {{ scroll: false, spotlightPadding: 0, nextLabel: 'Finish' }})
         ];
-        const geneStartIndex = rawSteps.findIndex(item => item.title === 'Switch to Gene source');
+        const geneStartIndex = rawSteps.findIndex(item => item.title === 'Switch to Feature source');
         const geneEndIndex = rawSteps.findIndex(item => item.title === 'Open a section modal');
         const visualSetupEndIndex = rawSteps.findIndex(item => item.title === 'Split boundary slider');
         if (geneStartIndex >= 0 && geneEndIndex > geneStartIndex && visualSetupEndIndex >= 0 && visualSetupEndIndex < geneStartIndex) {{
@@ -9798,8 +9798,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const regionEndIndex = rawSteps.findIndex(item => item.title === 'Module gene picker') >= 0
             ? rawSteps.findIndex(item => item.title === 'Module gene picker')
             : rawSteps.findIndex(item => item.title === 'Exploration annotation selector');
-        const umapRegionAnchorTitle = rawSteps.findIndex(item => item.title === 'Selection expression comparison') >= 0
-            ? 'Selection expression comparison'
+        const umapRegionAnchorTitle = rawSteps.findIndex(item => item.title === 'Selection feature comparison') >= 0
+            ? 'Selection feature comparison'
             : (rawSteps.findIndex(item => item.title === 'Selection Find More') >= 0
                 ? 'Selection Find More'
                 : (rawSteps.findIndex(item => item.title === 'UMAP panel position and size') >= 0
@@ -9816,7 +9816,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ['Viewer info button', 'Helpers'],
             ['Theme toggle', 'Session tools'],
             ['Visual parameters', 'Visual Setup'],
-            ['Switch to Gene source', 'Gene Expression'],
+            ['Switch to Feature source', 'Feature Values'],
             ['Pan mode', 'Spatial Selection'],
             ['UMAP toggle', 'UMAP'],
             ['Insights panel overview', 'Insights'],
@@ -10387,7 +10387,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ensureTutorialSelection('grid');
             tutorialSelectionFindMoreClicked = true;
             updateSelectionInfo?.();
-        }} else if (title === 'Selection gene markers') {{
+        }} else if (title === 'Selection feature markers') {{
             ensureTutorialSelection('grid');
             tutorialSelectionMarkersClicked = true;
             openTutorialInsightsPanel('compare', 'selection');
@@ -11069,9 +11069,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!title) return;
         if (title !== 'Find cells by query') closeSelectionQueryPanel();
         if (title !== 'Visual parameters') unlockTutorialVisualParamsPanel(false);
-        if (title !== 'Gene discovery panel') unlockTutorialGeneDiscoveryPanel(false);
-        if (title !== 'Gene expression scale') unlockTutorialGeneParamsPanel(false);
-        const isSplitGeneScaleStep = title === 'Gene expression scale';
+        if (title !== 'Feature discovery panel') unlockTutorialGeneDiscoveryPanel(false);
+        if (title !== 'Feature value scale') unlockTutorialGeneParamsPanel(false);
+        const isSplitGeneScaleStep = title === 'Feature value scale';
         const isSplitStep = title.startsWith('Open split') || title.startsWith('Split boundary') || title.startsWith('Choose split') || title.startsWith('Split expression') || isSplitGeneScaleStep;
 
         if (chapter === 'Visual Setup' || isSplitStep) {{
@@ -11080,7 +11080,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 if (isSplitGeneScaleStep) lockTutorialGeneParamsPanel();
                 else if (title.startsWith('Split expression')) ensureTutorialGeneParametersOpen();
             }} else {{
-                ensureTutorialDefaultMode(title.includes('Gene') ? 'gene' : 'annotation');
+                ensureTutorialDefaultMode(title.includes('Feature') ? 'gene' : 'annotation');
             }}
         }}
 
@@ -11105,12 +11105,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ensureTutorialDefaultMode('annotation');
         }}
 
-        if (chapter === 'Gene Expression' && !isSplitStep) {{
+        if (chapter === 'Feature Values' && !isSplitStep) {{
             ensureTutorialDefaultMode('gene');
-            if (title === 'Switch to Gene source') clearTutorialGeneInput();
-            if (title === 'Gene input field') ensureTutorialFirstGeneSelected();
-            if (title === 'Gene expression scale') setTutorialToolbarPanel('gene');
-            if (title === 'Gene discovery panel') {{
+            if (title === 'Switch to Feature source') clearTutorialGeneInput();
+            if (title === 'Feature input field') ensureTutorialFirstGeneSelected();
+            if (title === 'Feature value scale') setTutorialToolbarPanel('gene');
+            if (title === 'Feature discovery panel') {{
                 lockTutorialGeneDiscoveryPanel();
             }}
         }}
@@ -13886,7 +13886,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     }}
 
     function setGeneLoadingState(isLoading, message = '') {{
-        featureSidecarLoadingMessage = isLoading ? (message || 'Loading gene expression…') : '';
+        featureSidecarLoadingMessage = isLoading ? (message || 'Loading feature values…') : '';
         const geneInput = document.getElementById('feature-input');
         if (geneInput) {{
             geneInput.disabled = !!isLoading;
@@ -14305,8 +14305,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (featureSidecarShardCache.has(shardUrl)) return featureSidecarShardCache.get(shardUrl);
         if (featureSidecarShardPromises.has(shardUrl)) return featureSidecarShardPromises.get(shardUrl);
 
-        setGeneLoadingState(true, 'Loading gene expression…');
-        window.__karospaceShowLoadingWarning?.('Loading requested gene expression…');
+        setGeneLoadingState(true, 'Loading feature values…');
+        window.__karospaceShowLoadingWarning?.('Loading requested feature values…');
         const promise = fetch(shardUrl, {{ credentials: 'same-origin', cache: 'no-store' }})
             .then(async (response) => {{
                 if (!response.ok) {{
@@ -17157,7 +17157,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const pseudobulkKey = getPseudobulkDEColorKey(annotationCol, modality);
         const byColor = getPseudobulkDEPayloadForModality(modality)[pseudobulkKey] || null;
         if (!byColor || typeof byColor !== 'object') return '';
-        const rows = [['annotation_column', 'category', 'reference', 'rank', 'gene', 'base_mean', 'log2fc', 'pvalue', 'padj', 'score', 'pct_source', 'pct_reference']];
+        const rows = [['modality', 'annotation_column', 'category', 'reference', 'rank', 'feature', 'base_mean', 'log2fc', 'pvalue', 'padj', 'score', 'pct_source', 'pct_reference']];
         Object.entries(byColor).forEach(([sourceCategory, bucket]) => {{
             if (String(sourceCategory).startsWith('_') || !bucket || typeof bucket !== 'object') return;
             const comparisons = bucket.__rest__
@@ -17167,6 +17167,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 const entries = getPseudobulkDETableEntries(result);
                 entries.forEach((entry, idx) => {{
                     rows.push([
+                        modality,
                         annotationCol,
                         sourceCategory,
                         reference,
@@ -17192,11 +17193,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
     function exportMarkerGenesCsv(annotationCol = currentAnnotation, modality = getExplorationModality()) {{
         const csvText = buildMarkerGenesCsv(annotationCol, modality);
         if (!csvText) {{
-            alert('No pseudobulk DE genes are available for this annotation to export.');
+            alert('No pseudobulk DE features are available for this annotation to export.');
             return;
         }}
         const colorLabel = sanitizeFilenamePart(annotationCol || 'color');
-        const filename = `karospace-pseudobulk-de-genes-${{colorLabel}}-${{getScreenshotTimestamp()}}.csv`;
+        const modName = sanitizeFilenamePart(modality || DEFAULT_MODALITY_NAME || 'modality');
+        const filename = `karospace-pseudobulk-de-features-${{modName}}-${{colorLabel}}-${{getScreenshotTimestamp()}}.csv`;
         downloadTextFile(csvText, filename, 'text/csv;charset=utf-8');
     }}
 
@@ -17347,7 +17349,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 ? escapeHtml(selectionQueryStatus)
                 : preview
                     ? `Current query: <code>${{escapeHtml(preview)}}</code>`
-                    : 'Find cells by annotation, gene value, or section metadata.';
+                    : 'Find cells by annotation, feature value, or section metadata.';
         return `
             <div class="selection-query">
                 ${{showToggle ? `
@@ -17523,7 +17525,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             html += '</div>';
         }}
 
-        // Welch test for gene expression A vs B.
+        // Welch test for feature values A vs B.
         const expr = getCachedSelectionWelchExpression(selectedCells, compareAllCells ? null : selectedCellsB);
         if (selectedCells.size > 0 && (compareAllCells || selectedCellsB.size > 0)) {{
             const top = getWelchTopResults(expr);
@@ -17568,7 +17570,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         </div>
                     </div>
                 `).join('');
-                html += `<div class="selection-comparison-de-results">${{buildGroupVolcanoPlot(top, volcanoToolbar, {{ positive: colorA, negative: colorB }})}}<div class="comparison-stack">${{cards}}</div><div style="display:flex;justify-content:flex-end;gap:6px;margin-top:6px;"><button class="icon-btn" type="button" data-selection-de-export-csv title="Download all comparison genes as CSV" aria-label="Download all comparison genes as CSV"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg></button></div></div>`;
+                html += `<div class="selection-comparison-de-results">${{buildGroupVolcanoPlot(top, volcanoToolbar, {{ positive: colorA, negative: colorB }})}}<div class="comparison-stack">${{cards}}</div><div style="display:flex;justify-content:flex-end;gap:6px;margin-top:6px;"><button class="icon-btn" type="button" data-selection-de-export-csv title="Download all comparison features as CSV" aria-label="Download all comparison features as CSV"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg></button></div></div>`;
             }}
         }}
 
@@ -19597,7 +19599,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (!config || config.is_continuous) {{
             return {{
                 title: 'Suggestions unavailable',
-                subtitle: 'Switch to a categorical annotation to use pseudobulk DE gene suggestions.',
+                subtitle: 'Switch to a categorical annotation to use pseudobulk DE feature suggestions.',
                 groups: [],
                 hiddenCount: 0,
             }};
@@ -19608,10 +19610,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             const availableColors = getAvailableMarkerGeneColors();
             const availableLabel = availableColors.length
                 ? ` Available for: ${{availableColors.join(', ')}}.`
-                : ' No pseudobulk DE genes are embedded in this viewer.';
+                : ' No pseudobulk DE features are embedded in this viewer.';
             return {{
                 title: `Suggested from ${{formatMetadataLabel(currentAnnotation)}}`,
-                subtitle: `No pseudobulk DE genes are available for the active color.${{availableLabel}}`,
+                subtitle: `No pseudobulk DE features are available for the active color.${{availableLabel}}`,
                 groups: [],
                 hiddenCount: 0,
             }};
@@ -19631,7 +19633,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
         return {{
             title: `Suggested from ${{formatMetadataLabel(currentAnnotation)}}`,
-            subtitle: groups.length ? '' : 'No pseudobulk DE genes are available for the active color.',
+            subtitle: groups.length ? '' : 'No pseudobulk DE features are available for the active color.',
             groups: groups.slice(0, GENE_DISCOVERY_SUGGESTION_GROUP_LIMIT),
             hiddenCount: Math.max(0, groups.length - GENE_DISCOVERY_SUGGESTION_GROUP_LIMIT),
         }};
@@ -21094,7 +21096,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 '',
                 'Files:',
                 '- obs.csv      Per-cell metadata (' + totalCells.toLocaleString() + ' cells)',
-                '- var.csv      Gene list (' + nGenes.toLocaleString() + ' genes)',
+                '- var.csv      Feature list (' + nGenes.toLocaleString() + ' features)',
                 useSparse
                     ? '- X.mtx        Sparse expression matrix in Matrix Market coordinate format (' + nnz.toLocaleString() + ' non-zero entries)'
                     : '- X.csv        Dense expression matrix (rows = cells, columns = genes)',
@@ -24694,7 +24696,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                                 ${{renderGeneTokenButton(entry.gene, {{
                                     isActive: entry.gene === currentGene,
                                     showMeta: false,
-                                    title: 'Load region DE gene into the viewer',
+                                    title: 'Load region DE feature into the viewer',
                                 }})}}
                                 ${{renderGeneGoogleSearchButton(entry.gene, {{
                                     title: 'Search Google for this gene',
@@ -24810,7 +24812,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 </div>
             `;
         }} else if (!deResult.available && deResult.reason === 'no_loaded_features') {{
-            resultHtml = '<div class="agg-group-meta">No genes are currently loaded for region DE. Load genes in the Genes tab or click pseudobulk DE genes first.</div>';
+            resultHtml = '<div class="agg-group-meta">No features are currently loaded for region DE. Load features in the Features tab or click pseudobulk DE features first.</div>';
         }} else if (!deResult.available) {{
             resultHtml = '<div class="agg-group-meta">Choose two different regions to compare.</div>';
         }} else if (!displayedQuickResults.length) {{
@@ -24834,7 +24836,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         if (exportState) {{
             resultHtml += `
                 <div style="display:flex; justify-content:flex-end; gap:6px; margin-top:6px;">
-                    <button class="icon-btn" id="region-de-export-csv" type="button" title="Download all region DE genes as CSV" aria-label="Download all region DE genes as CSV"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg></button>
+                    <button class="icon-btn" id="region-de-export-csv" type="button" title="Download all region DE features as CSV" aria-label="Download all region DE features as CSV"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg></button>
                 </div>
             `;
         }}
@@ -24936,7 +24938,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             if (expressionEntries.length) {{
                 const colorA = getAnnotationDisplayColor(source) || 'var(--accent-strong)';
                 const colorB = getAnnotationDisplayColor(reference) || '#4cc9f0';
-                summaryHtml += `<div class="selection-summary-expr"><div class="selection-summary-title">Gene Expression by Region</div>`;
+                summaryHtml += `<div class="selection-summary-expr"><div class="selection-summary-title">Feature Values by Region</div>`;
                 expressionEntries.forEach((entry) => {{
                     const meanA = Number(entry.meanA || 0);
                     const meanB = Number(entry.meanB || 0);
@@ -26832,7 +26834,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
 
     function buildGeneDEHeatmap(data, annotationCol) {{
         if (!data || !data.genes.length || !data.categories.length) {{
-            return '<div class="marker-empty">No DE genes available for heatmap view.</div>';
+            return '<div class="marker-empty">No DE features available for heatmap view.</div>';
         }}
         const cellW = 30, cellH = 16, mt = 82, mr = 8, mb = 22;
         const maxGeneLabelChars = data.genes.length <= 1 ? 10 : 12;
@@ -27061,7 +27063,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const annotationMeta = DATA.annotations_meta?.[markerColorCol];
         if (!annotationMeta || annotationMeta.is_continuous) {{
             if (exportBtn) exportBtn.disabled = true;
-            container.innerHTML = toggleHtml + '<div class="marker-empty">Pseudobulk DE genes are available for categorical annotations only.</div>';
+            container.innerHTML = toggleHtml + '<div class="marker-empty">Pseudobulk DE features are available for categorical annotations only.</div>';
             bindGeneSubtabViewToggle(container, subtab, renderMarkerGenes);
             return;
         }}
@@ -27831,7 +27833,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         showMeta: false,
                         title: loadable
                             ? activateTitle
-                            : 'This DE gene is shown in the table but is not available for expression viewing',
+                            : 'This DE feature is shown in the table but is not available for feature viewing',
                     }});
                 }}).join('')}}
             </div>
@@ -27980,7 +27982,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             <div class="agg-group">
                 <div class="agg-group-title">${{title}}</div>
                 <div class="agg-group-meta">${{meta}}</div>
-                ${{renderComparisonGeneTokenGrid(summary.genes, available ? 'No contact-conditioned genes returned.' : 'Contact-conditioned DE genes unavailable for this direction.', 'Load contact-conditioned DE gene into the viewer', modality)}}
+                ${{renderComparisonGeneTokenGrid(summary.genes, available ? 'No contact-conditioned features returned.' : 'Contact-conditioned DE features unavailable for this direction.', 'Load contact-conditioned DE feature into the viewer', modality)}}
             </div>
         `;
     }}
@@ -28650,11 +28652,12 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         ].filter(Boolean).join('-');
     }}
 
-    function buildPseudobulkDECsv(entries) {{
-        const headers = ['gene', 'base_mean', 'log2fc', 'pvalue', 'padj', 'score', 'pct_source', 'pct_reference'];
+    function buildPseudobulkDECsv(entries, modality = getPseudobulkPanelModality()) {{
+        const headers = ['modality', 'feature', 'base_mean', 'log2fc', 'pvalue', 'padj', 'score', 'pct_source', 'pct_reference'];
         const lines = [headers.map(csvEscape).join(',')];
         entries.forEach((entry) => {{
             lines.push([
+                modality,
                 entry.gene,
                 csvFormatNumber(entry.baseMean),
                 csvFormatNumber(entry.log2fc),
@@ -28668,9 +28671,10 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         return lines.join('\\n') + '\\n';
     }}
 
-    function buildPseudobulkDEExcelHtml(entries) {{
-        const headers = ['gene', 'base_mean', 'log2fc', 'pvalue', 'padj', 'score', 'pct_source', 'pct_reference'];
+    function buildPseudobulkDEExcelHtml(entries, modality = getPseudobulkPanelModality()) {{
+        const headers = ['modality', 'feature', 'base_mean', 'log2fc', 'pvalue', 'padj', 'score', 'pct_source', 'pct_reference'];
         const rows = entries.map((entry) => [
+            modality,
             entry.gene,
             csvFormatNumber(entry.baseMean),
             csvFormatNumber(entry.log2fc),
@@ -28697,14 +28701,14 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         );
         const entries = getPseudobulkDETableEntries(result);
         if (!entries.length) {{
-            alert('No pseudobulk DE genes are available for this comparison.');
+            alert('No pseudobulk DE features are available for this comparison.');
             return;
         }}
         const stem = getPseudobulkDEFilenameStem();
         if (format === 'excel') {{
-            downloadTextFile(buildPseudobulkDEExcelHtml(entries), `${{stem}}.xls`, 'application/vnd.ms-excel;charset=utf-8');
+            downloadTextFile(buildPseudobulkDEExcelHtml(entries, getPseudobulkPanelModality()), `${{stem}}.xls`, 'application/vnd.ms-excel;charset=utf-8');
         }} else {{
-            downloadTextFile(buildPseudobulkDECsv(entries), `${{stem}}.csv`, 'text/csv;charset=utf-8');
+            downloadTextFile(buildPseudobulkDECsv(entries, getPseudobulkPanelModality()), `${{stem}}.csv`, 'text/csv;charset=utf-8');
         }}
     }}
 
@@ -29360,7 +29364,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             return `
                 <div class="agg-group">
                     <div class="agg-group-title">Pseudobulk DE</div>
-                    <div class="agg-group-meta">No pseudobulk DE genes were returned for this comparison.</div>
+                    <div class="agg-group-meta">No pseudobulk DE features were returned for this comparison.</div>
                 </div>
             `;
         }}
@@ -29389,7 +29393,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 : '';
             return `
                 <tr${{extraAttrs}} style="background:${{rowBackground}};" data-most-expressed="${{escapeHtml(mostExpressed || '')}}">
-                    <td><button type="button" class="pseudobulk-de-gene-btn" ${{loadable ? `data-pseudobulk-de-gene="${{escapeHtml(gene)}}"` : 'disabled'}} title="${{loadable ? 'Load DE gene into the viewer' : 'Expression vector unavailable'}}">${{escapeHtml(gene)}}</button></td>
+                    <td><button type="button" class="pseudobulk-de-gene-btn" ${{loadable ? `data-pseudobulk-de-gene="${{escapeHtml(gene)}}"` : 'disabled'}} title="${{loadable ? 'Load DE feature into the viewer' : 'Feature vector unavailable'}}">${{escapeHtml(gene)}}</button></td>
                     <td>${{formatScaleNumber(Number.isFinite(log2fcValue) ? log2fcValue : NaN)}}</td>
                     <td>${{formatAdjustedPValue(pvalAdjValue)}}</td>
                     <td>${{formatScaleNumber(Number.isFinite(scoreValue) ? scoreValue : NaN)}}</td>
@@ -29402,7 +29406,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 <table class="pseudobulk-de-table">
                     <thead>
                         <tr>
-                            <th>Gene</th>
+                            <th>Feature</th>
                             <th>log\u2082FC</th>
                             <th>adj. p</th>
                             <th>Score</th>
@@ -29414,7 +29418,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 </table>
             ` : `
                 <div class="agg-group-meta">
-                    No genes pass adj. p < ${{formatScaleNumber(padjCutoff)}} and |log\u2082FC| >= ${{formatScaleNumber(log2fcCutoff)}}.
+                    No features pass adj. p < ${{formatScaleNumber(padjCutoff)}} and |log\u2082FC| >= ${{formatScaleNumber(log2fcCutoff)}}.
                 </div>
             `;
         const volcanoHtml = buildVolcanoPlot(
@@ -29450,7 +29454,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const modeSwitch = `
             <div class="pseudobulk-de-panel-mode-switch" role="group" aria-label="Pseudobulk DE result view">
                 ${{modeButton('raw', 'Raw table')}}
-                ${{modeButton('genes', 'Genes')}}
+                ${{modeButton('genes', 'Features')}}
                 ${{modeButton('samples', 'Samples')}}
             </div>
         `;
@@ -29459,7 +29463,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 ${{tablePanel}}
             </div>
             <div class="pseudobulk-de-mode-panel" data-pseudobulk-de-mode-panel="genes"${{pseudobulkDeResultMode === 'genes' ? '' : ' hidden'}}>
-                <div class="pseudobulk-de-plot-grid">${{genePanels || '<div class="agg-group-meta">No gene-level plots are available.</div>'}}</div>
+                <div class="pseudobulk-de-plot-grid">${{genePanels || '<div class="agg-group-meta">No feature-level plots are available.</div>'}}</div>
             </div>
             <div class="pseudobulk-de-mode-panel" data-pseudobulk-de-mode-panel="samples"${{pseudobulkDeResultMode === 'samples' ? '' : ' hidden'}}>
                 <div class="pseudobulk-de-plot-grid">${{samplePanels || '<div class="agg-group-meta">No pseudobulk sample diagnostics are available.</div>'}}</div>
@@ -29667,7 +29671,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             0.5
         );
         const contrastInfo = `
-            <div class="comparison-info-warning"><strong>Warning.</strong> If annotations were defined from the same expression patterns being tested here, DE results can be inflated by double dipping. Interpret these marker genes as exploratory unless the annotations were defined independently or validated on independent data.</div>
+            <div class="comparison-info-warning"><strong>Warning.</strong> If annotations were defined from the same feature patterns being tested here, DE results can be inflated by double dipping. Interpret these marker features as exploratory unless the annotations were defined independently or validated on independent data.</div>
             <div class="comparison-info">
                 <strong>DESeq2 contrast.</strong> Model: ${{escapeHtml(modelFormula)}}.
                 <div class="comparison-info-settings">
@@ -29688,7 +29692,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             modality
         );
         const markerSection = markerSummary
-            ? `<div class="selection-summary-title">Pseudobulk Markers${{renderCalcInfoButton('de_genes')}}</div>${{markerSummary}}`
+            ? `<div class="selection-summary-title">Pseudobulk marker features${{renderCalcInfoButton('de_genes')}}</div>${{markerSummary}}`
             : '';
         const pathwaySection = renderClusterPAResultSection(
             pseudobulkDeGroupby,
@@ -29701,7 +29705,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             ${{controlsHtml}}
             ${{contrastInfo}}
             ${{markerSection}}
-            <div class="selection-summary-title" id="pseudobulk-de-section-title">Pseudobulk gene expression differential analysis${{renderCalcInfoButton('de_genes')}}${{getPseudobulkDEMethodBadge(pseudobulkDeGroupby, modality)}}</div>
+            <div class="selection-summary-title" id="pseudobulk-de-section-title">Pseudobulk feature differential analysis${{renderCalcInfoButton('de_genes')}}${{getPseudobulkDEMethodBadge(pseudobulkDeGroupby, modality)}}</div>
             ${{renderPseudobulkDEResultSection(pseudobulkDeGroupby, pseudobulkDeSourceCategory, pseudobulkDeReferenceCategory, modality)}}
             ${{pathwaySection ? '<div class="selection-summary-title" id="pathway-enrichment-title">Pathway Enrichment' + renderCalcInfoButton('pathway_enrichment_section') + '</div>' + pathwaySection : ''}}
         `;
@@ -30439,7 +30443,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                                 ${{renderGeneTokenButton(entry.gene, {{
                                     isActive: entry.gene === currentGene,
                                     showMeta: false,
-                                    title: 'Load group DE gene into the viewer',
+                                    title: 'Load group DE feature into the viewer',
                                 }})}}
                                 ${{renderGeneGoogleSearchButton(entry.gene, {{
                                     title: 'Search Google for this gene',
@@ -30584,7 +30588,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     </div>
                 `;
             }} else if (!quickResult.available && quickResult.reason === 'no_loaded_features') {{
-                resultHtml = '<div class="agg-group-meta">No genes are currently loaded for group DE. Load genes in the Genes tab or click pseudobulk DE genes first.</div>';
+                resultHtml = '<div class="agg-group-meta">No features are currently loaded for group DE. Load features in the Features tab or click pseudobulk DE features first.</div>';
             }} else if (!quickResult.available && quickResult.reason === 'same_group') {{
                 resultHtml = '<div class="agg-group-meta">Choose two different groups to compare.</div>';
             }} else if (!quickResult.available) {{
@@ -30804,7 +30808,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const displayed = result?.available ? selectWelchTopResults(result.results || [], groupDeTopN, groupDeMinPct, 1) : [];
         const renderCards = () => displayed.map((entry) => {{
             const sideColor = Number(entry.score || 0) >= 0 ? colorA : colorB;
-            return `<div class="comparison-card"><div class="comparison-card-title comparison-de-card-title"><div class="comparison-de-card-title-main">${{renderGeneTokenButton(entry.gene, {{ isActive: entry.gene === currentGene, showMeta: false, title: 'Load annotation DE gene into the viewer' }})}}${{renderGeneGoogleSearchButton(entry.gene, {{ title: 'Search Google for this gene' }})}}</div><div class="comparison-de-title-stats" style="border-color:${{sideColor}}"><span>log2FC ${{formatScaleNumber(entry.log2fc)}}</span><span>Score ${{formatScaleNumber(entry.score)}}</span></div></div><div class="comparison-metric-grid"><span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorA, sideColor)}};color:${{getTextColorForBackground(colorA)}}"><span>% expr A</span><strong>${{formatPseudobulkDEPct(entry.pctA)}}</strong><span>Mean A</span><strong>${{formatScaleNumber(entry.meanA)}}</strong></span><span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorB, sideColor)}};color:${{getTextColorForBackground(colorB)}}"><span>% expr B</span><strong>${{formatPseudobulkDEPct(entry.pctB)}}</strong><span>Mean B</span><strong>${{formatScaleNumber(entry.meanB)}}</strong></span></div></div>`;
+            return `<div class="comparison-card"><div class="comparison-card-title comparison-de-card-title"><div class="comparison-de-card-title-main">${{renderGeneTokenButton(entry.gene, {{ isActive: entry.gene === currentGene, showMeta: false, title: 'Load annotation DE feature into the viewer' }})}}${{renderGeneGoogleSearchButton(entry.gene, {{ title: 'Search Google for this feature' }})}}</div><div class="comparison-de-title-stats" style="border-color:${{sideColor}}"><span>log2FC ${{formatScaleNumber(entry.log2fc)}}</span><span>Score ${{formatScaleNumber(entry.score)}}</span></div></div><div class="comparison-metric-grid"><span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorA, sideColor)}};color:${{getTextColorForBackground(colorA)}}"><span>% detected A</span><strong>${{formatPseudobulkDEPct(entry.pctA)}}</strong><span>Mean A</span><strong>${{formatScaleNumber(entry.meanA)}}</strong></span><span class="comparison-de-metric-chip" style="background:${{getComparisonMetricChipBackground(colorB, sideColor)}};color:${{getTextColorForBackground(colorB)}}"><span>% detected B</span><strong>${{formatPseudobulkDEPct(entry.pctB)}}</strong><span>Mean B</span><strong>${{formatScaleNumber(entry.meanB)}}</strong></span></div></div>`;
         }}).join('');
         if (groupDeQuickRunning) {{
             html += '<div id="group-de-results"></div>';
@@ -30828,9 +30832,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                     }});
                 }}
             }}
-            html += `<div class="selection-summary-expr"><div class="selection-summary-title">Gene Expression by Annotation</div>${{displayed.map((entry) => {{ const vmax = Math.max(1e-12, Number(entry.meanA || 0), Number(entry.meanB || 0)); const factor = entry.meanB > 0 ? `${{(entry.meanA / entry.meanB).toFixed(1)}}x` : '—'; return `<div class="selection-summary-expr-row"><span class="selection-summary-expr-gene" data-gene-activate="${{escapeHtml(entry.gene)}}">${{escapeHtml(entry.gene)}}</span><div class="selection-summary-expr-bars"><div class="selection-summary-expr-bar" style="width:${{clampPercent(100 * entry.meanA / vmax)}}%;background:${{colorA}}">${{formatCompactNumber(entry.meanA)}} (${{(100 * entry.pctA).toFixed(0)}}%)</div><div class="selection-summary-expr-bar" style="width:${{clampPercent(100 * entry.meanB / vmax)}}%;background:${{colorB}}">${{formatCompactNumber(entry.meanB)}} (${{(100 * entry.pctB).toFixed(0)}}%)</div></div><span class="selection-summary-expr-factor">${{factor}}</span></div>`; }}).join('')}}</div>`;
+            html += `<div class="selection-summary-expr"><div class="selection-summary-title">Feature Values by Annotation</div>${{displayed.map((entry) => {{ const vmax = Math.max(1e-12, Number(entry.meanA || 0), Number(entry.meanB || 0)); const factor = entry.meanB > 0 ? `${{(entry.meanA / entry.meanB).toFixed(1)}}x` : '—'; return `<div class="selection-summary-expr-row"><span class="selection-summary-expr-gene" data-gene-activate="${{escapeHtml(entry.gene)}}">${{escapeHtml(entry.gene)}}</span><div class="selection-summary-expr-bars"><div class="selection-summary-expr-bar" style="width:${{clampPercent(100 * entry.meanA / vmax)}}%;background:${{colorA}}">${{formatCompactNumber(entry.meanA)}} (${{(100 * entry.pctA).toFixed(0)}}%)</div><div class="selection-summary-expr-bar" style="width:${{clampPercent(100 * entry.meanB / vmax)}}%;background:${{colorB}}">${{formatCompactNumber(entry.meanB)}} (${{(100 * entry.pctB).toFixed(0)}}%)</div></div><span class="selection-summary-expr-factor">${{factor}}</span></div>`; }}).join('')}}</div>`;
             const volcanoToolbar = '<button class="icon-btn" type="button" data-group-de-export-volcano title="Download volcano plot as SVG" aria-label="Download volcano plot as SVG"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg></button>';
-            html += `<div id="group-de-results">${{buildGroupVolcanoPlot(displayed, volcanoToolbar, {{ positive: colorA, negative: colorB }})}}<div class="comparison-stack">${{renderCards()}}</div><div style="display:flex;justify-content:flex-end;gap:6px;margin-top:6px;"><button class="icon-btn" type="button" data-group-de-export-csv title="Download all annotation comparison genes as CSV" aria-label="Download all annotation comparison genes as CSV"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg></button></div>${{DATA.feature_manifest_url && result === quickResult && Number(result.loadedGeneCount || 0) < Number(result.totalGeneCount || 0) ? '<div style="display:flex;justify-content:flex-end"><button class="legend-btn" id="group-de-run-full" type="button">Run Full DE</button></div>' : ''}}</div>`;
+            html += `<div id="group-de-results">${{buildGroupVolcanoPlot(displayed, volcanoToolbar, {{ positive: colorA, negative: colorB }})}}<div class="comparison-stack">${{renderCards()}}</div><div style="display:flex;justify-content:flex-end;gap:6px;margin-top:6px;"><button class="icon-btn" type="button" data-group-de-export-csv title="Download all annotation comparison features as CSV" aria-label="Download all annotation comparison features as CSV"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 15V3"></path><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><path d="m7 10 5 5 5-5"></path></svg></button></div>${{DATA.feature_manifest_url && result === quickResult && Number(result.loadedGeneCount || 0) < Number(result.totalGeneCount || 0) ? '<div style="display:flex;justify-content:flex-end"><button class="legend-btn" id="group-de-run-full" type="button">Run Full DE</button></div>' : ''}}</div>`;
         }} else if (quickResult && !quickResult.available) {{
             const noLoadedGenes = quickResult.reason === 'no_loaded_features' && !!DATA.feature_manifest_url;
             const message = noLoadedGenes
@@ -32927,7 +32931,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                 : `${{g}} is shown in DE results but its expression vector is unavailable for ${{getModalityDisplayLabel(modality)}}`;
             return `<span class="${{cls}}"${{activateAttr}} title="${{escapeHtml(title)}}">${{escapeHtml(g)}}</span>`;
         }}).join(', ');
-        const sourceMarkerLabel = sourceMarkers.length ? renderInlineGeneLinks(sourceMarkers) : 'No pseudobulk DE genes available.';
+        const sourceMarkerLabel = sourceMarkers.length ? renderInlineGeneLinks(sourceMarkers) : 'No pseudobulk DE features available.';
         const sourceN = (nCells[sourceIdx] ?? 0).toLocaleString();
         const degreeLabel = Number.isFinite(meanDegree[sourceIdx]) ? meanDegree[sourceIdx].toFixed(2) : '0.00';
         const withContactMarkers = topEntries.filter(entry => !!entry.contact).length;
@@ -32968,9 +32972,9 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
             <div class="agg-group">
                 <div class="agg-group-title">${{renderAggCategoryChip(annotationCol, source)}} → targets${{renderCalcInfoButton('neighbor_stats')}}</div>
                 <div class="agg-group-meta">n=${{sourceN}} | mean degree=${{degreeLabel}} | neighbor edges=${{formatNeighborCount(total)}}</div>
-                <div class="agg-group-meta">Source DE genes: ${{sourceMarkerLabel}}</div>
-                <div class="agg-group-meta">Contact-conditioned DE genes available for ${{withContactMarkers}}/${{topEntries.length}} shown targets in ${{escapeHtml(getModalityDisplayLabel(modality))}}.</div>
-                ${{hasInteractionMarkers ? '' : '<div class="agg-group-meta">Contact DE genes not precomputed for this annotation (use pseudobulk_additional_annotations during export for extra annotations).</div>'}}
+                <div class="agg-group-meta">Source DE features: ${{sourceMarkerLabel}}</div>
+                <div class="agg-group-meta">Contact-conditioned DE features available for ${{withContactMarkers}}/${{topEntries.length}} shown targets in ${{escapeHtml(getModalityDisplayLabel(modality))}}.</div>
+                ${{hasInteractionMarkers ? '' : '<div class="agg-group-meta">Contact DE features not precomputed for this annotation (use pseudobulk_additional_annotations during export for extra annotations).</div>'}}
             </div>
             <table class="trend-table">
                 <thead>
@@ -32979,8 +32983,8 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
                         <th>Share</th>
                         <th>Edges</th>
                         <th>Z</th>
-                        <th>Contact DE genes</th>
-                        <th>Type DE genes</th>
+                        <th>Contact DE features</th>
+                        <th>Type DE features</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -33807,7 +33811,7 @@ HTML_TEMPLATE = '''<!DOCTYPE html>
         const gridSideToolbar = document.getElementById('grid-side-toolbar');
         const visualParamsToggle = document.getElementById('visual-params-toggle');
         const geneParamsToggle = document.getElementById('gene-params-toggle');
-        const isTutorialGeneParamsPanelLocked = () => tutorialGeneParamsLocked && tutorialSteps[tutorialStepIndex]?.title === 'Gene expression scale';
+        const isTutorialGeneParamsPanelLocked = () => tutorialGeneParamsLocked && tutorialSteps[tutorialStepIndex]?.title === 'Feature value scale';
         const keepTutorialGeneParamsPanelOpen = () => {{
             gridSideToolbar?.classList.add('gene-open');
             gridSideToolbar?.classList.remove('visual-open', 'neighbor-open');
@@ -35537,7 +35541,7 @@ def export_to_html(
             '<div class="info-block">'
             '<div class="info-title">Viewer</div>'
             '<div class="info-text">KaroSpace interactive spatial viewer for exploring '
-            'sections, annotations, and gene expression.</div>'
+            'sections, annotations, and feature values.</div>'
             '</div>'
             '<div class="info-block">'
             '<div class="info-title">Contact</div>'

--- a/karospace/gui.py
+++ b/karospace/gui.py
@@ -91,7 +91,7 @@ Core Options
 
 Dataset Loading Options
 - Metadata section: Comma/newline-separated obs columns used as section metadata/filter chips.
-  Empty uses defaults (course, region, condition, timepoint, ...).
+  Empty disables section metadata/filter chips.
 - Metadata max columns: Empty or integer >= 0.
 - Metadata value order (JSON): Dict mapping metadata column -> ordered values.
   Example:
@@ -279,11 +279,11 @@ class KaroSpaceExportGUI:
         self.section_key = tk.StringVar(value="sample_id")
         self.spatial_key = tk.StringVar(value="spatial")
         self.annotation = tk.StringVar(value="leiden")
-        self.outline_by = tk.StringVar(value="condition")
+        self.outline_by = tk.StringVar(value="")
         self.title = tk.StringVar(value="KaroSpace")
-        self.section_metadata = tk.StringVar(value="condition")
+        self.section_metadata = tk.StringVar(value="")
         self.metadata_max_columns = tk.StringVar(value="")
-        self.metadata_labels = tk.StringVar(value='{\n  "condition": "Condition"\n}')
+        self.metadata_labels = tk.StringVar(value="{}")
         self.min_panel_size = tk.StringVar(value="150")
         self.spot_size = tk.StringVar(value="auto")
         self.downsample = tk.StringVar(value="")
@@ -854,7 +854,7 @@ class KaroSpaceExportGUI:
             "title": "KaroSpace",
             "section_key": "sample_id",
             "spatial_key": "spatial",
-            "outline_by": "condition",
+            "outline_by": "",
             "spot_size": "auto",
             "feature_encoding": "auto",
             "feature_storage": "embedded",
@@ -956,14 +956,14 @@ class KaroSpaceExportGUI:
         else:
             self.section_key.set("sample_id")
             self.annotation.set("leiden")
-            self.outline_by.set("condition")
+            self.outline_by.set("")
             self.title.set("KaroSpace")
             self.min_panel_size.set("150")
             self.downsample.set("")
-            self.section_metadata.set("condition")
+            self.section_metadata.set("")
             self.metadata_max_columns.set("")
-            self._set_text_widget(self.metadata_value_order_text, '{\n  "condition": ["control", "treated"]\n}')
-            self._merge_json_text_widget(self.metadata_labels_text, '{\n  "condition": "Condition"\n}')
+            self._set_text_widget(self.metadata_value_order_text, "{}")
+            self._set_text_widget(self.metadata_labels_text, "{}")
 
             self.cell_annotations_editor.set_items(["leiden_1", "leiden_2", "gmm_mana_10"])
             self.genes_editor.set_items(["Cd4", "Cd8a", "Gfap", "Mki67"])

--- a/karospace/gui.py
+++ b/karospace/gui.py
@@ -81,7 +81,7 @@ FIELD_HELP_TEXT = """Input / Output
 
 Core Options
 - Group by: Column in adata.obs that identifies sections (for example sample_id).
-- Main cells annotation: Starting cell annotation variable (obs column or a pre-loaded gene).
+- Main cells annotation: Starting cell annotation variable (obs column or a pre-loaded feature).
 - Outline by: Optional obs/metadata column used to paint panel outlines. Leave blank to disable.
 - Theme: light or dark.
 - Title: Viewer page title shown in header/browser tab.
@@ -100,24 +100,24 @@ Dataset Loading Options
   Example:
   {"sample_id": "Sample", "last_score": "Disease score"}
 
-Annotation & Gene Content
+Annotation & Feature Content
 - Cells annotations: Comma/newline-separated obs columns to include in the annotation dropdown.
-- Genes: Hand-picked gene symbols (comma/newline-separated) to pre-load for expression view.
-- In embedded mode, significant shared-fit pseudobulk DE genes are embedded automatically up to the per-comparison cap.
+- Features: Hand-picked feature names (comma/newline-separated) to pre-load for visualization.
+- In embedded mode, significant shared-fit pseudobulk DE features are embedded automatically up to the per-comparison cap.
 
 Advanced Options
-- Gene encoding: auto | dense | sparse.
-- Feature storage: embedded keeps requested/top DE genes in the HTML; sidecar writes all gene expression vectors to separate sidecar files.
+- Feature encoding: auto | dense | sparse.
+- Feature storage: embedded keeps requested/top DE features in the HTML; sidecar writes all feature vectors to separate sidecar files.
 - Feature manifest path: Optional override for the sidecar JSON path. Leave blank to place it next to the HTML.
 - Feature sparse threshold: Number between 0 and 1 (used when encoding=auto).
 - Neighbor permutations: "auto" or integer >= 0.
 - Neighbor stats annotations: "auto" or comma/newline-separated obs columns.
 - Neighbor stats seed: Integer random seed.
 - Interaction top targets: Integer > 0.
-- Interaction top genes: Integer > 0.
+- Interaction top features: Integer > 0.
 - Interaction min cells: Integer > 0.
 - Interaction min neighbors: Integer > 0.
-- Pseudobulk DE uses one shared replicate + annotation fit for each selected annotation, with category-versus-category and balanced-rest contrasts. Non-embedded DE genes remain visible but cannot be clicked for expression.
+- Pseudobulk DE uses one shared replicate + annotation fit for each selected annotation, with category-versus-category and balanced-rest contrasts. Non-embedded DE features remain visible but cannot be clicked for visualization.
 - Interaction markers use the same pseudobulk counts layer and section replicate.
 """
 
@@ -490,7 +490,7 @@ class KaroSpaceExportGUI:
         ttk.Label(header, text="KaroSpaceBuilder", style="AppTitle.TLabel").pack(anchor="w")
         ttk.Label(
             header,
-            text="Build and export shareable KaroSpace viewers with full control over annotations, genes, and analytics.",
+            text="Build and export shareable KaroSpace viewers with full control over annotations, features, and analytics.",
             style="Subtitle.TLabel",
         ).pack(anchor="w", pady=(4, 0))
 
@@ -530,7 +530,7 @@ class KaroSpaceExportGUI:
         advanced_tab = ttk.Frame(self.tabs, style="App.TFrame", padding=4)
         help_tab = ttk.Frame(self.tabs, style="App.TFrame", padding=4)
         self.tabs.add(basic_tab, text="Basic")
-        self.tabs.add(colors_tab, text="Annotations & Genes")
+        self.tabs.add(colors_tab, text="Annotations & Features")
         self.tabs.add(advanced_tab, text="Advanced")
         self.tabs.add(help_tab, text="Help")
 
@@ -628,22 +628,22 @@ class KaroSpaceExportGUI:
         )
         self.cell_annotations_editor.pack(fill="x")
 
-        genes_group = ttk.LabelFrame(colors_tab, text="Gene Layers", padding=12, style="Card.TLabelframe")
-        genes_group.pack(fill="x", pady=(0, 10))
-        self.genes_editor = SearchableListEditor(
-            genes_group,
-            "Genes",
+        features_group = ttk.LabelFrame(colors_tab, text="Feature Layers", padding=12, style="Card.TLabelframe")
+        features_group.pack(fill="x", pady=(0, 10))
+        self.features_editor = SearchableListEditor(
+            features_group,
+            "Features",
             height=7,
-            help_text="Hand-pick genes for expression view and dotplot.",
+            help_text="Hand-pick features for visualization and dotplot.",
         )
-        self.genes_editor.pack(fill="x")
+        self.features_editor.pack(fill="x")
 
-        genes_opts = ttk.Frame(genes_group, style="Card.TFrame")
-        genes_opts.pack(fill="x", pady=(10, 0))
-        ttk.Label(genes_opts, text="Corr. top N").pack(side="left", padx=(0, 4))
-        ttk.Entry(genes_opts, textvariable=self.gene_correlation_top_n, width=6).pack(side="left")
-        ttk.Label(genes_opts, text="Moran genes N").pack(side="left", padx=(12, 4))
-        ttk.Entry(genes_opts, textvariable=self.spatial_variable_genes_n, width=6).pack(side="left")
+        features_opts = ttk.Frame(features_group, style="Card.TFrame")
+        features_opts.pack(fill="x", pady=(10, 0))
+        ttk.Label(features_opts, text="Corr. top N").pack(side="left", padx=(0, 4))
+        ttk.Entry(features_opts, textvariable=self.gene_correlation_top_n, width=6).pack(side="left")
+        ttk.Label(features_opts, text="Moran features N").pack(side="left", padx=(12, 4))
+        ttk.Entry(features_opts, textvariable=self.spatial_variable_genes_n, width=6).pack(side="left")
 
         advanced_group = ttk.LabelFrame(advanced_tab, text="Advanced Options", padding=12, style="Card.TLabelframe")
         advanced_group.pack(fill="x", pady=(0, 10))
@@ -670,7 +670,7 @@ class KaroSpaceExportGUI:
         encoding_group.pack(fill="x", pady=(0, 10))
         encoding_group.columnconfigure(1, weight=1)
         encoding_group.columnconfigure(3, weight=1)
-        ttk.Label(encoding_group, text="Gene encoding").grid(row=0, column=0, sticky="w", pady=4)
+        ttk.Label(encoding_group, text="Feature encoding").grid(row=0, column=0, sticky="w", pady=4)
         ttk.Combobox(encoding_group, textvariable=self.feature_encoding, values=["auto", "dense", "sparse"], state="readonly").grid(
             row=0, column=1, sticky="ew", padx=(8, 16), pady=4
         )
@@ -712,7 +712,7 @@ class KaroSpaceExportGUI:
         ttk.Entry(interaction_group, textvariable=self.interaction_markers_top_targets).grid(
             row=0, column=1, sticky="ew", padx=(8, 16), pady=4
         )
-        ttk.Label(interaction_group, text="Top genes").grid(row=0, column=2, sticky="w", pady=4)
+        ttk.Label(interaction_group, text="Top features").grid(row=0, column=2, sticky="w", pady=4)
         ttk.Entry(interaction_group, textvariable=self.interaction_markers_top_genes).grid(row=0, column=3, sticky="ew", pady=4)
         ttk.Label(interaction_group, text="Min cells").grid(row=1, column=0, sticky="w", pady=4)
         ttk.Entry(interaction_group, textvariable=self.interaction_markers_min_cells).grid(
@@ -730,7 +730,7 @@ class KaroSpaceExportGUI:
         hint_lines = [
             "1. Start with a preset (Default, Pancreas, Lightweight).",
             "2. Browse to your .h5ad and click Inspect.",
-            "3. Use tabbed editors to add annotations, genes, and section metadata lists.",
+            "3. Use tabbed editors to add annotations, features, and section metadata lists.",
             "4. Open Advanced only when needed.",
             "5. Export HTML.",
         ]
@@ -912,7 +912,7 @@ class KaroSpaceExportGUI:
                 "Serpina3n",
             ]
             self.cell_annotations_editor.set_items(pancreas_colors)
-            self.genes_editor.set_items(pancreas_genes)
+            self.features_editor.set_items(pancreas_genes)
 
             self.neighbor_stats_auto.set(False)
             self.neighbor_stats_annotations_editor.set_items(["leiden_2"])
@@ -939,7 +939,7 @@ class KaroSpaceExportGUI:
             self._merge_json_text_widget(self.metadata_labels_text, '{\n  "condition": "Condition"\n}')
 
             self.cell_annotations_editor.set_items(["leiden_1"])
-            self.genes_editor.set_items(["Cd4", "Cd8a", "Mki67"])
+            self.features_editor.set_items(["Cd4", "Cd8a", "Mki67"])
 
             self.neighbor_stats_auto.set(True)
             self.neighbor_stats_annotations_editor.set_items([])
@@ -966,7 +966,7 @@ class KaroSpaceExportGUI:
             self._set_text_widget(self.metadata_labels_text, "{}")
 
             self.cell_annotations_editor.set_items(["leiden_1", "leiden_2", "gmm_mana_10"])
-            self.genes_editor.set_items(["Cd4", "Cd8a", "Gfap", "Mki67"])
+            self.features_editor.set_items(["Cd4", "Cd8a", "Gfap", "Mki67"])
 
             self.neighbor_stats_auto.set(True)
             self.neighbor_stats_annotations_editor.set_items([])
@@ -1116,7 +1116,7 @@ class KaroSpaceExportGUI:
         self.outline_combo.configure(values=[""] + self._obs_columns)
         self.cell_annotations_editor.set_choices(self._obs_columns)
         self.neighbor_stats_annotations_editor.set_choices(self._obs_columns)
-        self.genes_editor.set_choices(self._var_names)
+        self.features_editor.set_choices(self._var_names)
         self.spatial_key_combo.configure(values=self._obsm_keys)
 
         if self.spatial_key.get() not in self._obsm_keys:
@@ -1157,7 +1157,7 @@ class KaroSpaceExportGUI:
             else:
                 self.outline_by.set("")
 
-        self._log(f"Inspect complete: {len(self._obs_columns)} obs columns, {len(self._var_names)} genes.")
+        self._log(f"Inspect complete: {len(self._obs_columns)} obs columns, {len(self._var_names)} features.")
         self._set_busy(False, "Ready.")
 
     def _on_inspect_error(self, exc: Exception) -> None:
@@ -1253,10 +1253,10 @@ class KaroSpaceExportGUI:
         if feature_manifest_path_raw:
             feature_manifest_path = str(Path(feature_manifest_path_raw).expanduser())
 
-        gene_correlation_top_n = _parse_non_negative_int("Corr. top N", self.gene_correlation_top_n.get())
-        spatial_variable_genes_n = _parse_non_negative_int("SVG n", self.spatial_variable_genes_n.get())
+        feature_correlation_top_n = _parse_non_negative_int("Corr. top N", self.gene_correlation_top_n.get())
+        spatial_variable_features_n = _parse_non_negative_int("Moran features N", self.spatial_variable_genes_n.get())
         cell_annotations = _unique(self.cell_annotations_editor.get_items())
-        features = _unique(self.genes_editor.get_items())
+        features = _unique(self.features_editor.get_items())
         outline_by = self.outline_by.get().strip() or None
 
         load_kwargs = {
@@ -1278,8 +1278,8 @@ class KaroSpaceExportGUI:
             "metadata_labels": metadata_labels,
             "cell_annotations": cell_annotations,
             "features": features,
-            "gene_correlation_top_n": gene_correlation_top_n,
-            "spatial_variable_genes_n": spatial_variable_genes_n,
+            "gene_correlation_top_n": feature_correlation_top_n,
+            "spatial_variable_genes_n": spatial_variable_features_n,
             "feature_encoding": self.feature_encoding.get().strip() or "auto",
             "feature_storage": feature_storage,
             "feature_manifest_path": feature_manifest_path,
@@ -1287,7 +1287,7 @@ class KaroSpaceExportGUI:
             "neighbor_stats_permutations": _parse_neighbor_permutations(self.neighbor_permutations.get()),
             "neighbor_stats_seed": int(self.neighbor_stats_seed.get().strip() or "0"),
             "interaction_markers_top_targets": _parse_positive_int("Interaction top targets", self.interaction_markers_top_targets.get()),
-            "interaction_markers_top_genes": _parse_positive_int("Interaction top genes", self.interaction_markers_top_genes.get()),
+            "interaction_markers_top_genes": _parse_positive_int("Interaction top features", self.interaction_markers_top_genes.get()),
             "interaction_markers_min_cells": _parse_positive_int("Interaction min cells", self.interaction_markers_min_cells.get()),
             "interaction_markers_min_neighbors": _parse_positive_int(
                 "Interaction min neighbors",
@@ -1296,7 +1296,7 @@ class KaroSpaceExportGUI:
         }
 
         if bool(self.neighbor_stats_auto.get()):
-            export_kwargs["neighbor_stats_annotations"] = [color]
+            export_kwargs["neighbor_stats_annotations"] = _unique([color, *(cell_annotations or [])])
         else:
             export_kwargs["neighbor_stats_annotations"] = _unique(self.neighbor_stats_annotations_editor.get_items())
 

--- a/karospace/pathways.py
+++ b/karospace/pathways.py
@@ -263,9 +263,7 @@ def _match_gene_sets(
 
 def _result_gene_table(result: Mapping[str, Any]) -> List[Dict[str, Any]]:
     genes = result.get("genes") if isinstance(result.get("genes"), list) else []
-    log2fc = result.get("log2foldchanges")
-    if not isinstance(log2fc, list):
-        log2fc = result.get("logfoldchanges") if isinstance(result.get("logfoldchanges"), list) else []
+    log2fc = result.get("log2foldchanges") if isinstance(result.get("log2foldchanges"), list) else []
     pvals_adj = result.get("pvals_adj") if isinstance(result.get("pvals_adj"), list) else []
     pvals = result.get("pvals") if isinstance(result.get("pvals"), list) else []
     scores = result.get("scores") if isinstance(result.get("scores"), list) else []

--- a/karospace/pseudobulk.py
+++ b/karospace/pseudobulk.py
@@ -1155,11 +1155,11 @@ def _format_result(
     return result
 
 
-def _count_threshold_passing_genes(result: Dict[str, Any]) -> int:
+def _count_threshold_passing_genes(result: Dict[str, Any], *, direction: str = "absolute") -> int:
     """Count DE genes satisfying the result's display/embed thresholds."""
     if not result or result.get("available") is False:
         return 0
-    log2fc = result.get("log2foldchanges") or result.get("logfoldchanges") or []
+    log2fc = result.get("log2foldchanges") or []
     padj = result.get("pvals_adj") or []
     try:
         padj_cutoff = float(result.get("padj_cutoff", 0.05))
@@ -1169,11 +1169,35 @@ def _count_threshold_passing_genes(result: Dict[str, Any]) -> int:
     count = 0
     for value, adjusted in zip(log2fc, padj):
         try:
-            if float(adjusted) < padj_cutoff and abs(float(value)) >= log2fc_cutoff:
+            log2fc_value = float(value)
+            if direction == "positive":
+                passes_log2fc = log2fc_value >= log2fc_cutoff
+            else:
+                passes_log2fc = abs(log2fc_value) >= log2fc_cutoff
+            if float(adjusted) < padj_cutoff and passes_log2fc:
                 count += 1
         except (TypeError, ValueError):
             continue
     return count
+
+
+def _format_threshold_passing_log(
+    result: Dict[str, Any],
+    *,
+    padj_cutoff: float,
+    log2fc_cutoff: float,
+    direction: str = "absolute",
+) -> str:
+    count = _count_threshold_passing_genes(result, direction=direction)
+    log2fc_clause = (
+        f"log2FC >= {float(log2fc_cutoff):g}"
+        if direction == "positive"
+        else f"|log2FC| >= {float(log2fc_cutoff):g}"
+    )
+    return (
+        f"{count} genes pass the DE thresholds "
+        f"(padj < {float(padj_cutoff):g} and {log2fc_clause})"
+    )
 
 
 def _truncate_gene_result(result: Dict[str, Any], top_n: int) -> Dict[str, Any]:
@@ -1190,7 +1214,6 @@ def _truncate_gene_result(result: Dict[str, Any], top_n: int) -> Dict[str, Any]:
         "pct_reference",
         "base_mean",
     ]
-    result.pop("logfoldchanges", None)
     for field in fields:
         if isinstance(result.get(field), list):
             result[field] = result[field][:n]
@@ -1426,7 +1449,7 @@ def compute_pseudobulk_interaction_markers(
                 log_step(
                     f"{source_name} -> {target_name}: skipped, insufficient paired replicates "
                     f"({len(paired_reps)}; need >= {required_min_replicates})",
-                    level=3,
+                    level=2,
                 )
                 source_result[target_name] = _empty_interaction_result(
                     "insufficient_replicates",
@@ -1493,7 +1516,7 @@ def compute_pseudobulk_interaction_markers(
                     f"{'s' if len(paired_reps) != 1 else ''}, "
                     f"{pair_counts.shape[0]} pseudobulk samples, "
                     f"{pair_counts.shape[1]} genes)",
-                    level=3,
+                    level=2,
                 )
                 sample_diagnostics = _compute_pseudobulk_sample_diagnostics(pair_counts, pair_meta)
                 pair_result = _fit_deseq2_pair(
@@ -1533,10 +1556,10 @@ def compute_pseudobulk_interaction_markers(
                 log_detail(
                     f"Stored top {min(top_genes, len(formatted.get('genes') or []))} marker genes "
                     "plus diagnostics for this source-target interaction.",
-                    level=4,
+                    level=3,
                 )
             except Exception as exc:
-                log_step(f"{source_name} -> {target_name}: failed ({exc})", level=3)
+                log_step(f"{source_name} -> {target_name}: failed ({exc})", level=2)
                 source_result[target_name] = _empty_interaction_result(
                     "de_failed",
                     n_contact=n_pos,
@@ -1881,9 +1904,12 @@ def compute_pseudobulk_sample_metadata_de(
                 level=4,
             )
         log_detail(
-            f"{_count_threshold_passing_genes(formatted)} "
-            f"genes pass the DE thresholds (padj < {float(padj_cutoff):g} "
-            f"and |log2FC| >= {float(log2fc_cutoff):g})",
+            _format_threshold_passing_log(
+                formatted,
+                padj_cutoff=padj_cutoff,
+                log2fc_cutoff=log2fc_cutoff,
+                direction="positive",
+            ),
             level=4,
         )
 
@@ -2527,10 +2553,14 @@ def _compute_pseudobulk_group_de_shared(
                 f"of {prefilter_count} fitted genes for reported DE results",
                 level=4,
             )
+        direction = "positive" if formatted.get("contrast_type") == "balanced_rest" else "absolute"
         log_detail(
-            f"{_count_threshold_passing_genes(formatted)} "
-            f"genes pass the DE thresholds (padj < {float(padj_cutoff):g} "
-            f"and |log2FC| >= {float(log2fc_cutoff):g})",
+            _format_threshold_passing_log(
+                formatted,
+                padj_cutoff=padj_cutoff,
+                log2fc_cutoff=log2fc_cutoff,
+                direction=direction,
+            ),
             level=4,
         )
 

--- a/tests/test_exporter_large_graph.py
+++ b/tests/test_exporter_large_graph.py
@@ -1,0 +1,49 @@
+import karospace.exporter as exporter
+
+
+def test_oversized_section_neighbor_graph_is_omitted():
+    original_limit = exporter.EMBEDDED_VIEWER_DATA_SINGLE_SCRIPT_MAX_CHARS
+    exporter.EMBEDDED_VIEWER_DATA_SINGLE_SCRIPT_MAX_CHARS = 96
+    try:
+        primary_json, fragments = exporter._serialize_embedded_viewer_data(
+            {
+                "sections": [
+                    {
+                        "id": "section-a",
+                        "n_cells": 2,
+                        "edges": None,
+                        "edges_b64": "x" * 128,
+                    }
+                ],
+                "has_neighbors": True,
+            }
+        )
+    finally:
+        exporter.EMBEDDED_VIEWER_DATA_SINGLE_SCRIPT_MAX_CHARS = original_limit
+
+    assert '"sections":[null]' in primary_json
+    assert 'data-karospace-section-key="edges_b64">null</script>' in fragments
+    assert "x" * 128 not in fragments
+
+
+def test_oversized_non_graph_section_field_still_raises():
+    original_limit = exporter.EMBEDDED_VIEWER_DATA_SINGLE_SCRIPT_MAX_CHARS
+    exporter.EMBEDDED_VIEWER_DATA_SINGLE_SCRIPT_MAX_CHARS = 96
+    try:
+        try:
+            exporter._serialize_embedded_viewer_data(
+                {
+                    "sections": [
+                        {
+                            "id": "section-a",
+                            "xb64": "x" * 128,
+                        }
+                    ],
+                }
+            )
+        except ValueError as exc:
+            assert "section 0, 'xb64'" in str(exc)
+        else:
+            raise AssertionError("Expected oversized non-graph section field to raise")
+    finally:
+        exporter.EMBEDDED_VIEWER_DATA_SINGLE_SCRIPT_MAX_CHARS = original_limit

--- a/tests/test_multimodal_export_schema.py
+++ b/tests/test_multimodal_export_schema.py
@@ -1,8 +1,16 @@
+import io
+import json
+import uuid
+from contextlib import redirect_stdout
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 from anndata import AnnData
 
-from karospace.data_loader import Modality, SectionData, SpatialDataset
+from karospace.cli import _run_export_cli
+from karospace.data_loader import Modality, SectionData, SpatialDataset, inspect_input_file
+from karospace.exporter import _extract_embedded_viewer_data, export_to_html
 
 
 def _make_multimodal_dataset():
@@ -11,6 +19,7 @@ def _make_multimodal_dataset():
             "section": pd.Categorical(["s1", "s1", "s1", "s1"]),
             "replicate": pd.Categorical(["r1", "r2", "r1", "r2"]),
             "cell_type": pd.Categorical(["A", "A", "B", "B"]),
+            "cell_state": pd.Categorical(["X", "Y", "X", "Y"]),
         },
         index=[f"cell{i}" for i in range(4)],
     )
@@ -76,7 +85,7 @@ def _make_multimodal_dataset():
         adata=adata,
         sections=[SectionData("s1", adata.obsm["spatial"])],
         section_key="section",
-        obs_columns=["section", "replicate", "cell_type"],
+        obs_columns=["section", "replicate", "cell_type", "cell_state"],
         var_names=list(var.index),
         modalities=modalities,
         default_modality="rna",
@@ -122,20 +131,104 @@ def test_multimodal_export_uses_only_by_modality_payloads():
         assert removed_key not in data
 
 
+def test_inspect_input_reports_feature_counts_by_modality(tmp_path=None):
+    adata = _make_multimodal_dataset().adata.copy()
+    adata.obsm["protein"] = np.asarray(
+        [
+            [5, 1],
+            [6, 1],
+            [2, 8],
+            [2, 9],
+        ],
+        dtype=np.float32,
+    )
+    adata.uns["protein_var"] = pd.DataFrame(index=["protein_a", "protein_b"])
+
+    report = inspect_input_file(adata)
+    by_name = {entry["name"]: entry for entry in report["feature_modalities"]}
+    assert by_name["rna"]["n_features"] == 2
+    assert by_name["rna"]["is_default"] is True
+    assert by_name["protein"]["n_features"] == 2
+
+
+def test_cli_inspect_input_prints_feature_counts_by_modality(tmp_path=None):
+    output_dir = Path(tmp_path) if tmp_path is not None else Path("/private/tmp")
+    input_path = output_dir / "karospace-inspect-multimodal-test.h5ad"
+    adata = _make_multimodal_dataset().adata.copy()
+    adata.obsm["protein"] = np.asarray(
+        [
+            [5, 1],
+            [6, 1],
+            [2, 8],
+            [2, 9],
+        ],
+        dtype=np.float32,
+    )
+    adata.uns["protein_var"] = pd.DataFrame(index=["protein_a", "protein_b"])
+    adata.write_h5ad(input_path)
+
+    stream = io.StringIO()
+    with redirect_stdout(stream):
+        _run_export_cli([str(input_path), "--inspect-input"])
+
+    output = stream.getvalue()
+    assert "Cells: 4\n" in output
+    assert "Features by modality:" in output
+    assert "  - rna [RNA] (default): 2 features" in output
+    assert "  - protein: 2 features" in output
+    assert "Genes:" not in output
+
+
+def test_cli_help_prefers_feature_named_options():
+    stream = io.StringIO()
+    with redirect_stdout(stream):
+        try:
+            _run_export_cli(["--help"])
+        except SystemExit as exc:
+            assert exc.code == 0
+
+    output = stream.getvalue()
+    assert "Feature content and storage:" in output
+    assert "--pseudobulk-min-feature-counts" in output
+    assert "--interaction-markers-top-features" in output
+    assert "--feature-correlation-top-n" in output
+    assert "--category-means-n-features" in output
+    assert "--spatial-variable-features-n" in output
+    assert "--pseudobulk-min-gene-counts" not in output
+    assert "--interaction-markers-top-genes" not in output
+    assert "--gene-correlation-top-n" not in output
+    assert "--category-means-n-genes" not in output
+    assert "--spatial-variable-genes-n" not in output
+
+
 def test_secondary_analytics_are_modality_scoped():
     multimodal_dataset = _make_multimodal_dataset()
-    data = multimodal_dataset.to_json_data(
-        annotation="cell_type",
-        features=["rna_a", "protein_a"],
-        pseudobulk_de_annotations=["cell_type"],
-        pseudobulk_replicate_annotation="replicate",
-        pseudobulk_modalities=["rna", "protein"],
-        pseudobulk_min_replicates=1,
-        pseudobulk_min_cells_per_pseudobulk=1,
-        spatial_variable_genes_n=2,
-        category_means_n_genes=2,
-        gene_correlation_top_n=1,
-    )
+    stream = io.StringIO()
+    with redirect_stdout(stream):
+        data = multimodal_dataset.to_json_data(
+            annotation="cell_type",
+            features=["rna_a"],
+            pseudobulk_de_annotations=["cell_type"],
+            pseudobulk_replicate_annotation="replicate",
+            pseudobulk_modalities=["rna", "protein"],
+            pseudobulk_min_replicates=1,
+            pseudobulk_min_cells_per_pseudobulk=1,
+            spatial_variable_genes_n=2,
+            category_means_n_genes=2,
+            gene_correlation_top_n=1,
+        )
+
+    log_text = stream.getvalue()
+    assert "Stored pseudobulk result payload:" in log_text
+    assert "Features selected for HTML embedding for modality rna:" in log_text
+    assert "Features selected for HTML embedding for modality protein: 2." in log_text
+    protein_log = log_text.split("Pseudobulk DE: modality=protein", 1)[1]
+    protein_balanced_rest_log = protein_log.split("Preparing 1 pairwise", 1)[0]
+    assert "log2FC >= 1" in protein_balanced_rest_log
+    assert "|log2FC| >= 1" not in protein_balanced_rest_log
+    assert data["embedded_features_by_modality"]["protein"] == ["protein_a", "protein_b"]
+    assert set(data["feature_state_by_modality"]["protein"]["features_meta"]) == {"protein_a", "protein_b"}
+    assert data["marker_features_by_modality"]["protein"]["cell_type"]["A"] == ["protein_a"]
 
     assert set(data["category_feature_means_by_modality"]) == {"rna", "protein"}
     assert set(data["feature_correlations_by_modality"]) == {"rna", "protein"}
@@ -151,3 +244,301 @@ def test_secondary_analytics_are_modality_scoped():
 
         spatial = data["spatial_variable_features_by_modality"][modality]
         assert any(row["gene"] == feature_name for row in spatial)
+
+
+def test_spatial_variable_features_warn_when_graph_missing():
+    multimodal_dataset = _make_multimodal_dataset()
+    multimodal_dataset.adata.obsp.clear()
+
+    stream = io.StringIO()
+    with redirect_stdout(stream):
+        data = multimodal_dataset.to_json_data(
+            annotation="cell_type",
+            features=["rna_a"],
+            pseudobulk_de_annotations=[],
+            interaction_marker_annotations=[],
+            spatial_variable_genes_n=2,
+            category_means_n_genes=0,
+            gene_correlation_top_n=0,
+        )
+
+    log_text = stream.getvalue()
+    assert "Warning: Spatially variable feature calculation skipped for modality 'rna'" in log_text
+    assert "no spatial graph found in adata.obsp" in log_text
+    assert "spatial_connectivities, connectivities, neighbors, neighbor_graph" in log_text
+    assert data["spatial_variable_features_by_modality"]["rna"] == []
+
+
+def test_neighbor_and_interaction_annotations_include_cell_annotations():
+    multimodal_dataset = _make_multimodal_dataset()
+    data = multimodal_dataset.to_json_data(
+        annotation="cell_type",
+        cell_annotations=["cell_state"],
+        features=["rna_a", "protein_a"],
+        pseudobulk_de_annotations=[],
+        interaction_marker_annotations=["cell_type", "cell_state"],
+        neighbor_stats_annotations=["cell_type", "cell_state"],
+        pseudobulk_replicate_annotation="replicate",
+        pseudobulk_modalities=["rna", "protein"],
+        pseudobulk_min_replicates=1,
+        pseudobulk_min_cells_per_pseudobulk=1,
+        interaction_markers_min_cells=1,
+        interaction_markers_min_neighbors=1,
+        interaction_markers_top_targets=2,
+        interaction_markers_top_genes=2,
+    )
+
+    assert set(data["neighbor_stats"]) == {"cell_type", "cell_state"}
+    assert set(data["interaction_markers_by_modality"]) == {"rna", "protein"}
+    for modality_payload in data["interaction_markers_by_modality"].values():
+        assert set(modality_payload) == {"cell_type", "cell_state"}
+
+
+def test_export_defaults_analyze_neighbors_for_cell_annotations():
+    multimodal_dataset = _make_multimodal_dataset()
+    captured = {}
+
+    class CapturedToJsonCall(RuntimeError):
+        pass
+
+    def capture_to_json_data(annotation, **kwargs):
+        captured["annotation"] = annotation
+        captured["kwargs"] = kwargs
+        raise CapturedToJsonCall
+
+    original_to_json_data = multimodal_dataset.to_json_data
+    multimodal_dataset.to_json_data = capture_to_json_data
+    try:
+        try:
+            export_to_html(
+                multimodal_dataset,
+                output_path="/private/tmp/karospace-export-defaults-capture.html",
+                main_cell_annotation="cell_type",
+                cell_annotations=["cell_state"],
+                features=[],
+                modalities=["rna"],
+                pseudobulk=None,
+                interaction_markers="auto",
+                neighbor_stats_annotations=None,
+                neighbor_stats_permutations=0,
+                spatial_variable_genes_n=0,
+                category_means_n_genes=0,
+                gene_correlation_top_n=0,
+                pathway_gsea_permutations=0,
+                tutorial=False,
+            )
+        except CapturedToJsonCall:
+            pass
+    finally:
+        multimodal_dataset.to_json_data = original_to_json_data
+
+    assert captured["annotation"] == "cell_type"
+    assert captured["kwargs"]["neighbor_stats_annotations"] == ["cell_type", "cell_state"]
+    assert captured["kwargs"]["interaction_marker_annotations"] == ["cell_type", "cell_state"]
+
+
+def test_export_neighbor_defaults_include_cell_annotations_without_interactions():
+    multimodal_dataset = _make_multimodal_dataset()
+    captured = {}
+
+    class CapturedToJsonCall(RuntimeError):
+        pass
+
+    def capture_to_json_data(annotation, **kwargs):
+        captured["annotation"] = annotation
+        captured["kwargs"] = kwargs
+        raise CapturedToJsonCall
+
+    original_to_json_data = multimodal_dataset.to_json_data
+    multimodal_dataset.to_json_data = capture_to_json_data
+    try:
+        try:
+            export_to_html(
+                multimodal_dataset,
+                output_path="/private/tmp/karospace-neighbor-defaults-capture.html",
+                main_cell_annotation="cell_type",
+                cell_annotations=["cell_state"],
+                features=[],
+                modalities=["rna"],
+                pseudobulk=None,
+                interaction_markers=None,
+                neighbor_stats_annotations=None,
+                neighbor_stats_permutations=0,
+                spatial_variable_genes_n=0,
+                category_means_n_genes=0,
+                gene_correlation_top_n=0,
+                pathway_gsea_permutations=0,
+                tutorial=False,
+            )
+        except CapturedToJsonCall:
+            pass
+    finally:
+        multimodal_dataset.to_json_data = original_to_json_data
+
+    assert captured["annotation"] == "cell_type"
+    assert captured["kwargs"]["neighbor_stats_annotations"] == ["cell_type", "cell_state"]
+    assert captured["kwargs"]["interaction_marker_annotations"] == []
+
+
+def test_feature_sidecar_manifest_is_modality_only(tmp_path=None):
+    output_dir = Path(tmp_path) if tmp_path is not None else Path("/private/tmp")
+    output_path = output_dir / "karospace-sidecar-schema-test.html"
+    manifest_path = output_dir / "karospace-sidecar-schema-test.features.json"
+
+    export_to_html(
+        _make_multimodal_dataset(),
+        output_path=str(output_path),
+        main_cell_annotation="cell_type",
+        features=["rna_a"],
+        modalities=["rna", "protein"],
+        feature_storage="sidecar",
+        feature_manifest_path=str(manifest_path),
+        feature_sidecar_shard_size=1,
+        pseudobulk=None,
+        interaction_markers=None,
+        spatial_variable_genes_n=0,
+        category_means_n_genes=0,
+        gene_correlation_top_n=0,
+        pathway_gsea_permutations=0,
+        tutorial=False,
+    )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["format"] == "karospace-feature-sidecar-manifest-v4"
+    assert set(manifest["modalities"]) == {"rna", "protein"}
+    for removed_key in [
+        "shards",
+        "features_meta",
+        "feature_encodings",
+        "feature_value_encodings",
+        "feature_to_shard",
+        "section_order",
+    ]:
+        assert removed_key not in manifest
+
+    for modality_entry in manifest["modalities"].values():
+        assert "section_order" in modality_entry
+        assert "features_meta" in modality_entry
+        assert "feature_to_shard" in modality_entry
+
+
+def test_embedded_storage_includes_explicit_extra_modalities_without_sidecar(tmp_path=None):
+    output_dir = Path(tmp_path) if tmp_path is not None else Path("/private/tmp")
+    stem = f"karospace-embedded-default-{uuid.uuid4().hex}"
+    output_path = output_dir / f"{stem}.html"
+    manifest_path = output_dir / f"{stem}.features.json"
+    shard_dir = output_dir / f"{stem}.features"
+
+    stream = io.StringIO()
+    with redirect_stdout(stream):
+        export_to_html(
+            _make_multimodal_dataset(),
+            output_path=str(output_path),
+            main_cell_annotation="cell_type",
+            features=["rna_a", "protein_a"],
+            modalities=["rna", "protein"],
+            feature_storage="embedded",
+            pseudobulk=None,
+            pseudobulk_modalities=["rna", "protein"],
+            interaction_markers=None,
+            spatial_variable_genes_n=0,
+            category_means_n_genes=0,
+            gene_correlation_top_n=0,
+            pathway_gsea_permutations=0,
+            tutorial=False,
+        )
+
+    data = _extract_embedded_viewer_data(output_path.read_text(encoding="utf-8"))
+    log_text = stream.getvalue()
+    assert data["feature_manifest_url"] is None
+    assert set(data["features_by_modality"]) == {"rna", "protein"}
+    assert [entry["name"] for entry in data["modalities"]] == ["rna", "protein"]
+    assert data["requested_features_by_modality"] == {
+        "rna": ["rna_a"],
+        "protein": ["protein_a"],
+    }
+    assert data["embedded_features_by_modality"]["rna"] == ["rna_a"]
+    assert data["embedded_features_by_modality"]["protein"] == ["protein_a"]
+    assert set(data["feature_state_by_modality"]["protein"]["features_meta"]) == {"protein_a"}
+    assert "Features embedded in HTML: rna=1, protein=1 (total 2)." in log_text
+    assert "extra modalities" not in log_text
+    assert "feature_storage='sidecar'" not in log_text
+    assert "Skipping pathway enrichment for modality protein" not in log_text
+    assert "pathway enrichment unavailable for modality protein" not in log_text
+    assert not manifest_path.exists()
+    assert not shard_dir.exists()
+
+
+def test_embedded_storage_defaults_to_default_modality_without_sidecar(tmp_path=None):
+    output_dir = Path(tmp_path) if tmp_path is not None else Path("/private/tmp")
+    stem = f"karospace-embedded-default-only-{uuid.uuid4().hex}"
+    output_path = output_dir / f"{stem}.html"
+    manifest_path = output_dir / f"{stem}.features.json"
+    shard_dir = output_dir / f"{stem}.features"
+
+    stream = io.StringIO()
+    with redirect_stdout(stream):
+        export_to_html(
+            _make_multimodal_dataset(),
+            output_path=str(output_path),
+            main_cell_annotation="cell_type",
+            features=["rna_a", "protein_a"],
+            feature_storage="embedded",
+            pseudobulk=None,
+            interaction_markers=None,
+            spatial_variable_genes_n=0,
+            category_means_n_genes=0,
+            gene_correlation_top_n=0,
+            pathway_gsea_permutations=0,
+            tutorial=False,
+        )
+
+    data = _extract_embedded_viewer_data(output_path.read_text(encoding="utf-8"))
+    log_text = stream.getvalue()
+    assert data["feature_manifest_url"] is None
+    assert set(data["features_by_modality"]) == {"rna"}
+    assert data["requested_features_by_modality"] == {"rna": ["rna_a"]}
+    assert data["embedded_features_by_modality"]["rna"] == ["rna_a"]
+    assert data["embedded_features_by_modality"].get("protein", []) == []
+    assert data["feature_state_by_modality"].get("protein", {}).get("features_meta", {}) == {}
+    assert "Features embedded in HTML (rna): 1" in log_text
+    assert "protein=1" not in log_text
+    assert "extra modalities" not in log_text
+    assert "feature_storage='sidecar'" not in log_text
+    assert not manifest_path.exists()
+    assert not shard_dir.exists()
+
+
+def test_neighbor_interaction_dispersion_logs_follow_computation_tree():
+    stream = io.StringIO()
+    with redirect_stdout(stream):
+        _make_multimodal_dataset().to_json_data(
+            annotation="cell_type",
+            cell_annotations=["cell_state"],
+            features=["rna_a", "protein_a"],
+            pseudobulk_de_annotations=[],
+            interaction_marker_annotations=["cell_type", "cell_state"],
+            neighbor_stats_annotations=["cell_type", "cell_state"],
+            pseudobulk_replicate_annotation="replicate",
+            pseudobulk_modalities=["rna", "protein"],
+            pseudobulk_min_replicates=1,
+            pseudobulk_min_cells_per_pseudobulk=1,
+            interaction_markers_min_cells=1,
+            interaction_markers_min_neighbors=1,
+            interaction_markers_top_targets=2,
+            interaction_markers_top_genes=2,
+        )
+
+    log_text = stream.getvalue()
+    neighbor_idx = log_text.index("- Computing neighbor composition stats")
+    interaction_idx = log_text.index("- Computing contact-conditioned pseudobulk interaction markers")
+    dispersion_idx = log_text.index("- Computing full-cell spatial dispersion")
+    assert neighbor_idx < interaction_idx < dispersion_idx
+
+    lines = log_text.splitlines()
+    assert "  - Neighbor stats: annotation column cell_type" in lines
+    assert "    - A -> B: skipped, insufficient paired replicates (0; need >= 2)" in lines
+    assert "  - A -> B: skipped, insufficient paired replicates (0; need >= 2)" not in lines
+
+    dispersion_rows = [line for line in lines if "cell_type: stored dispersion rows" in line]
+    assert dispersion_rows == ["  ↳ cell_type: stored dispersion rows for 2 categories."]

--- a/tests/test_multimodal_export_schema.py
+++ b/tests/test_multimodal_export_schema.py
@@ -1,0 +1,112 @@
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+
+from karospace.data_loader import Modality, SectionData, SpatialDataset
+
+
+def _make_multimodal_dataset():
+    obs = pd.DataFrame(
+        {
+            "section": pd.Categorical(["s1", "s1", "s1", "s1"]),
+            "cell_type": pd.Categorical(["A", "A", "B", "B"]),
+        },
+        index=[f"cell{i}" for i in range(4)],
+    )
+    var = pd.DataFrame(index=["rna_a", "rna_b"])
+    x = np.asarray(
+        [
+            [1, 0],
+            [2, 1],
+            [0, 3],
+            [1, 4],
+        ],
+        dtype=np.float32,
+    )
+    adata = AnnData(X=x, obs=obs, var=var)
+    adata.layers["normalized"] = x
+    adata.obsm["spatial"] = np.asarray(
+        [
+            [0, 0],
+            [1, 0],
+            [0, 1],
+            [1, 1],
+        ],
+        dtype=np.float32,
+    )
+
+    protein_x = np.asarray(
+        [
+            [5, 1],
+            [6, 1],
+            [2, 8],
+            [2, 9],
+        ],
+        dtype=np.float32,
+    )
+    modalities = {
+        "rna": Modality(
+            name="rna",
+            matrix=x,
+            var=var,
+            layers={"normalized": x},
+            value_kind="counts",
+            label="RNA",
+        ),
+        "protein": Modality(
+            name="protein",
+            matrix=protein_x,
+            var=pd.DataFrame(index=["protein_a", "protein_b"]),
+            layers={"normalized": protein_x},
+            value_kind="intensity",
+            label="Protein",
+        ),
+    }
+    return SpatialDataset(
+        adata=adata,
+        sections=[SectionData("s1", adata.obsm["spatial"])],
+        section_key="section",
+        obs_columns=["section", "cell_type"],
+        var_names=list(var.index),
+        modalities=modalities,
+        default_modality="rna",
+    )
+
+
+def test_multimodal_export_uses_only_by_modality_payloads():
+    multimodal_dataset = _make_multimodal_dataset()
+    data = multimodal_dataset.to_json_data(
+        annotation="cell_type",
+        features=["rna_a"],
+        pseudobulk_de_annotations=[],
+        interaction_marker_annotations=[],
+        pseudobulk_modalities=["rna", "protein"],
+    )
+
+    assert data["default_modality"] == "rna"
+    assert set(data["features_by_modality"]) == {"rna", "protein"}
+    assert set(data["embedded_features_by_modality"]) == {"rna", "protein"}
+    assert set(data["feature_state_by_modality"]) == {"rna", "protein"}
+    assert set(data["pseudobulk_de_by_modality"]) == {"rna", "protein"}
+    assert set(data["interaction_markers_by_modality"]) == {"rna", "protein"}
+
+    rna_state = data["feature_state_by_modality"]["rna"]
+    assert set(rna_state["features_meta"]) == {"rna_a"}
+    assert rna_state["feature_encodings"]["rna_a"] in {"dense", "sparse"}
+    assert data["embedded_features_by_modality"]["rna"] == ["rna_a"]
+    assert data["embedded_features_by_modality"]["protein"] == []
+
+    for removed_key in [
+        "available_features",
+        "embedded_features",
+        "features_meta",
+        "feature_encodings",
+        "feature_value_encodings",
+        "pseudobulk_de",
+        "interaction_markers",
+        "category_gene_means",
+        "gene_correlations",
+        "spatial_variable_genes",
+        "pathway_settings",
+    ]:
+        assert removed_key not in data

--- a/tests/test_multimodal_export_schema.py
+++ b/tests/test_multimodal_export_schema.py
@@ -9,6 +9,7 @@ def _make_multimodal_dataset():
     obs = pd.DataFrame(
         {
             "section": pd.Categorical(["s1", "s1", "s1", "s1"]),
+            "replicate": pd.Categorical(["r1", "r2", "r1", "r2"]),
             "cell_type": pd.Categorical(["A", "A", "B", "B"]),
         },
         index=[f"cell{i}" for i in range(4)],
@@ -31,6 +32,15 @@ def _make_multimodal_dataset():
             [1, 0],
             [0, 1],
             [1, 1],
+        ],
+        dtype=np.float32,
+    )
+    adata.obsp["spatial_connectivities"] = np.asarray(
+        [
+            [0, 1, 1, 0],
+            [1, 0, 0, 1],
+            [1, 0, 0, 1],
+            [0, 1, 1, 0],
         ],
         dtype=np.float32,
     )
@@ -66,7 +76,7 @@ def _make_multimodal_dataset():
         adata=adata,
         sections=[SectionData("s1", adata.obsm["spatial"])],
         section_key="section",
-        obs_columns=["section", "cell_type"],
+        obs_columns=["section", "replicate", "cell_type"],
         var_names=list(var.index),
         modalities=modalities,
         default_modality="rna",
@@ -110,3 +120,34 @@ def test_multimodal_export_uses_only_by_modality_payloads():
         "pathway_settings",
     ]:
         assert removed_key not in data
+
+
+def test_secondary_analytics_are_modality_scoped():
+    multimodal_dataset = _make_multimodal_dataset()
+    data = multimodal_dataset.to_json_data(
+        annotation="cell_type",
+        features=["rna_a", "protein_a"],
+        pseudobulk_de_annotations=["cell_type"],
+        pseudobulk_replicate_annotation="replicate",
+        pseudobulk_modalities=["rna", "protein"],
+        pseudobulk_min_replicates=1,
+        pseudobulk_min_cells_per_pseudobulk=1,
+        spatial_variable_genes_n=2,
+        category_means_n_genes=2,
+        gene_correlation_top_n=1,
+    )
+
+    assert set(data["category_feature_means_by_modality"]) == {"rna", "protein"}
+    assert set(data["feature_correlations_by_modality"]) == {"rna", "protein"}
+    assert set(data["spatial_variable_features_by_modality"]) == {"rna", "protein"}
+
+    for modality, feature_name in [("rna", "rna_a"), ("protein", "protein_a")]:
+        means = data["category_feature_means_by_modality"][modality]
+        assert means is not None
+        assert feature_name in means["genes"]
+
+        correlations = data["feature_correlations_by_modality"][modality]
+        assert feature_name in correlations
+
+        spatial = data["spatial_variable_features_by_modality"][modality]
+        assert any(row["gene"] == feature_name for row in spatial)

--- a/tests/test_multimodal_html_runtime.py
+++ b/tests/test_multimodal_html_runtime.py
@@ -67,3 +67,14 @@ def test_split_controls_have_independent_feature_namespaces(tmp_path=None):
     assert 'id="overview-blend-b-namespace"' in html
     assert "overviewBlendSpec.a.modality" in html
     assert "overviewBlendSpec.b.modality" in html
+
+
+def test_exploration_uses_features_and_modality_payloads(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert 'data-insights-tree-parent="features"' in html
+    assert 'id="exploration-feature-modality-select"' in html
+    assert "DATA.pseudobulk_de_by_modality" in html
+    assert "DATA.category_feature_means_by_modality" in html
+    assert "DATA.gene_correlations" not in html
+    assert "DATA.spatial_variable_genes" not in html

--- a/tests/test_multimodal_html_runtime.py
+++ b/tests/test_multimodal_html_runtime.py
@@ -78,3 +78,11 @@ def test_exploration_uses_features_and_modality_payloads(tmp_path=None):
     assert "DATA.category_feature_means_by_modality" in html
     assert "DATA.gene_correlations" not in html
     assert "DATA.spatial_variable_genes" not in html
+
+
+def test_compare_pseudobulk_has_modality_selector(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert 'id="pseudobulk-de-modality-select"' in html
+    assert "getPseudobulkDEPayloadForModality" in html
+    assert "(DATA.pseudobulk_de || {})" not in html

--- a/tests/test_multimodal_html_runtime.py
+++ b/tests/test_multimodal_html_runtime.py
@@ -39,6 +39,20 @@ def test_generated_html_uses_modality_scoped_feature_helpers(tmp_path=None):
     assert "resolveCanonicalGeneName" not in html
 
 
+def test_generated_html_drops_removed_legacy_paths(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert "renderLegacyGroupDE" not in html
+    assert "computeCellSetDEAsync" not in html
+    assert "function computeCellSetDE(" not in html
+    assert "section.he_image)" not in html
+    assert "section.he_image " not in html
+    assert "logfoldchanges" not in html
+    assert "karospace-feature-sidecar-manifest-v3" not in html
+    assert "targetModality === DEFAULT_MODALITY_NAME ? manifest : null" not in html
+    assert "manifest.section_order" not in html
+
+
 def test_generated_html_has_panel_scoped_modality_state(tmp_path=None):
     html = _render_multimodal_html(tmp_path)
 
@@ -46,7 +60,6 @@ def test_generated_html_has_panel_scoped_modality_state(tmp_path=None):
     assert "visual:" in html
     assert "exploration:" in html
     assert "module:" in html
-    assert "pseudobulk:" in html
     assert "interactions:" in html
     assert "let CURRENT_MODALITY" not in html
 
@@ -111,12 +124,29 @@ def test_feature_module_changes_refresh_visual_namespace_controls(tmp_path=None)
     assert "setSelectOptions(select, options, selected);" in html
 
 
-def test_feature_dropdowns_use_full_modality_catalog(tmp_path=None):
+def test_feature_dropdowns_use_full_catalog_only_with_sidecar(tmp_path=None):
     html = _render_multimodal_html(tmp_path)
 
-    assert "const base = getFeatureCatalog(modality);" in html
-    assert "const base = getLoadedFeaturesForModality(modality);" not in html
+    assert "const base = DATA.feature_manifest_url" in html
+    assert "? getFeatureCatalog(modality)" in html
+    assert ": getLoadedFeaturesForModality(modality);" in html
     assert '"rna_b"' in html
+
+
+def test_marker_search_datalist_uses_embedded_features_only(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert "function getEmbeddedFeatureDatalistValuesForModality" in html
+    assert "if (subtab === 'distribution') return embedded;" in html
+    assert "subtab === 'means'" in html
+    assert "getPseudobulkMeanFeatureNames(explorationColorCol || currentAnnotation || '', modality)" in html
+
+
+def test_marker_search_does_not_mutate_visual_feature_controls(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert "Marker search filters Insights panels only." in html
+    assert "if (isViewerFeatureLoadable(gene, modality))" not in html
 
 
 def test_split_controls_have_independent_feature_namespaces(tmp_path=None):
@@ -163,17 +193,33 @@ def test_compare_group_de_uses_exploration_modality(tmp_path=None):
 def test_selection_comparison_reruns_when_focused_modality_changes(tmp_path=None):
     html = _render_multimodal_html(tmp_path)
 
-    assert "const key = `${getExplorationModality()}:${groupB === null ? 'all' : 'region-b'}:${selectionRevision}:${selectionWelchRevision}`;" in html
+    assert "return `${getExplorationModality()}:${groupB === null ? 'all' : 'region-b'}:${selectionRevision}:${selectionWelchRevision}`;" in html
     assert "const shouldRerunSelectionComparison = selectionWelchRunRequested && selectedCells.size > 0;" in html
-    assert "selectionWelchRunRequested = shouldRerunSelectionComparison;" in html
-    assert "selectionWelchButtonHidden = shouldRerunSelectionComparison;" in html
+    assert "resetSelectionWelchState({ keepRequested: shouldRerunSelectionComparison });" in html
     assert "updateSelectionInfo?.();" in html
+    assert "await runSelectionWelchComparison();" in html
 
 
-def test_compare_pseudobulk_has_modality_selector(tmp_path=None):
+def test_selection_comparison_uses_full_sidecar_features(tmp_path=None):
     html = _render_multimodal_html(tmp_path)
 
-    assert 'id="pseudobulk-de-modality-select"' in html
+    assert "async function runSelectionWelchComparison()" in html
+    assert "const fullResult = await runFullCellSetDE(cellSetA, cellSetB, {" in html
+    assert "if (shouldRunFullSidecarDE(targetModality))" in html
+    assert "selectionWelchCache.set(key, normalized);" in html
+    assert "const selectionWelchResult = getCachedSelectionWelchResult(selectedCells, compareAllCells ? null : selectedCellsB);" in html
+    assert "const cachedResult = getCachedSelectionWelchResult(selectedCells, compareAllCells ? null : selectedCellsB);" in html
+    assert "Scanning all ${getModalityDisplayLabel(resultModality)} features from the sidecar." in html
+    assert "Full sidecar comparison across ${Number(selectionWelchResult.totalGeneCount || 0).toLocaleString()} ${getModalityDisplayLabel(resultModality)} features." in html
+
+
+def test_compare_pseudobulk_follows_exploration_controls(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert 'id="pseudobulk-de-modality-select"' not in html
+    assert 'id="pseudobulk-de-annotation"' not in html
+    assert "return getExplorationModality();" in html
+    assert "function setPseudobulkPanelModality" not in html
     assert "getPseudobulkDEPayloadForModality" in html
     assert "(DATA.pseudobulk_de || {})" not in html
 
@@ -193,8 +239,15 @@ def test_html_copy_has_no_generic_gene_labels(tmp_path=None):
     assert "Marker features" in html
     assert "Spatial features" in html
     assert "Pseudobulk feature differential analysis" in html
+    assert "Features in selection" in html
+    assert "Feature values - annotation A vs annotation B" in html
     assert "No features matched" in html
     assert "No genes matched" not in html
+    assert "Gene symbol" not in html
+    assert "Genes in selection" not in html
+    assert "Gene expression" not in html
+    assert "Sidecar gene loading" not in html
+    assert "No genes are currently loaded" not in html
 
 
 def test_download_filenames_include_modality(tmp_path=None):

--- a/tests/test_multimodal_html_runtime.py
+++ b/tests/test_multimodal_html_runtime.py
@@ -86,3 +86,11 @@ def test_compare_pseudobulk_has_modality_selector(tmp_path=None):
     assert 'id="pseudobulk-de-modality-select"' in html
     assert "getPseudobulkDEPayloadForModality" in html
     assert "(DATA.pseudobulk_de || {})" not in html
+
+
+def test_interaction_markers_use_modality_payload(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert 'id="interaction-marker-modality-select"' in html
+    assert "DATA.interaction_markers_by_modality" in html
+    assert "(DATA.interaction_markers || {})" not in html

--- a/tests/test_multimodal_html_runtime.py
+++ b/tests/test_multimodal_html_runtime.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from karospace.exporter import export_to_html
+from tests.test_multimodal_export_schema import _make_multimodal_dataset
+
+
+def _render_multimodal_html(tmp_path=None):
+    output_path = (
+        Path(tmp_path) / "multimodal-viewer.html"
+        if tmp_path is not None
+        else Path("/private/tmp/karospace-multimodal-runtime-test.html")
+    )
+    export_to_html(
+        _make_multimodal_dataset(),
+        output_path=str(output_path),
+        main_cell_annotation="cell_type",
+        features=["rna_a"],
+        modalities=["rna"],
+        pseudobulk=None,
+        interaction_markers=None,
+        spatial_variable_genes_n=0,
+        category_means_n_genes=0,
+        gene_correlation_top_n=0,
+        pathway_gsea_permutations=0,
+        tutorial=False,
+    )
+    return output_path.read_text(encoding="utf-8")
+
+
+def test_generated_html_uses_modality_scoped_feature_helpers(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert "function resolveCanonicalFeatureName(token, modality" in html
+    assert "async function ensureFeatureAvailable(feature, options" in html
+    assert "const FEATURE_INDEX_BY_MODALITY = new Map()" in html
+    assert "function buildFeatureIndex(modality" in html
+    assert "AVAILABLE_GENE_SET" not in html
+    assert "resolveCanonicalGeneName" not in html

--- a/tests/test_multimodal_html_runtime.py
+++ b/tests/test_multimodal_html_runtime.py
@@ -58,3 +58,12 @@ def test_visual_controls_have_feature_namespace_select(tmp_path=None):
     assert 'id="feature-discovery-panel"' in html
     assert 'id="gene-input"' not in html
     assert 'id="modality-select"' not in html
+
+
+def test_split_controls_have_independent_feature_namespaces(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert 'id="overview-blend-a-namespace"' in html
+    assert 'id="overview-blend-b-namespace"' in html
+    assert "overviewBlendSpec.a.modality" in html
+    assert "overviewBlendSpec.b.modality" in html

--- a/tests/test_multimodal_html_runtime.py
+++ b/tests/test_multimodal_html_runtime.py
@@ -94,3 +94,22 @@ def test_interaction_markers_use_modality_payload(tmp_path=None):
     assert 'id="interaction-marker-modality-select"' in html
     assert "DATA.interaction_markers_by_modality" in html
     assert "(DATA.interaction_markers || {})" not in html
+
+
+def test_html_copy_has_no_generic_gene_labels(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert "Feature discovery" in html
+    assert "Marker features" in html
+    assert "Spatial features" in html
+    assert "Pseudobulk feature differential analysis" in html
+
+
+def test_download_filenames_include_modality(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert "'karospace-pseudobulk-de'," in html
+    assert "sanitizeFilenamePart(getPseudobulkPanelModality()" in html
+    assert "karospace-pseudobulk-de-features-${modName}-" in html
+    assert "['modality', 'feature', 'base_mean'" in html
+    assert "['modality', 'annotation_column', 'category', 'reference', 'rank', 'feature'" in html

--- a/tests/test_multimodal_html_runtime.py
+++ b/tests/test_multimodal_html_runtime.py
@@ -47,3 +47,14 @@ def test_generated_html_has_panel_scoped_modality_state(tmp_path=None):
     assert "pseudobulk:" in html
     assert "interactions:" in html
     assert "let CURRENT_MODALITY" not in html
+
+
+def test_visual_controls_have_feature_namespace_select(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert 'id="visual-feature-namespace-select"' in html
+    assert 'id="feature-input"' in html
+    assert 'id="feature-list"' in html
+    assert 'id="feature-discovery-panel"' in html
+    assert 'id="gene-input"' not in html
+    assert 'id="modality-select"' not in html

--- a/tests/test_multimodal_html_runtime.py
+++ b/tests/test_multimodal_html_runtime.py
@@ -36,3 +36,14 @@ def test_generated_html_uses_modality_scoped_feature_helpers(tmp_path=None):
     assert "function buildFeatureIndex(modality" in html
     assert "AVAILABLE_GENE_SET" not in html
     assert "resolveCanonicalGeneName" not in html
+
+
+def test_generated_html_has_panel_scoped_modality_state(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert "const PANEL_MODALITY_STATE" in html
+    assert "visual:" in html
+    assert "exploration:" in html
+    assert "pseudobulk:" in html
+    assert "interactions:" in html
+    assert "let CURRENT_MODALITY" not in html

--- a/tests/test_multimodal_html_runtime.py
+++ b/tests/test_multimodal_html_runtime.py
@@ -45,6 +45,7 @@ def test_generated_html_has_panel_scoped_modality_state(tmp_path=None):
     assert "const PANEL_MODALITY_STATE" in html
     assert "visual:" in html
     assert "exploration:" in html
+    assert "module:" in html
     assert "pseudobulk:" in html
     assert "interactions:" in html
     assert "let CURRENT_MODALITY" not in html
@@ -61,6 +62,63 @@ def test_visual_controls_have_feature_namespace_select(tmp_path=None):
     assert 'id="modality-select"' not in html
 
 
+def test_feature_discovery_uses_visual_namespace(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert "const discoveryModality = getVisualModality();" in html
+    assert "getGeneSuggestionGroups(discoveryModality)" in html
+    assert "getFeatureTokensForModality(recentGenes, discoveryModality)" in html
+    assert "getFeatureTokensForModality(panel?.genes || [], discoveryModality)" in html
+
+
+def test_exploration_feature_controls_accept_manual_input(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert '<input type="text" id="gene-module-gene-picker"' in html
+    assert 'list="gene-module-gene-list"' in html
+    assert '<select id="gene-module-gene-picker"' not in html
+    assert 'id="marker-gene-search" type="text" list="marker-gene-search-list"' in html
+    assert '<select class="marker-search" id="marker-gene-search"' not in html
+    assert "moduleGenePicker?.addEventListener('keydown'" in html
+    assert "markerSearch?.addEventListener('keydown'" in html
+    assert "resolveCanonicalFeatureName(moduleGenePicker.value, moduleFocusedModality)" in html
+
+
+def test_feature_modules_are_scoped_to_focused_modality(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert 'id="gene-module-modality-select"' in html
+    assert "function getModuleBuilderModality()" in html
+    assert "function setModuleBuilderModality(modality)" in html
+    assert "function getGeneModulesForModality(modality = getModuleBuilderModality())" in html
+    assert "const activeModules = getGeneModulesForModality(moduleFocusedModality);" in html
+    assert "getFeatureDatalistValuesForModality(moduleFocusedModality)" in html
+    assert "createGeneModule('', genes, moduleFocusedModality)" in html
+    assert "format: 'karospace-feature-modules-v2'" in html
+    assert "modality: getGeneModuleModality(module)" in html
+    assert "features: module.genes.slice()" in html
+    assert "getSectionGeneValues(section, moduleGene, sourceModality)" in html
+    assert "getGeneScaleRange(moduleGene, sourceModality)" in html
+
+
+def test_feature_module_changes_refresh_visual_namespace_controls(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert "function syncVisualFeatureNamespaceSelect()" in html
+    assert "if (typeof syncVisualFeatureNamespaceSelect === 'function') syncVisualFeatureNamespaceSelect();" in html
+    assert "const syncFeatureNamespaceSelect = () =>" in html
+    assert "syncVisualFeatureNamespaceSelect();" in html
+    assert "setSelectOptions(select, options, selected);" in html
+
+
+def test_feature_dropdowns_use_full_modality_catalog(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert "const base = getFeatureCatalog(modality);" in html
+    assert "const base = getLoadedFeaturesForModality(modality);" not in html
+    assert '"rna_b"' in html
+
+
 def test_split_controls_have_independent_feature_namespaces(tmp_path=None):
     html = _render_multimodal_html(tmp_path)
 
@@ -75,10 +133,41 @@ def test_exploration_uses_features_and_modality_payloads(tmp_path=None):
 
     assert 'data-insights-tree-parent="features"' in html
     assert 'id="exploration-feature-modality-select"' in html
+    assert "Focused modality" in html
+    assert html.index('id="exploration-annotation-select"') < html.index('id="exploration-feature-modality-select"')
+    assert html.index('id="exploration-feature-modality-select"') < html.index('id="visualization-menu-label"')
     assert "DATA.pseudobulk_de_by_modality" in html
     assert "DATA.category_feature_means_by_modality" in html
     assert "DATA.gene_correlations" not in html
     assert "DATA.spatial_variable_genes" not in html
+
+
+def test_compare_group_de_uses_exploration_modality(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert "function shouldRunFullSidecarDE(modality = getExplorationModality())" in html
+    assert "const activeModality = getExplorationModality();" in html
+    assert "getSectionGeneValues(section, gene, modality)" in html
+    assert "getFeatureSidecarManifestEntryForModality(manifest, targetModality)" in html
+    assert "return `${getExplorationModality()}::${groupA.key}::${groupB.key}`;" in html
+    assert "return `${getExplorationModality()}::${groupAKey}::${groupBKey}`;" in html
+    assert "async function runAnnotationGroupDE(sourceSpec, valueA, valueB, restrictSpec, restrictValue)" in html
+    assert "runAnnotationGroupDE(sourceSpec, groupDeSourceValue, groupDeReferenceValue, restrictSpec, groupDeRestrictValue)" in html
+    assert "if (shouldRunFullSidecarDE(getExplorationModality()))" in html
+    assert "runFullRegionAnnotationDE(source, reference);" in html
+    assert "const resultModality = result?.modality || getExplorationModality();" in html
+    assert "allowUnknown: true" in html
+    assert "modality: resultModality" in html
+
+
+def test_selection_comparison_reruns_when_focused_modality_changes(tmp_path=None):
+    html = _render_multimodal_html(tmp_path)
+
+    assert "const key = `${getExplorationModality()}:${groupB === null ? 'all' : 'region-b'}:${selectionRevision}:${selectionWelchRevision}`;" in html
+    assert "const shouldRerunSelectionComparison = selectionWelchRunRequested && selectedCells.size > 0;" in html
+    assert "selectionWelchRunRequested = shouldRerunSelectionComparison;" in html
+    assert "selectionWelchButtonHidden = shouldRerunSelectionComparison;" in html
+    assert "updateSelectionInfo?.();" in html
 
 
 def test_compare_pseudobulk_has_modality_selector(tmp_path=None):
@@ -104,6 +193,8 @@ def test_html_copy_has_no_generic_gene_labels(tmp_path=None):
     assert "Marker features" in html
     assert "Spatial features" in html
     assert "Pseudobulk feature differential analysis" in html
+    assert "No features matched" in html
+    assert "No genes matched" not in html
 
 
 def test_download_filenames_include_modality(tmp_path=None):

--- a/tests/test_multimodal_html_runtime.py
+++ b/tests/test_multimodal_html_runtime.py
@@ -35,6 +35,7 @@ def test_generated_html_uses_modality_scoped_feature_helpers(tmp_path=None):
     assert "const FEATURE_INDEX_BY_MODALITY = new Map()" in html
     assert "function buildFeatureIndex(modality" in html
     assert "AVAILABLE_GENE_SET" not in html
+    assert "DATA.available_features" not in html
     assert "resolveCanonicalGeneName" not in html
 
 

--- a/tests/test_section_metadata_defaults.py
+++ b/tests/test_section_metadata_defaults.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+
+from karospace.data_loader import load_spatial_data
+
+
+def _make_section_metadata_adata():
+    obs = pd.DataFrame(
+        {
+            "sample_id": ["s1", "s1", "s2", "s2"],
+            "region": ["cortex", "cortex", "hippocampus", "hippocampus"],
+            "cell_type": pd.Categorical(["A", "B", "A", "B"]),
+        },
+        index=[f"cell{i}" for i in range(4)],
+    )
+    adata = AnnData(
+        X=np.ones((4, 2), dtype=np.float32),
+        obs=obs,
+        var=pd.DataFrame(index=["gene_a", "gene_b"]),
+    )
+    adata.obsm["spatial"] = np.asarray(
+        [
+            [0, 0],
+            [1, 0],
+            [0, 1],
+            [1, 1],
+        ],
+        dtype=np.float32,
+    )
+    return adata
+
+
+def test_load_spatial_data_does_not_add_default_section_metadata():
+    dataset = load_spatial_data(_make_section_metadata_adata(), section_key="sample_id")
+
+    assert dataset.section_metadata == []
+    assert dataset.section_metadata_extra == []
+    assert all(section.metadata == {} for section in dataset.sections)
+
+    data = dataset.to_json_data(annotation="cell_type", features=[])
+    assert data["section_metadata"] == []
+    assert data["section_metadata_extra"] == []
+    assert data["metadata_filters"] == {}
+    assert all(section["metadata"] == {} for section in data["sections"])
+
+
+def test_load_spatial_data_keeps_only_existing_requested_section_metadata():
+    dataset = load_spatial_data(
+        _make_section_metadata_adata(),
+        section_key="sample_id",
+        section_metadata=["region", "missing_column"],
+        section_metadata_extra=["also_missing"],
+    )
+
+    assert dataset.section_metadata == ["region"]
+    assert dataset.section_metadata_extra == []
+    assert [section.metadata for section in dataset.sections] == [
+        {"region": "cortex"},
+        {"region": "hippocampus"},
+    ]
+
+    data = dataset.to_json_data(annotation="cell_type", features=[])
+    assert data["section_metadata"] == ["region"]
+    assert data["section_metadata_extra"] == []
+    assert data["metadata_filters"] == {"region": ["cortex", "hippocampus"]}


### PR DESCRIPTION
This PR advances the multimodal viewer work by moving user-facing language and data handling from gene-specific assumptions toward modality-scoped “feature” terminology. It keeps gene-specific wording where biologically appropriate, such as pathway enrichment, while making the viewer, CLI, GUI, export payloads, and docs work more consistently for RNA, protein, and other feature modalities.

## What Changed

- Renamed user-facing CLI, GUI, README, and viewer copy from “genes” to “features” where the value can come from any modality.
- Added feature-named CLI options while preserving legacy gene-named aliases for compatibility.
- Updated multimodal export behavior so embedded feature payloads, marker features, pseudobulk DE, correlations, category means, and spatial feature rankings are scoped by modality.
- Updated sidecar manifest handling to use the v4 modality-scoped schema.
- Improved default analytics behavior for additional cell annotations and neighbor/interaction analysis.
- Removed older legacy viewer paths and top-level/default-modality assumptions.
- Added/expanded tests for multimodal export schema, embedded vs sidecar feature behavior, modality-scoped runtime helpers, and feature terminology.

## Notes

The branch was updated with the latest `origin/main` and conflict resolutions kept the newer modality-scoped feature model. The incoming cell-level marker fallback is preserved through the existing pseudobulk fallback payload path rather than adding a separate legacy top-level marker payload.
